### PR TITLE
Clear the permanent store before saving properties

### DIFF
--- a/src/xbot/common/properties/ITableProxy.java
+++ b/src/xbot/common/properties/ITableProxy.java
@@ -22,4 +22,6 @@ public interface ITableProxy {
     public Boolean getBoolean (String key);
     
     public String getString (String key);
+    
+    public void clear();
 }

--- a/src/xbot/common/properties/PropertyManager.java
+++ b/src/xbot/common/properties/PropertyManager.java
@@ -77,6 +77,12 @@ public class PropertyManager {
      * Save all properties into permanent storage.
      */
     public void saveOutAllProperties() {
+    	
+    	// We should clear the permanent storage before we save, otherwise we can have
+    	// "orphaned" values that are loaded/saved indefinitely, even if there's nothing in the 
+    	// code that uses them.
+    	
+    	permanentStore.clear();
         
         if (properties.size() == 0)
         {

--- a/src/xbot/common/properties/SmartDashboardTableWrapper.java
+++ b/src/xbot/common/properties/SmartDashboardTableWrapper.java
@@ -17,6 +17,10 @@ public class SmartDashboardTableWrapper implements ITableProxy {
     public void setDouble(String key, double value) {
         SmartDashboard.putNumber(key, value);
     }
+    
+    public void clear(){
+    	// Do not clear the smart dashboard
+    }
 
     public Double getDouble(String key) {
         try {

--- a/src/xbot/common/properties/SmartDashboardTableWrapper.java
+++ b/src/xbot/common/properties/SmartDashboardTableWrapper.java
@@ -4,6 +4,8 @@
  */
 package xbot.common.properties;
 
+import org.apache.log4j.Logger;
+
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.tables.TableKeyNotDefinedException;
 
@@ -14,12 +16,17 @@ import edu.wpi.first.wpilibj.tables.TableKeyNotDefinedException;
  */
 public class SmartDashboardTableWrapper implements ITableProxy {
 
+	private static final Logger log = Logger
+            .getLogger(SmartDashboardTableWrapper.class);
+	
     public void setDouble(String key, double value) {
         SmartDashboard.putNumber(key, value);
     }
     
     public void clear(){
-    	// Do not clear the smart dashboard
+    	// Do not clear the smart dashboard - the SmartDashboard doesn't really have a mechanism
+    	// to clear it, so instead we'll just put an angry warning message!
+    	log.warn("Somebody attempted to clear the SmartDashboard. This will never work - why are you doing this?!");
     }
 
     public Double getDouble(String key) {

--- a/src/xbot/common/properties/TableProxy.java
+++ b/src/xbot/common/properties/TableProxy.java
@@ -16,7 +16,11 @@ public class TableProxy implements ITableProxy {
     public Hashtable<String, String> table;
 
     public TableProxy() {
-        this.table = new Hashtable<String, String>();
+        clear();
+    }
+    
+    public void clear() {
+    	this.table = new Hashtable<String, String>();
     }
     
     public void setDouble(String key, double value) {

--- a/tests/xbot/common/properties/PermanentStorageProxyTest.java
+++ b/tests/xbot/common/properties/PermanentStorageProxyTest.java
@@ -42,6 +42,20 @@ public class PermanentStorageProxyTest extends BaseWPITest {
         assertEquals("What time is it?", p.getString("phrase"));        
     }
     
+    @Test
+    public void testClear() {
+    	PermanentStorageProxy p = new PermanentStorage();
+        p.writeToFile("double,fancyname,1.23\nboolean,flag,true\nstring,phrase,What time is it?");
+        
+        p.loadFromDisk();
+        
+        p.clear();
+        
+        boolean result = p.getDouble("fancyname") == null;
+        
+        assertEquals("Should get null back when the table is clear!", result, true);
+    }
+    
     @After
     public void cleanUp()
     {

--- a/tests/xbot/common/properties/PermanentStorageProxyTest.java
+++ b/tests/xbot/common/properties/PermanentStorageProxyTest.java
@@ -48,6 +48,8 @@ public class PermanentStorageProxyTest extends BaseWPITest {
         p.writeToFile("double,fancyname,1.23\nboolean,flag,true\nstring,phrase,What time is it?");
         
         p.loadFromDisk();
+        // need to verify that information was loaded
+        assertEquals(p.getDouble("fancyname"), 1.23, .01);
         
         p.clear();
         


### PR DESCRIPTION
@aschokking @WasabiFan @riverole @shahronak 

This is something I saw happen a few times last year - where we would remove a property from the code, but then it would continue to get loaded/saved indefinitely until I deleted it manually from the flat file.