### PR TITLE
Use WPILib's Preferences system to store Properties

### DIFF
--- a/src/xbot/common/injection/RobotModule.java
+++ b/src/xbot/common/injection/RobotModule.java
@@ -9,6 +9,7 @@ import xbot.common.logging.SilentRobotAssertionManager;
 import xbot.common.math.PIDFactory;
 import xbot.common.properties.ITableProxy;
 import xbot.common.properties.PermanentStorage;
+import xbot.common.properties.PreferenceStorage;
 import xbot.common.properties.RobotDatabaseStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
 
@@ -21,7 +22,7 @@ public class RobotModule extends AbstractModule {
     protected void configure() {
         this.bind(WPIFactory.class).to(RealWPIFactory.class);
         this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class);
-        this.bind(PermanentStorage.class).to(RobotDatabaseStorage.class);
+        this.bind(PermanentStorage.class).to(PreferenceStorage.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(SilentRobotAssertionManager.class);
         this.install(new FactoryModuleBuilder().build(PIDFactory.class));

--- a/src/xbot/common/properties/PreferenceStorage.java
+++ b/src/xbot/common/properties/PreferenceStorage.java
@@ -4,6 +4,16 @@ import org.apache.log4j.Logger;
 
 import edu.wpi.first.wpilibj.Preferences;
 
+/**
+ * @author John
+ * 
+ * This saves properties to the robot using WPI's built-in Preferences library:
+ * http://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/Preferences.html
+ * 
+ * This stores them in a simple key-value pair on the robot, in a file called
+ * /home/lvuser/networktables.ini
+ * 
+ */
 public class PreferenceStorage implements PermanentStorage {
 
     protected static Logger log;

--- a/src/xbot/common/properties/PreferenceStorage.java
+++ b/src/xbot/common/properties/PreferenceStorage.java
@@ -1,0 +1,58 @@
+package xbot.common.properties;
+
+import org.apache.log4j.Logger;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+public class PreferenceStorage implements PermanentStorage {
+
+    protected static Logger log;
+    
+    @Override
+    public void setDouble(String key, double value) {
+        Preferences.getInstance().putDouble(key, value);
+    }
+
+    @Override
+    public void setBoolean(String key, boolean value) {
+        Preferences.getInstance().putBoolean(key, value);
+    }
+
+    @Override
+    public void setString(String key, String value) {
+        Preferences.getInstance().putString(key, value);
+    }
+
+    @Override
+    public Double getDouble(String key) {
+        if (Preferences.getInstance().containsKey(key))
+        {
+            return Preferences.getInstance().getDouble(key, 0);
+        }
+        return null;
+    }
+
+    @Override
+    public Boolean getBoolean(String key) {
+        if (Preferences.getInstance().containsKey(key))
+        {
+            return Preferences.getInstance().getBoolean(key, false);
+        }
+        return null;
+    }
+
+    @Override
+    public String getString(String key) {
+        if (Preferences.getInstance().containsKey(key))
+        {
+            return Preferences.getInstance().getString(key, null);
+        }
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        // Can't figure out how to clear it - could not figure out how to make Java happy
+        // with the untyped Vector output from the library
+    }
+}

--- a/src/xbot/common/properties/PreferenceStorage.java
+++ b/src/xbot/common/properties/PreferenceStorage.java
@@ -52,7 +52,6 @@ public class PreferenceStorage implements PermanentStorage {
 
     @Override
     public void clear() {
-        // Can't figure out how to clear it - could not figure out how to make Java happy
-        // with the untyped Vector output from the library
+        Preferences.getInstance().getKeys().clear();
     }
 }


### PR DESCRIPTION
Instead of using the Derby database, we use the Preferences system, which has a simple way of serializing things to disk on the robot.