### PR TITLE
Prevent error when property's key is missing from the store

### DIFF
--- a/src/xbot/common/properties/BooleanProperty.java
+++ b/src/xbot/common/properties/BooleanProperty.java
@@ -6,6 +6,7 @@
 
 package xbot.common.properties;
 
+import org.apache.log4j.Logger;
 
 /**
  * A property holding a boolean value.
@@ -39,7 +40,14 @@ public class BooleanProperty extends Property {
      * @return the current boolean value
      */
     public boolean get() {
-        return randomAccessStore.getBoolean(key).booleanValue();
+        Boolean nullableTableValue = randomAccessStore.getBoolean(key);
+        
+        if(nullableTableValue == null) {
+            log.error("Property key not present in the underlying store! Returning default value.");
+            return defaultValue;
+        }
+        
+        return nullableTableValue.booleanValue();
     }
 
     /**

--- a/src/xbot/common/properties/BooleanProperty.java
+++ b/src/xbot/common/properties/BooleanProperty.java
@@ -35,7 +35,8 @@ public class BooleanProperty extends Property {
         Boolean nullableTableValue = randomAccessStore.getBoolean(key);
         
         if(nullableTableValue == null) {
-            log.error("Property key \"" + key + "\" not present in the underlying store! IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
+            log.error("Property key \"" + key + "\" not present in the underlying store!"
+                    + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             return defaultValue;
         }
         

--- a/src/xbot/common/properties/BooleanProperty.java
+++ b/src/xbot/common/properties/BooleanProperty.java
@@ -35,7 +35,7 @@ public class BooleanProperty extends Property {
         Boolean nullableTableValue = randomAccessStore.getBoolean(key);
         
         if(nullableTableValue == null) {
-            log.error("Property key not present in the underlying store! Returning default value.");
+            log.error("Property key \"" + key + "\" not present in the underlying store! IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             return defaultValue;
         }
         

--- a/src/xbot/common/properties/BooleanProperty.java
+++ b/src/xbot/common/properties/BooleanProperty.java
@@ -1,12 +1,4 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package xbot.common.properties;
-
-import org.apache.log4j.Logger;
 
 /**
  * A property holding a boolean value.

--- a/src/xbot/common/properties/DoubleProperty.java
+++ b/src/xbot/common/properties/DoubleProperty.java
@@ -28,7 +28,8 @@ public class DoubleProperty extends Property {
         Double nullableTableValue = randomAccessStore.getDouble(key);
         
         if(nullableTableValue == null) {
-            log.error("Property key not present in the underlying store! Returning default value.");
+            log.error("Property key \"" + key + "\" not present in the underlying store!"
+                    + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             return defaultValue;
         }
         

--- a/src/xbot/common/properties/DoubleProperty.java
+++ b/src/xbot/common/properties/DoubleProperty.java
@@ -36,7 +36,6 @@ public class DoubleProperty extends Property {
         return nullableTableValue.doubleValue();
     }
     
-
     public void set(double value) {
         randomAccessStore.setDouble(key, value);
     }

--- a/src/xbot/common/properties/DoubleProperty.java
+++ b/src/xbot/common/properties/DoubleProperty.java
@@ -25,7 +25,14 @@ public class DoubleProperty extends Property {
     
 
     public double get() {
-        return randomAccessStore.getDouble(key).doubleValue();
+        Double nullableTableValue = randomAccessStore.getDouble(key);
+        
+        if(nullableTableValue == null) {
+            log.error("Property key not present in the underlying store! Returning default value.");
+            return defaultValue;
+        }
+        
+        return nullableTableValue.doubleValue();
     }
     
 

--- a/src/xbot/common/properties/Property.java
+++ b/src/xbot/common/properties/Property.java
@@ -34,20 +34,7 @@ public abstract class Property {
     }
     
     public PropertyPersistenceType persistenceType;
-    private static Logger log = Logger.getLogger(Property.class);
-
-    /**
-     * The name of the property. This should be unique unless you really know
-     * what you're doing.
-     * 
-     */
-    public Property(String key, XPropertyManager manager) {
-        this.key = sanitizeKey(key);
-        this.permanentStore = manager.permanentStore;
-        this.randomAccessStore = manager.randomAccessStore;
-        this.persistenceType = PropertyPersistenceType.Persistent;
-        manager.registerProperty(this);
-    } 
+    protected static Logger log;
     
     /**
      * The name of the property. This should be unique unless you really know
@@ -57,11 +44,22 @@ public abstract class Property {
      */
     public Property(String key, XPropertyManager manager, PropertyPersistenceType persistenceType) {
         this.key = sanitizeKey(key);
+        log =  Logger.getLogger(this.getClass().getSimpleName() + " (\"" + this.key + "\")");
+        
         this.permanentStore = manager.permanentStore;
         this.randomAccessStore = manager.randomAccessStore;
         this.persistenceType = persistenceType;
         manager.registerProperty(this);
     }
+
+    /**
+     * The name of the property. This should be unique unless you really know
+     * what you're doing.
+     * 
+     */
+    public Property(String key, XPropertyManager manager) {
+        this(key, manager, PropertyPersistenceType.Persistent);
+    } 
 
     private String sanitizeKey(String key) {
         String sanitizedKey = key;

--- a/src/xbot/common/properties/StringProperty.java
+++ b/src/xbot/common/properties/StringProperty.java
@@ -26,7 +26,14 @@ public class StringProperty extends Property {
     }
     
     public String get() {
-        return randomAccessStore.getString(key);
+        String nullableTableValue = randomAccessStore.getString(key);
+        
+        if(nullableTableValue == null) {
+            log.error("Property key not present in the underlying store! Returning default value.");
+            return defaultValue;
+        }
+        
+        return nullableTableValue;
     }
     
     public void set(String value) {

--- a/src/xbot/common/properties/StringProperty.java
+++ b/src/xbot/common/properties/StringProperty.java
@@ -29,7 +29,8 @@ public class StringProperty extends Property {
         String nullableTableValue = randomAccessStore.getString(key);
         
         if(nullableTableValue == null) {
-            log.error("Property key not present in the underlying store! Returning default value.");
+            log.error("Property key \"" + key + "\" not present in the underlying store!"
+                    + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             return defaultValue;
         }
         


### PR DESCRIPTION
There's a missing check in the property classes which opens us up to fatal errors (to the extent of "Robots don't quit!") when the underlying data store is missing the property's key. This PR fixes that issue and replaces the `NullPointerException` with an angry error print.

Note that I decided to make the `StringProperty` match the others even though it isn't strictly necessary; it seems better to return the default value instead of `null`.