### PR TITLE
Guice-up PIDManager creation

### DIFF
--- a/src/xbot/common/injection/RobotModule.java
+++ b/src/xbot/common/injection/RobotModule.java
@@ -6,12 +6,14 @@ import xbot.common.injection.wpi_factories.RealWPIFactory;
 import xbot.common.injection.wpi_factories.WPIFactory;
 import xbot.common.logging.RobotAssertionManager;
 import xbot.common.logging.SilentRobotAssertionManager;
+import xbot.common.math.PIDManagerFactory;
 import xbot.common.properties.ITableProxy;
 import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.RobotDatabaseStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 public class RobotModule extends AbstractModule {
 
@@ -22,6 +24,7 @@ public class RobotModule extends AbstractModule {
         this.bind(PermanentStorage.class).to(RobotDatabaseStorage.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(SilentRobotAssertionManager.class);
+        this.install(new FactoryModuleBuilder().build(PIDManagerFactory.class));
     }
 
 }

--- a/src/xbot/common/math/PIDManager.java
+++ b/src/xbot/common/math/PIDManager.java
@@ -1,5 +1,9 @@
 package xbot.common.math;
 
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+
 import xbot.common.logging.RobotAssertionManager;
 import xbot.common.properties.BooleanProperty;
 import xbot.common.properties.DoubleProperty;
@@ -16,18 +20,19 @@ public class PIDManager extends PIDPropertyManager {
     private DoubleProperty minOutput;
     private BooleanProperty isEnabled;
     
+    @AssistedInject
     public PIDManager(
-            String functionName, 
+            @Assisted String functionName, 
             XPropertyManager propMan, 
             RobotAssertionManager assertionManager,
-            double defaultP, 
-            double defaultI, 
-            double defaultD, 
-            double defaultF,
-            double defaultMaxOutput, 
-            double defaultMinOutput,
-            double errorThreshold, 
-            double derivativeThreshold) {
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD, 
+            @Assisted("defaultF") double defaultF,
+            @Assisted("defaultMaxOutput") double defaultMaxOutput, 
+            @Assisted("defaultMinOutput") double defaultMinOutput,
+            @Assisted("errorThreshold") double errorThreshold, 
+            @Assisted("derivativeThreshold") double derivativeThreshold) {
         super(functionName, propMan, assertionManager, defaultP, defaultI, defaultD, defaultF, errorThreshold, derivativeThreshold);
         
         maxOutput = propMan.createPersistentProperty(functionName + " Max Output", defaultMaxOutput);
@@ -39,44 +44,47 @@ public class PIDManager extends PIDPropertyManager {
     }
     
     // And now, the wall of constructors to support simpler PIDManagers.
-    
+    @AssistedInject
     public PIDManager(
-            String functionName,
+            @Assisted String functionName,
             XPropertyManager propMan,
             RobotAssertionManager assertionManager,
-            double defaultP, 
-            double defaultI, 
-            double defaultD, 
-            double defaultF,
-            double defaultMaxOutput, 
-            double defaultMinOutput) {
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD, 
+            @Assisted("defaultF") double defaultF,
+            @Assisted("defaultMaxOutput") double defaultMaxOutput, 
+            @Assisted("defaultMinOutput") double defaultMinOutput) {
         this(functionName, propMan, assertionManager, defaultP, defaultI, defaultD, defaultF, defaultMaxOutput, defaultMinOutput, -1, -1);
     }
 
+    @AssistedInject
     public PIDManager(
-            String functionName, 
+            @Assisted String functionName, 
             XPropertyManager propMan,
             RobotAssertionManager assertionManager,
-            double defaultP, 
-            double defaultI, 
-            double defaultD,
-            double defaultMaxOutput, 
-            double defaultMinOutput) {
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD, 
+            @Assisted("defaultMaxOutput") double defaultMaxOutput, 
+            @Assisted("defaultMinOutput") double defaultMinOutput) {
         this(functionName, propMan, assertionManager, defaultP, defaultI, defaultD, 0, 1.0, -1.0, -1, -1);
     }
     
+    @AssistedInject
     public PIDManager(
-            String functionName, 
+            @Assisted String functionName, 
             XPropertyManager propMan,
             RobotAssertionManager assertionManager,
-            double defaultP, 
-            double defaultI, 
-            double defaultD) {
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD) {
         this(functionName, propMan, assertionManager, defaultP, defaultI, defaultD, 1.0, -1.0);
     }
 
+    @AssistedInject
     public PIDManager(
-            String functionName, 
+            @Assisted String functionName, 
             XPropertyManager propMan,
             RobotAssertionManager assertionManager) {
         this(functionName, propMan, assertionManager, 0, 0, 0);

--- a/src/xbot/common/math/PIDManagerFactory.java
+++ b/src/xbot/common/math/PIDManagerFactory.java
@@ -1,17 +1,45 @@
 package xbot.common.math;
 
+import com.google.inject.assistedinject.Assisted;
+
 public interface PIDManagerFactory {
 
-    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD, double defaultF,
-            double defaultMaxOutput, double defaultMinOutput, double errorThreshold, double derivativeThreshold);
+    public PIDManager create(
+            String functionName,
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD, 
+            @Assisted("defaultF") double defaultF,
+            @Assisted("defaultMaxOutput") double defaultMaxOutput, 
+            @Assisted("defaultMinOutput") double defaultMinOutput,
+            @Assisted("errorThreshold") double errorThreshold, 
+            @Assisted("derivativeThreshold") double derivativeThreshold);
+    
+    public PIDManager create(
+            String functionName,
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD, 
+            @Assisted("defaultF") double defaultF,
+            @Assisted("defaultMaxOutput") double defaultMaxOutput, 
+            @Assisted("defaultMinOutput") double defaultMinOutput);
 
-    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD, double defaultF,
-            double defaultMaxOutput, double defaultMinOutput);
+    
+    public PIDManager create(
+            String functionName, 
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD, 
+            @Assisted("defaultMaxOutput") double defaultMaxOutput, 
+            @Assisted("defaultMinOutput") double defaultMinOutput);
+    
+    
+    public PIDManager create(
+            String functionName, 
+            @Assisted("defaultP") double defaultP, 
+            @Assisted("defaultI") double defaultI, 
+            @Assisted("defaultD") double defaultD);
 
-    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD,
-            double defaultMaxOutput, double defaultMinOutput);
-
-    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD);
-
+    
     public PIDManager create(String functionName);
 }

