### PR TITLE
Feature/setpoint systems

### DIFF
--- a/src/xbot/common/command/BaseSetpointCommand.java
+++ b/src/xbot/common/command/BaseSetpointCommand.java
@@ -1,8 +1,8 @@
 package xbot.common.command;
 
-public abstract class BaseSetpointCommand extends BaseCommand{
+public abstract class BaseSetpointCommand extends BaseCommand {
 
-    public BaseSetpointCommand(SupportsSetpoint system) {
-        requires(system.getSetpointSystem());
+    public BaseSetpointCommand(SupportsSetpointLock system) {
+        requires(system.getSetpointLock());
     }
 }

--- a/src/xbot/common/command/BaseSetpointCommand.java
+++ b/src/xbot/common/command/BaseSetpointCommand.java
@@ -1,0 +1,8 @@
+package xbot.common.command;
+
+public abstract class BaseSetpointCommand extends BaseCommand{
+
+    public BaseSetpointCommand(SupportsSetpoint system) {
+        requires(system.getSetpointSystem());
+    }
+}

--- a/src/xbot/common/command/BaseSetpointSubsystem.java
+++ b/src/xbot/common/command/BaseSetpointSubsystem.java
@@ -1,0 +1,22 @@
+package xbot.common.command;
+
+import edu.wpi.first.wpilibj.command.Subsystem;
+
+public abstract class BaseSetpointSubsystem extends BaseSubsystem implements SupportsSetpoint {
+
+    private Subsystem setpointLock;
+    
+    public BaseSetpointSubsystem() {
+        setpointLock = new Subsystem() {
+            @Override
+            protected void initDefaultCommand() {
+                // Do nothing
+            }
+        };
+    }
+
+    @Override
+    public Subsystem getSetpointSystem() {
+       return setpointLock;
+    }    
+}

--- a/src/xbot/common/command/BaseSetpointSubsystem.java
+++ b/src/xbot/common/command/BaseSetpointSubsystem.java
@@ -2,7 +2,7 @@ package xbot.common.command;
 
 import edu.wpi.first.wpilibj.command.Subsystem;
 
-public abstract class BaseSetpointSubsystem extends BaseSubsystem implements SupportsSetpoint {
+public abstract class BaseSetpointSubsystem extends BaseSubsystem implements SupportsSetpointLock {
 
     private Subsystem setpointLock;
     
@@ -16,7 +16,7 @@ public abstract class BaseSetpointSubsystem extends BaseSubsystem implements Sup
     }
 
     @Override
-    public Subsystem getSetpointSystem() {
+    public Subsystem getSetpointLock() {
        return setpointLock;
     }    
 }

--- a/src/xbot/common/command/SupportsSetpoint.java
+++ b/src/xbot/common/command/SupportsSetpoint.java
@@ -1,0 +1,8 @@
+package xbot.common.command;
+
+import edu.wpi.first.wpilibj.command.Subsystem;
+
+public interface SupportsSetpoint {
+
+    public Subsystem getSetpointSystem();
+}

--- a/src/xbot/common/command/SupportsSetpointLock.java
+++ b/src/xbot/common/command/SupportsSetpointLock.java
@@ -2,7 +2,7 @@ package xbot.common.command;
 
 import edu.wpi.first.wpilibj.command.Subsystem;
 
-public interface SupportsSetpoint {
+public interface SupportsSetpointLock {
 
-    public Subsystem getSetpointSystem();
+    public Subsystem getSetpointLock();
 }

--- a/tests/xbot/common/command/MockSetpointCommand.java
+++ b/tests/xbot/common/command/MockSetpointCommand.java
@@ -1,0 +1,20 @@
+package xbot.common.command;
+
+import com.google.inject.Inject;
+
+public class MockSetpointCommand extends BaseSetpointCommand {
+
+    @Inject
+    public MockSetpointCommand(MockSetpointSystem system) {
+        super(system);
+    }
+
+    @Override
+    public void initialize() {
+    }
+
+    @Override
+    public void execute() {
+    }
+
+}

--- a/tests/xbot/common/command/MockSetpointCommand.java
+++ b/tests/xbot/common/command/MockSetpointCommand.java
@@ -16,5 +16,4 @@ public class MockSetpointCommand extends BaseSetpointCommand {
     @Override
     public void execute() {
     }
-
 }

--- a/tests/xbot/common/command/MockSetpointSystem.java
+++ b/tests/xbot/common/command/MockSetpointSystem.java
@@ -1,0 +1,8 @@
+package xbot.common.command;
+
+import com.google.inject.Singleton;
+
+@Singleton
+public class MockSetpointSystem extends BaseSetpointSubsystem {
+
+}

--- a/tests/xbot/common/command/SetpointSystemTest.java
+++ b/tests/xbot/common/command/SetpointSystemTest.java
@@ -1,0 +1,46 @@
+package xbot.common.command;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.wpi.first.wpilibj.command.Scheduler;
+import xbot.common.injection.BaseWPITest;
+
+public class SetpointSystemTest extends BaseWPITest{
+
+    @Before
+    public void setUp() {
+        super.setUp();
+    }
+    
+    @Test
+    public void testSetpointSystemCanBeCreated() {
+        MockSetpointCommand first = injector.getInstance(MockSetpointCommand.class);
+    }
+    
+    @Test
+    public void testSetpointCommandsCollide() {
+        MockSetpointCommand first = injector.getInstance(MockSetpointCommand.class);
+        MockSetpointCommand second = injector.getInstance(MockSetpointCommand.class);
+        
+        XScheduler xScheduler = this.injector.getInstance(XScheduler.class);
+        
+        assertFalse("First command is not running", first.isRunning());
+        assertFalse("Second command is not running", second.isRunning());
+        
+        Scheduler.getInstance().add(first);
+        xScheduler.run();
+        assertTrue("First command is running", first.isRunning());
+        
+        Scheduler.getInstance().add(second);
+        xScheduler.run();
+        
+        assertTrue("Second command is running", second.isRunning());
+        assertFalse("First command is no longer running", first.isRunning());
+    }
+    
+    
+}

--- a/tests/xbot/common/command/SetpointSystemTest.java
+++ b/tests/xbot/common/command/SetpointSystemTest.java
@@ -9,13 +9,8 @@ import org.junit.Test;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import xbot.common.injection.BaseWPITest;
 
-public class SetpointSystemTest extends BaseWPITest{
+public class SetpointSystemTest extends BaseWPITest {
 
-    @Before
-    public void setUp() {
-        super.setUp();
-    }
-    
     @Test
     public void testSetpointSystemCanBeCreated() {
         MockSetpointCommand first = injector.getInstance(MockSetpointCommand.class);


### PR DESCRIPTION
Adds the abstract classes BaseSetpointCommand and BaseSetpointSystem.

The idea: for a lot of maintainer/setpoint systems, we have been creating an extra "dummy" subsystem to use as a lock for all the setpoint commands.

With this new approach, if you want your Subsystem to be "setpoint-able", you extend it from BaseSetpointSubsystem, which automatically creates a dummy subsystem for use by BaseSetpointCommands (which automatically require the dummy subsystem without any code from you).