### PR TITLE
Stop using database for most unit tests

### DIFF
--- a/src/xbot/common/injection/RobotModule.java
+++ b/src/xbot/common/injection/RobotModule.java
@@ -8,6 +8,7 @@ import xbot.common.logging.RobotAssertionManager;
 import xbot.common.logging.SilentRobotAssertionManager;
 import xbot.common.properties.DatabaseStorageBase;
 import xbot.common.properties.ITableProxy;
+import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.RobotDatabaseStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
 
@@ -19,7 +20,7 @@ public class RobotModule extends AbstractModule {
     protected void configure() {
         this.bind(WPIFactory.class).to(RealWPIFactory.class);
         this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class);
-        this.bind(DatabaseStorageBase.class).to(RobotDatabaseStorage.class);
+        this.bind(PermanentStorage.class).to(RobotDatabaseStorage.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(SilentRobotAssertionManager.class);
     }

--- a/src/xbot/common/properties/DatabaseStorageBase.java
+++ b/src/xbot/common/properties/DatabaseStorageBase.java
@@ -14,7 +14,7 @@ import org.apache.log4j.Logger;
  *
  * @author John
  */
-public abstract class DatabaseStorageBase implements ITableProxy {
+public abstract class DatabaseStorageBase implements PermanentStorage {
 
     private static Logger log = Logger.getLogger(DatabaseStorageBase.class);
 

--- a/src/xbot/common/properties/PermanentStorage.java
+++ b/src/xbot/common/properties/PermanentStorage.java
@@ -1,0 +1,5 @@
+package xbot.common.properties;
+
+public interface PermanentStorage extends ITableProxy {
+
+}

--- a/src/xbot/common/properties/Property.java
+++ b/src/xbot/common/properties/Property.java
@@ -20,7 +20,7 @@ public abstract class Property {
      */
     public String key;
 
-    DatabaseStorageBase permanentStore;
+    PermanentStorage permanentStore;
     ITableProxy randomAccessStore;
     
     /** 

--- a/src/xbot/common/properties/PropertyManager.java
+++ b/src/xbot/common/properties/PropertyManager.java
@@ -29,14 +29,14 @@ public class PropertyManager {
     /**
      *
      */
-    public DatabaseStorageBase permanentStore;
+    public PermanentStorage permanentStore;
     /**
      *
      */
     public ITableProxy randomAccessStore;
 
     @Inject
-    public PropertyManager(DatabaseStorageBase permanentStore, ITableProxy randomAccessStore) {
+    public PropertyManager(PermanentStorage permanentStore, ITableProxy randomAccessStore) {
         this.properties = new ArrayList<Property>();
         this.permanentStore = permanentStore;
         this.randomAccessStore = randomAccessStore;

--- a/tests/xbot/common/injection/BaseWPITest.java
+++ b/tests/xbot/common/injection/BaseWPITest.java
@@ -28,11 +28,11 @@ public class BaseWPITest {
 
     public PropertyManager propertyManager;
     
-    protected AbstractModule guice_module = new UnitTestModule();
+    protected AbstractModule guiceModule = new UnitTestModule();
 
     @Before
     public void setUp() {
-        injector = Guice.createInjector(guice_module);
+        injector = Guice.createInjector(guiceModule);
 
         mockRobotIO = injector.getInstance(MockRobotIO.class);
 

--- a/tests/xbot/common/injection/BaseWPITest.java
+++ b/tests/xbot/common/injection/BaseWPITest.java
@@ -4,6 +4,7 @@ import org.apache.log4j.xml.DOMConfigurator;
 import org.junit.Before;
 import org.junit.Ignore;
 
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -26,10 +27,12 @@ public class BaseWPITest {
     public MockRobotState mockRobotState;
 
     public PropertyManager propertyManager;
+    
+    protected AbstractModule guice_module = new UnitTestModule();
 
     @Before
     public void setUp() {
-        injector = Guice.createInjector(new UnitTestModule());
+        injector = Guice.createInjector(guice_module);
 
         mockRobotIO = injector.getInstance(MockRobotIO.class);
 

--- a/tests/xbot/common/injection/UnitTestModule.java
+++ b/tests/xbot/common/injection/UnitTestModule.java
@@ -8,6 +8,8 @@ import xbot.common.logging.LoudRobotAssertionManager;
 import xbot.common.logging.RobotAssertionManager;
 import xbot.common.properties.DatabaseStorageBase;
 import xbot.common.properties.ITableProxy;
+import xbot.common.properties.MockPermamentStorage;
+import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.TableProxy;
 
 import com.google.inject.AbstractModule;
@@ -20,6 +22,9 @@ import org.junit.Ignore;
 
 @Ignore
 public class UnitTestModule extends AbstractModule {
+    
+    public boolean useRealDatabaseForPropertyStorage = false;
+    
     @Override
     protected void configure() {
         this.bind(Timer.StaticInterface.class).to(MockTimer.class);
@@ -27,7 +32,13 @@ public class UnitTestModule extends AbstractModule {
         this.bind(WPIFactory.class).to(MockWPIFactory.class);
 
         this.bind(ITableProxy.class).to(TableProxy.class).in(Singleton.class);
-        this.bind(DatabaseStorageBase.class).to(OffRobotDatabaseStorage.class).in(Singleton.class);
+        
+        if(this.useRealDatabaseForPropertyStorage) {
+            this.bind(PermanentStorage.class).to(OffRobotDatabaseStorage.class).in(Singleton.class);
+        } else {
+            this.bind(PermanentStorage.class).to(MockPermamentStorage.class).in(Singleton.class);
+        }
+        
 
         this.bind(SmartDashboardCommandPutter.class).to(MockSmartDashboardCommandPutter.class);
 

--- a/tests/xbot/common/injection/UnitTestModule.java
+++ b/tests/xbot/common/injection/UnitTestModule.java
@@ -33,11 +33,13 @@ public class UnitTestModule extends AbstractModule {
 
         this.bind(ITableProxy.class).to(TableProxy.class).in(Singleton.class);
         
+        Class<? extends PermanentStorage> permanentStorageClass = null;
         if(this.useRealDatabaseForPropertyStorage) {
-            this.bind(PermanentStorage.class).to(OffRobotDatabaseStorage.class).in(Singleton.class);
+            permanentStorageClass = OffRobotDatabaseStorage.class;
         } else {
-            this.bind(PermanentStorage.class).to(MockPermamentStorage.class).in(Singleton.class);
+            permanentStorageClass = MockPermamentStorage.class;
         }
+        this.bind(PermanentStorage.class).to(permanentStorageClass).in(Singleton.class);
         
 
         this.bind(SmartDashboardCommandPutter.class).to(MockSmartDashboardCommandPutter.class);

--- a/tests/xbot/common/properties/MockPermamentStorage.java
+++ b/tests/xbot/common/properties/MockPermamentStorage.java
@@ -1,0 +1,5 @@
+package xbot.common.properties;
+
+public class MockPermamentStorage extends TableProxy implements PermanentStorage {
+
+}

--- a/tests/xbot/common/properties/PermanentStorageProxyTest.java
+++ b/tests/xbot/common/properties/PermanentStorageProxyTest.java
@@ -16,7 +16,7 @@ public class PermanentStorageProxyTest extends BaseWPITest {
     public void setUp() {
         UnitTestModule module = new UnitTestModule();
         module.useRealDatabaseForPropertyStorage = true;
-        this.guice_module = module;
+        this.guiceModule = module;
         
         super.setUp();
     }

--- a/tests/xbot/common/properties/PermanentStorageProxyTest.java
+++ b/tests/xbot/common/properties/PermanentStorageProxyTest.java
@@ -8,18 +8,23 @@ import org.junit.Test;
 
 import xbot.common.injection.BaseWPITest;
 import xbot.common.injection.OffRobotDatabaseStorage;
+import xbot.common.injection.UnitTestModule;
 
 public class PermanentStorageProxyTest extends BaseWPITest {
 
     @Before
     public void setUp() {
+        UnitTestModule module = new UnitTestModule();
+        module.useRealDatabaseForPropertyStorage = true;
+        this.guice_module = module;
+        
         super.setUp();
     }
 
     @Test
     public void testSaveAndLoad() {
 
-        DatabaseStorageBase p = propertyManager.permanentStore;
+        PermanentStorage p = propertyManager.permanentStore;
 
         p.setDouble("fancyname", 1.23);
         p.setBoolean("flag", true);
@@ -31,7 +36,7 @@ public class PermanentStorageProxyTest extends BaseWPITest {
     }
 
     public void testClear() {
-        DatabaseStorageBase p = propertyManager.permanentStore;
+        PermanentStorage p = propertyManager.permanentStore;
 
         p.setDouble("fancyname", 1.23);
         p.setBoolean("flag", true);

--- a/tests/xbot/common/properties/PropertyTest.java
+++ b/tests/xbot/common/properties/PropertyTest.java
@@ -117,6 +117,8 @@ public class PropertyTest extends BaseWPITest {
     public void cleanUp() {
         // We need a way to obliterate the database locally so tests don't leak. Can't delete the files themselves,
         // because the database process still has a handle on some of them.
-        assertEquals(true, ((OffRobotDatabaseStorage) propertyManager.permanentStore).obliterateStorage());
+        if(propertyManager.permanentStore instanceof OffRobotDatabaseStorage) {
+            assertEquals(true, ((OffRobotDatabaseStorage) propertyManager.permanentStore).obliterateStorage());
+        }
     }
 }


### PR DESCRIPTION
Add a level of abstraction infront of the database. Only use the real database for those tests but use in memory table for everything else.
@JohnGilb @WasabiFan 