### PR TITLE
Fixed a bug where getPosition was returning encoder ticks

### DIFF
--- a/src/xbot/common/controls/actuators/MockCANTalon.java
+++ b/src/xbot/common/controls/actuators/MockCANTalon.java
@@ -383,7 +383,7 @@ public class MockCANTalon implements XCANTalon {
             return 0;
         }
         
-        return this.getEncoderPosition();
+        return internalEncoder.getDistance();
     }
 
     @Override


### PR DESCRIPTION
Fixed a bug where getPosition was returning encoder ticks what was set in setPosition