--- a/src/xbot/common/math/PIDManagerFactory.java
+++ b/src/xbot/common/math/PIDManagerFactory.java
@@ -1,0 +1,17 @@
+package xbot.common.math;
+
+public interface PIDManagerFactory {
+
+    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD, double defaultF,
+            double defaultMaxOutput, double defaultMinOutput, double errorThreshold, double derivativeThreshold);
+
+    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD, double defaultF,
+            double defaultMaxOutput, double defaultMinOutput);
+
+    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD,
+            double defaultMaxOutput, double defaultMinOutput);
+
+    public PIDManager create(String functionName, double defaultP, double defaultI, double defaultD);
+
+    public PIDManager create(String functionName);
+}

--- a/src/xbot/common/math/XYPairManager.java
+++ b/src/xbot/common/math/XYPairManager.java
@@ -14,14 +14,14 @@ public class XYPairManager {
     private DoubleProperty propY;
 
     public XYPairManager(String functionName, XPropertyManager propMan, double defaultX, double defaultY) {
-        setupPIDManager(functionName, propMan, defaultX, defaultY);
+        setupXYPairManager(functionName, propMan, defaultX, defaultY);
     }
 
     public XYPairManager(String functionName, XPropertyManager propMan) {
-        setupPIDManager(functionName, propMan, 0, 0);
+        setupXYPairManager(functionName, propMan, 0, 0);
     }
 
-    private void setupPIDManager(String functionName, XPropertyManager propMan, double defaultX, double defaultY) {
+    private void setupXYPairManager(String functionName, XPropertyManager propMan, double defaultX, double defaultY) {
         propX = new DoubleProperty(functionName + " X", defaultX, propMan);
         propY = new DoubleProperty(functionName + " Y", defaultY, propMan);
     }

--- a/tests/xbot/common/injection/UnitTestModule.java
+++ b/tests/xbot/common/injection/UnitTestModule.java
@@ -6,6 +6,7 @@ import xbot.common.injection.wpi_factories.MockWPIFactory;
 import xbot.common.injection.wpi_factories.WPIFactory;
 import xbot.common.logging.LoudRobotAssertionManager;
 import xbot.common.logging.RobotAssertionManager;
+import xbot.common.math.PIDManagerFactory;
 import xbot.common.properties.ITableProxy;
 import xbot.common.properties.MockPermamentStorage;
 import xbot.common.properties.PermanentStorage;
@@ -13,6 +14,7 @@ import xbot.common.properties.TableProxy;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 import edu.wpi.first.wpilibj.MockTimer;
 import edu.wpi.first.wpilibj.Timer;
@@ -44,5 +46,7 @@ public class UnitTestModule extends AbstractModule {
         this.bind(SmartDashboardCommandPutter.class).to(MockSmartDashboardCommandPutter.class);
 
         this.bind(RobotAssertionManager.class).to(LoudRobotAssertionManager.class);
+        
+        this.install(new FactoryModuleBuilder().build(PIDManagerFactory.class));
     }
 }

--- a/tests/xbot/common/math/PIDManagerTest.java
+++ b/tests/xbot/common/math/PIDManagerTest.java
@@ -24,8 +24,7 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void testDefaultOutputLimits() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0);
+        PIDManager manager = factory.create("test", 1, 0, 0);
         double output = manager.calculate(100, 0);
         assertEquals(1.0, output, 0.001);
         
