### PR TITLE
SmartDashboard command putter

### DIFF
--- a/src/xbot/common/injection/RobotModule.java
+++ b/src/xbot/common/injection/RobotModule.java
@@ -6,6 +6,8 @@ import xbot.common.properties.ITableProxy;
 import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.PermanentStorageProxy;
 import xbot.common.properties.SmartDashboardTableWrapper;
+import xbot.common.wpi_extensions.RealSmartDashboardCommandPutter;
+import xbot.common.wpi_extensions.SmartDashboardCommandPutter;
 
 import com.google.inject.AbstractModule;
 
@@ -16,6 +18,7 @@ public class RobotModule extends AbstractModule {
 		this.bind(WPIFactory.class).to(RealWPIFactory.class);
 		this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class);
 		this.bind(PermanentStorageProxy.class).to(PermanentStorage.class);
+		this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
 	}
 
 }

--- a/src/xbot/common/wpi_extensions/BaseCommand.java
+++ b/src/xbot/common/wpi_extensions/BaseCommand.java
@@ -1,9 +1,14 @@
 package xbot.common.wpi_extensions;
 
+import com.google.inject.Inject;
+
 import edu.wpi.first.wpilibj.command.Command;
 
 public abstract class BaseCommand extends Command {
 	
+    @Inject
+    SmartDashboardCommandPutter commandPutter;
+    
 	@Override
 	public abstract void initialize();
 
@@ -24,5 +29,17 @@ public abstract class BaseCommand extends Command {
 	public void interrupted() {
 		this.end();
 	}
+	
+    public void includeOnSmartDashboard () {
+        if(commandPutter != null) {
+            commandPutter.addCommandToSmartDashboard(this);
+        }
+    }
+    
+    public void includeOnSmartDashboard (String label) {
+        if(commandPutter != null) {
+            commandPutter.addCommandToSmartDashboard(label, this);
+        }
+    }
 
 }

--- a/src/xbot/common/wpi_extensions/BaseCommandGroup.java
+++ b/src/xbot/common/wpi_extensions/BaseCommandGroup.java
@@ -1,0 +1,16 @@
+package xbot.common.wpi_extensions;
+
+import com.google.inject.Inject;
+
+import edu.wpi.first.wpilibj.command.CommandGroup;
+
+public class BaseCommandGroup extends CommandGroup {
+    @Inject
+    SmartDashboardCommandPutter commandPutter;
+    
+    public void includeOnSmartDashboard () {
+        if(commandPutter != null) {
+            commandPutter.addCommandToSmartDashboard(this);
+        }
+    }
+}

--- a/src/xbot/common/wpi_extensions/RealSmartDashboardCommandPutter.java
+++ b/src/xbot/common/wpi_extensions/RealSmartDashboardCommandPutter.java
@@ -1,0 +1,18 @@
+package xbot.common.wpi_extensions;
+
+import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+public class RealSmartDashboardCommandPutter implements SmartDashboardCommandPutter {
+
+    @Override
+    public void addCommandToSmartDashboard(Command command) {
+       SmartDashboard.putData(command);
+    }
+
+    @Override
+    public void addCommandToSmartDashboard(String label, Command command) {
+        SmartDashboard.putData(label, command);
+    }
+
+}

--- a/src/xbot/common/wpi_extensions/SmartDashboardCommandPutter.java
+++ b/src/xbot/common/wpi_extensions/SmartDashboardCommandPutter.java
@@ -1,0 +1,8 @@
+package xbot.common.wpi_extensions;
+
+import edu.wpi.first.wpilibj.command.Command;
+
+public interface SmartDashboardCommandPutter {
+    public void addCommandToSmartDashboard(Command command);
+    public void addCommandToSmartDashboard(String label, Command command);
+}

--- a/tests/xbot/common/injection/UnitTestModule.java
+++ b/tests/xbot/common/injection/UnitTestModule.java
@@ -5,6 +5,8 @@ import xbot.common.injection.wpi_factories.WPIFactory;
 import xbot.common.properties.ITableProxy;
 import xbot.common.properties.PermanentStorageProxy;
 import xbot.common.properties.TableProxy;
+import xbot.common.wpi_extensions.MockSmartDashboardCommandPutter;
+import xbot.common.wpi_extensions.SmartDashboardCommandPutter;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
@@ -24,5 +26,7 @@ public class UnitTestModule extends AbstractModule {
 		
 		this.bind(ITableProxy.class).to(TableProxy.class).in(Singleton.class);
 		this.bind(PermanentStorageProxy.class).to(MockPermanentStorage.class).in(Singleton.class);
+		
+		this.bind(SmartDashboardCommandPutter.class).to(MockSmartDashboardCommandPutter.class);
 	}
 }

--- a/tests/xbot/common/wpi_extensions/BaseCommandTest.java
+++ b/tests/xbot/common/wpi_extensions/BaseCommandTest.java
@@ -1,0 +1,31 @@
+package xbot.common.wpi_extensions;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import xbot.common.injection.BaseWPITest;
+
+public class BaseCommandTest extends BaseWPITest {
+
+    @Test
+    public void testPuttingOnSmartDashboardDoesntCrashTest() {
+        BaseCommand command = injector.getInstance(TestBaseCommand.class);
+        command.includeOnSmartDashboard("label");
+        command.includeOnSmartDashboard();
+    }
+
+}
+
+class TestBaseCommand extends BaseCommand {
+    @Override
+    public void initialize() {
+        
+        
+    }
+
+    @Override
+    public void execute() {
+       
+    }
+}

--- a/tests/xbot/common/wpi_extensions/MockSmartDashboardCommandPutter.java
+++ b/tests/xbot/common/wpi_extensions/MockSmartDashboardCommandPutter.java
@@ -1,0 +1,19 @@
+package xbot.common.wpi_extensions;
+
+import edu.wpi.first.wpilibj.command.Command;
+
+public class MockSmartDashboardCommandPutter implements SmartDashboardCommandPutter {
+
+    @Override
+    public void addCommandToSmartDashboard(Command command) {
+        // intentionally left blank as the SmartDashboard isn't available off the robot right now
+        
+    }
+
+    @Override
+    public void addCommandToSmartDashboard(String label, Command command) {
+        // intentionally left blank as the SmartDashboard isn't available off the robot right now
+        
+    }
+
+}


### PR DESCRIPTION
This is ported from the 2015 repo's pull request.

Basically when we wanted to put commands on the smart dashboard (like certain reset/calibration commands that don't need buttons) we have now written code that can't be unit tested since the SmartDashboard static would break.

This add a helper function on commands you can call to set it to the smartdashboard if the code is running on the real robot or not.

@JohnGilb @WasabiFan @shahronak @riverole 