### PR TITLE
updateTelemetry on BaseSubsystem

### DIFF
--- a/src/xbot/common/command/BaseRobot.java
+++ b/src/xbot/common/command/BaseRobot.java
@@ -1,6 +1,6 @@
 package xbot.common.command;
 
-import java.util.Vector;
+import java.util.ArrayList;
 
 import org.apache.log4j.Logger;
 import org.apache.log4j.xml.DOMConfigurator;
@@ -37,7 +37,7 @@ public class BaseRobot extends IterativeRobot {
     
     protected Command autonomousCommand;
     
-    protected Vector<BaseSubsystem> telemetryUpdatingSubsystems = new Vector<BaseSubsystem>();
+    protected ArrayList<TelemetrySource> telemetrySources = new ArrayList<TelemetrySource>();
 
     public BaseRobot() {
         super();
@@ -123,18 +123,18 @@ public class BaseRobot extends IterativeRobot {
         LiveWindow.run();
     }
     
-    protected void sharedPeriodic(){
+    protected void sharedPeriodic() {
         xScheduler.run();
-        this.updateTelemetrySubsystems();
+        this.updateTelemetrySources();
     }
     
-    protected void registerTelemetrySubsystem(BaseSubsystem subsystem) {
-        this.telemetryUpdatingSubsystems.add(subsystem);
+    protected void registerTelemetrySource(TelemetrySource telemetrySource) {
+        this.telemetrySources.add(telemetrySource);
     }
     
-    protected void updateTelemetrySubsystems() {
-        for (BaseSubsystem subsystem : this.telemetryUpdatingSubsystems) {
-            subsystem.updateTelemetry();
+    protected void updateTelemetrySources() {
+        for (TelemetrySource telemetrySource: this.telemetrySources) {
+            telemetrySource.updateTelemetry();
         }
     }
 }

--- a/src/xbot/common/command/BaseRobot.java
+++ b/src/xbot/common/command/BaseRobot.java
@@ -1,5 +1,7 @@
 package xbot.common.command;
 
+import java.util.Vector;
+
 import org.apache.log4j.Logger;
 import org.apache.log4j.xml.DOMConfigurator;
 
@@ -34,6 +36,8 @@ public class BaseRobot extends IterativeRobot {
     protected Injector injector;
     
     protected Command autonomousCommand;
+    
+    protected Vector<BaseSubsystem> telemetryUpdatingSubsystems = new Vector<BaseSubsystem>();
 
     public BaseRobot() {
         super();
@@ -77,7 +81,7 @@ public class BaseRobot extends IterativeRobot {
     }
 
     public void disabledPeriodic() {
-        xScheduler.run();
+        this.sharedPeriodic();
     }
 
     public void autonomousInit() {
@@ -94,7 +98,7 @@ public class BaseRobot extends IterativeRobot {
      * This function is called periodically during autonomous
      */
     public void autonomousPeriodic() {
-        xScheduler.run();
+        this.sharedPeriodic();
     }
 
     public void teleopInit() {
@@ -109,7 +113,7 @@ public class BaseRobot extends IterativeRobot {
      * This function is called periodically during operator control
      */
     public void teleopPeriodic() {
-        xScheduler.run();
+        this.sharedPeriodic();
     }
 
     /**
@@ -117,5 +121,20 @@ public class BaseRobot extends IterativeRobot {
      */
     public void testPeriodic() {
         LiveWindow.run();
+    }
+    
+    protected void sharedPeriodic(){
+        xScheduler.run();
+        this.updateTelemetrySubsystems();
+    }
+    
+    protected void registerTelemetrySubsystem(BaseSubsystem subsystem) {
+        this.telemetryUpdatingSubsystems.add(subsystem);
+    }
+    
+    protected void updateTelemetrySubsystems() {
+        for (BaseSubsystem subsystem : this.telemetryUpdatingSubsystems) {
+            subsystem.updateTelemetry();
+        }
     }
 }

--- a/src/xbot/common/command/BaseSubsystem.java
+++ b/src/xbot/common/command/BaseSubsystem.java
@@ -14,10 +14,5 @@ public class BaseSubsystem extends Subsystem {
     protected void initDefaultCommand() {
 
     }
-    
-    public void updateTelemetry() {
-        // Override in subclass if desired
-        throw new NotImplementedException();
-    }
 
 }

--- a/src/xbot/common/command/BaseSubsystem.java
+++ b/src/xbot/common/command/BaseSubsystem.java
@@ -2,6 +2,7 @@ package xbot.common.command;
 
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Subsystem;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class BaseSubsystem extends Subsystem {
 
@@ -12,6 +13,11 @@ public class BaseSubsystem extends Subsystem {
     @Override
     protected void initDefaultCommand() {
 
+    }
+    
+    public void updateTelemetry() {
+        // Override in subclass if desired
+        throw new NotImplementedException();
     }
 
 }

--- a/src/xbot/common/command/TelemetrySource.java
+++ b/src/xbot/common/command/TelemetrySource.java
@@ -1,0 +1,5 @@
+package xbot.common.command;
+
+public interface TelemetrySource {
+    public void updateTelemetry();
+}


### PR DESCRIPTION
* Add an optional `updateTelemetry` method on BaseSubsystem
* Add ability for these subsystems to be registered with BaseRobot class and they will be called automatically during every periodic loop.

The goal here was to make it as low overhead as possible, subsystems just need to override the method and then get registered (so no need for additional boilerplate commands to call updateTelemetry).