@@ -35,8 +34,7 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void testOverrideOutputLimits() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25);
         double output = manager.calculate(100, 0);
         assertEquals(0.5, output, 0.001);
         
@@ -46,15 +44,13 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void testIsOnTargetStartsFalse() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 1, 0);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 1, 0);
         assertFalse(manager.isOnTarget());
     }
     
     @Test
     public void testIsOnTargetUsingError() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 1, 0);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 1, 0);
         
         manager.calculate(100, 0);
         assertFalse(manager.isOnTarget());
@@ -65,8 +61,7 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void testIsOnTargetUsingDerivative() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 0, 1);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 0, 1);
         
         manager.calculate(100, 0);
         assertFalse(manager.isOnTarget());
@@ -80,8 +75,7 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void testIsOnTargetUsingErrorAndDerivative() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 1, 1);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 1, 1);
         
         manager.calculate(100, 0);
         assertFalse(manager.isOnTarget());
@@ -95,8 +89,7 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void testIsOnTargetThenNot() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 1, 0);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 1, 0);
         manager.calculate(100, 0);
         assertFalse(manager.isOnTarget());
         
@@ -109,16 +102,14 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void testNotSettingThresholds() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25);
         
         assertFalse(manager.isOnTarget());
     }
     
     @Test
     public void testLegacyIsOnTarget() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25);
         
         assertFalse(manager.isOnTarget(1));
         
@@ -131,16 +122,14 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test(expected=RobotAssertionException.class)
     public void testAttemptNegativeThreshold() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 1, 1);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 1, 1);
         
         manager.setErrorThreshold(-10);
     }
     
     @Test
     public void disableEnableErrorTolerance() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 1, 0);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 1, 0);
         
         manager.calculate(100, 100);
         
@@ -159,8 +148,7 @@ public class PIDManagerTest extends BaseWPITest{
     
     @Test
     public void disableEnableDerivativeTolerance() {
-        PIDManager manager = new PIDManager(
-                "test", injector.getInstance(XPropertyManager.class), injector.getInstance(RobotAssertionManager.class), 1, 0, 0, 0, 0.5, -0.25, 0, 1);
+        PIDManager manager = factory.create("test", 1, 0, 0, 0, 0.5, -0.25, 0, 1);
         
         manager.calculate(100, 100);
         manager.calculate(100, 100);

--- a/tests/xbot/common/math/PIDManagerTest.java
+++ b/tests/xbot/common/math/PIDManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import xbot.common.injection.BaseWPITest;
@@ -12,6 +13,14 @@ import xbot.common.logging.RobotAssertionManager;
 import xbot.common.properties.XPropertyManager;
 
 public class PIDManagerTest extends BaseWPITest{
+    
+    PIDManagerFactory factory;
+    
+    @Before
+    public void setUp() {
+        super.setUp();
+        factory = injector.getInstance(PIDManagerFactory.class);
+    }
     
     @Test
     public void testDefaultOutputLimits() {


### PR DESCRIPTION
Make it easier to create a PIDManager with a factory implemented using guice's AssistedInjection.

Updated the PIDManagerTest with how to use it.

This has the advantage of not requiring consumers to provide all of the injectable dependencies PIDManager has now or in the future. Also general good practice in how AssistedInjection works to help us see if there are other places we might want to leverage it.