### PR TITLE
Feature/pid property manager lite

### DIFF
--- a/src/xbot/common/math/PIDPropertyManager.java
+++ b/src/xbot/common/math/PIDPropertyManager.java
@@ -40,7 +40,7 @@ public class PIDPropertyManager {
         return propD.get();
     }
 
-    public void setDefaultD(double d) {
+    public void setD(double d) {
         propD.set(d);
     }
 
@@ -48,7 +48,7 @@ public class PIDPropertyManager {
         return propF.get();
     }
 
-    public void setDefaultF(double f) {
+    public void setF(double f) {
         propF.set(f);
     }
 }

--- a/src/xbot/common/math/PIDPropertyManager.java
+++ b/src/xbot/common/math/PIDPropertyManager.java
@@ -1,0 +1,88 @@
+package xbot.common.math;
+
+import com.google.inject.Inject;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.XPropertyManager;
+
+public class PIDPropertyManager {
+
+    private String name;
+    
+    private DoubleProperty propP;
+    private DoubleProperty propI;
+    private DoubleProperty propD;
+    private DoubleProperty propF;
+    
+    private DoubleProperty maxOutput;
+    private DoubleProperty minOutput;
+    
+    @Inject
+    public PIDPropertyManager(String functionName, XPropertyManager propMan, 
+            double defaultP, double defaultI, double defaultD, double defaultF,
+            double defaultMaxOutput, double defaultMinOutput) {
+        
+        propP = propMan.createPersistentProperty(functionName + " P", defaultP);
+        propI = propMan.createPersistentProperty(functionName + " I", defaultI);
+        propD = propMan.createPersistentProperty(functionName + " D", defaultD);
+        propF = propMan.createPersistentProperty(functionName + " F", defaultF);
+        
+        maxOutput = propMan.createPersistentProperty(functionName + " Max Output", defaultMaxOutput);
+        minOutput = propMan.createPersistentProperty(functionName + " Min Output", defaultMinOutput);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getP() {
+        return propP.get();
+    }
+
+    public void setP(double p) {
+        propP.set(p);
+    }
+
+    public double getI() {
+        return propI.get();
+    }
+
+    public void setI(double i) {
+        propI.set(i);
+    }
+
+    public double getD() {
+        return propD.get();
+    }
+
+    public void setDefaultD(double d) {
+        propD.set(d);
+    }
+
+    public double getF() {
+        return propF.get();
+    }
+
+    public void setDefaultF(double f) {
+        propF.set(f);
+    }
+
+    public double getMaxOutput() {
+        return maxOutput.get();
+    }
+
+    public void setMaxOutput(double max) {
+        maxOutput.set(max);
+    }
+
+    public double getDefaultMinOutput() {
+        return minOutput.get();
+    }
+
+    public void setDefaultMinOutput(double min) {
+        minOutput.set(min);
+    }
+}

--- a/src/xbot/common/math/PIDPropertyManager.java
+++ b/src/xbot/common/math/PIDPropertyManager.java
@@ -13,21 +13,14 @@ public class PIDPropertyManager {
     private DoubleProperty propD;
     private DoubleProperty propF;
     
-    private DoubleProperty maxOutput;
-    private DoubleProperty minOutput;
-    
     @Inject
     public PIDPropertyManager(String functionName, XPropertyManager propMan, 
-            double defaultP, double defaultI, double defaultD, double defaultF,
-            double defaultMaxOutput, double defaultMinOutput) {
+            double defaultP, double defaultI, double defaultD, double defaultF) {
         
         propP = propMan.createPersistentProperty(functionName + " P", defaultP);
         propI = propMan.createPersistentProperty(functionName + " I", defaultI);
         propD = propMan.createPersistentProperty(functionName + " D", defaultD);
         propF = propMan.createPersistentProperty(functionName + " F", defaultF);
-        
-        maxOutput = propMan.createPersistentProperty(functionName + " Max Output", defaultMaxOutput);
-        minOutput = propMan.createPersistentProperty(functionName + " Min Output", defaultMinOutput);
     }
 
     public String getName() {
@@ -68,21 +61,5 @@ public class PIDPropertyManager {
 
     public void setDefaultF(double f) {
         propF.set(f);
-    }
-
-    public double getMaxOutput() {
-        return maxOutput.get();
-    }
-
-    public void setMaxOutput(double max) {
-        maxOutput.set(max);
-    }
-
-    public double getDefaultMinOutput() {
-        return minOutput.get();
-    }
-
-    public void setDefaultMinOutput(double min) {
-        minOutput.set(min);
     }
 }

--- a/src/xbot/common/math/PIDPropertyManager.java
+++ b/src/xbot/common/math/PIDPropertyManager.java
@@ -5,8 +5,6 @@ import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.XPropertyManager;
 
 public class PIDPropertyManager {
-
-    private String name;
     
     private DoubleProperty propP;
     private DoubleProperty propI;
@@ -16,19 +14,10 @@ public class PIDPropertyManager {
     @Inject
     public PIDPropertyManager(String functionName, XPropertyManager propMan, 
             double defaultP, double defaultI, double defaultD, double defaultF) {
-        
         propP = propMan.createPersistentProperty(functionName + " P", defaultP);
         propI = propMan.createPersistentProperty(functionName + " I", defaultI);
         propD = propMan.createPersistentProperty(functionName + " D", defaultD);
         propF = propMan.createPersistentProperty(functionName + " F", defaultF);
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public double getP() {


### PR DESCRIPTION
With the use of CANTalons, we are having situations where subsystems like the SideShooter need to create PIDF properties (so we can tune easily via dashboard). This is probably going to happen more than once, so I've created a simple property container class for PIDF values.

I was also thinking about directly integrating this into the XCANTalon, but haven't thought of a good way to do that yet.