### PR TITLE
Use correct file name in DeployJRE project

### DIFF
--- a/DeployJRE/build.xml
+++ b/DeployJRE/build.xml
@@ -17,7 +17,7 @@
 	<delete dir="ejdk1.8.0_06"/>
 	
 	<!-- Extract the JRE -->
-	<untar src="ejdk-8u6-fcs-b23-linux-arm-vfp-sflt-12_jun_2014.gz" dest="." compression="gzip"/>
+	<untar src="ejdk-8u6-fcs-b23-linux-arm-vfp-sflt-12_jun_2014.tar.gz" dest="." compression="gzip"/>
 	
 	<!-- Run JRECreate to make an environment with a compact debugging profile -->
 	<java jar="ejdk1.8.0_06/lib/JRECreate.jar"

--- a/DeployJRE/readme.txt
+++ b/DeployJRE/readme.txt
@@ -1,1 +1,1 @@
-Get ejdk-8u6-fcs-b23-linux-arm-vfp-sflt-12_jun_2014.gz from oracle.
+Get ejdk-8u6-fcs-b23-linux-arm-vfp-sflt-12_jun_2014.tar.gz from Oracle (http://www.oracle.com/technetwork/java/embedded/embedded-se/downloads/javaseembedded8u6-2406243.html).


### PR DESCRIPTION
The official name of the file includes the `.tar` in the extension, as it should since we are `untar`-ing it (i.e. it is a tarball that has been gzipped). 
