### PR TITLE
Adds a method to XCANTalon allowing us to ensure that the talon is in…

### DIFF
--- a/src/xbot/common/controls/actuators/MockCANTalon.java
+++ b/src/xbot/common/controls/actuators/MockCANTalon.java
@@ -651,4 +651,10 @@ public class MockCANTalon implements XCANTalon {
         // Intentionally left blank. There is no need for properties in mock mode.
     }
 
+    @Override
+    public void ensureModeForTalon(TalonControlMode mode) {
+        // TODO Auto-generated method stub
+        
+    }
+
 }

--- a/src/xbot/common/controls/actuators/MockCANTalon.java
+++ b/src/xbot/common/controls/actuators/MockCANTalon.java
@@ -652,7 +652,7 @@ public class MockCANTalon implements XCANTalon {
     }
 
     @Override
-    public void ensureModeForTalon(TalonControlMode mode) {
+    public void ensureTalonControlMode(TalonControlMode mode) {
         this.setControlMode(mode);
     }
 

--- a/src/xbot/common/controls/actuators/MockCANTalon.java
+++ b/src/xbot/common/controls/actuators/MockCANTalon.java
@@ -651,6 +651,14 @@ public class MockCANTalon implements XCANTalon {
         // Intentionally left blank. There is no need for properties in mock mode.
     }
 
+    /**
+     * When working with the real implementation of the talon, we want to minimize
+     * setControlMode calls, as these appear to send a message across the CAN bus, and
+     * the bus has a finite bandwidth.
+     * 
+     * However, the Mock implementation has no such restrictions (it's all in-memory faked
+     * stuff), so we can just call set every tick.
+     */
     @Override
     public void ensureTalonControlMode(TalonControlMode mode) {
         this.setControlMode(mode);

--- a/src/xbot/common/controls/actuators/MockCANTalon.java
+++ b/src/xbot/common/controls/actuators/MockCANTalon.java
@@ -653,8 +653,7 @@ public class MockCANTalon implements XCANTalon {
 
     @Override
     public void ensureModeForTalon(TalonControlMode mode) {
-        // TODO Auto-generated method stub
-        
+        this.setControlMode(mode);
     }
 
 }

--- a/src/xbot/common/controls/actuators/XCANTalon.java
+++ b/src/xbot/common/controls/actuators/XCANTalon.java
@@ -1,6 +1,7 @@
 package xbot.common.controls.actuators;
 
 import com.ctre.CANTalon;
+import com.ctre.CANTalon.TalonControlMode;
 
 import xbot.common.properties.XPropertyManager;
 
@@ -129,4 +130,5 @@ public interface XCANTalon extends XSpeedController {
     // Custom helpers -------------------------------------
     void createTelemetryProperties(String deviceName, XPropertyManager propertyManager);
     void updateTelemetryProperties();
+    void ensureModeForTalon(TalonControlMode mode);
 }

--- a/src/xbot/common/controls/actuators/XCANTalon.java
+++ b/src/xbot/common/controls/actuators/XCANTalon.java
@@ -130,5 +130,5 @@ public interface XCANTalon extends XSpeedController {
     // Custom helpers -------------------------------------
     void createTelemetryProperties(String deviceName, XPropertyManager propertyManager);
     void updateTelemetryProperties();
-    void ensureModeForTalon(TalonControlMode mode);
+    void ensureTalonControlMode(TalonControlMode mode);
 }

--- a/src/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
+++ b/src/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
@@ -478,7 +478,7 @@ public class CANTalonWPIAdapter implements XCANTalon {
     }
 
     @Override
-    public void ensureModeForTalon(TalonControlMode mode) {
+    public void ensureTalonControlMode(TalonControlMode mode) {
         if (this.getControlMode() != mode) {
             this.setControlMode(mode);
         }

--- a/src/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
+++ b/src/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
@@ -477,4 +477,11 @@ public class CANTalonWPIAdapter implements XCANTalon {
         temperatureProperty.set(this.getTemperature());
     }
 
+    @Override
+    public void ensureModeForTalon(TalonControlMode mode) {
+        if (this.getControlMode() != mode) {
+            this.setControlMode(mode);
+        }
+    }
+
 }

--- a/src/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
+++ b/src/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
@@ -477,6 +477,13 @@ public class CANTalonWPIAdapter implements XCANTalon {
         temperatureProperty.set(this.getTemperature());
     }
 
+    /**
+     * When working with the real implementation of the talon, we want to minimize
+     * setControlMode calls, as these appear to send a message across the CAN bus, and
+     * the bus has a finite bandwidth. However, the call to getControlMode appears to read
+     * from local in-memory information about the Talon, and thus is much cheaper to call
+     * repeatedly.
+     */
     @Override
     public void ensureTalonControlMode(TalonControlMode mode) {
         if (this.getControlMode() != mode) {


### PR DESCRIPTION
… the control mode we want it to be in. Given that many of our subsystems will use talons in at least two modes (PID and PercentVbus), this should prove useful.