### PR TITLE
Add a generic interface for using CAN devices

### DIFF
--- a/checkstyle_suppressions.xml
+++ b/checkstyle_suppressions.xml
@@ -8,6 +8,7 @@
     <suppress files="nav6" checks="[a-zA-Z0-9]*"/>
     <suppress files="navx" checks="[a-zA-Z0-9]*"/>
     <suppress files="CANTalon" checks="[a-zA-Z0-9]*"/>
+    <suppress files="XCANDevice" checks="[a-zA-Z0-9]*"/>
     <suppress files="JSON" checks="[a-zA-Z0-9]*"/>
     <suppress files="AutonomousPathTrajectoryPlanner" checks="[a-zA-Z0-9]*"/>
 </suppressions>

--- a/src/xbot/common/controls/misc/XCANDevice.java
+++ b/src/xbot/common/controls/misc/XCANDevice.java
@@ -1,0 +1,6 @@
+package xbot.common.controls.misc;
+
+public interface XCANDevice {
+    void send(byte[] data);
+    byte[] receive();
+}

--- a/src/xbot/common/controls/misc/wpi_adapters/CANDeviceWPIAdapter.java
+++ b/src/xbot/common/controls/misc/wpi_adapters/CANDeviceWPIAdapter.java
@@ -1,0 +1,43 @@
+package xbot.common.controls.misc.wpi_adapters;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import xbot.common.controls.misc.XCANDevice;
+import edu.wpi.first.wpilibj.can.CANJNI;
+
+public class CANDeviceWPIAdapter implements XCANDevice {
+
+    private final int arbitrationId;
+    public CANDeviceWPIAdapter(int arbitrationId) {
+        this.arbitrationId = arbitrationId;
+    }
+    
+    @Override
+    public void send(byte[] data) {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
+        CANJNI.FRCNetCommCANSessionMuxSendMessage(this.arbitrationId, buffer, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
+    }
+
+    @Override
+    public byte[] receive() {
+        ByteBuffer targetMessageIdBuffer = ByteBuffer.allocateDirect(4);
+        targetMessageIdBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        targetMessageIdBuffer.asIntBuffer().put(this.arbitrationId);
+        
+        // A buffer is required, but we don't care about the timestamp value.
+        ByteBuffer timeStamp = ByteBuffer.allocateDirect(4);
+        
+        ByteBuffer resultBuf = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(targetMessageIdBuffer.asIntBuffer(), CANJNI.CAN_IS_FRAME_REMOTE, timeStamp);
+        
+        if(resultBuf == null) {
+            return null;
+        }
+        
+        byte[] resultBytes = new byte[resultBuf.remaining()];
+        resultBuf.get(resultBytes);
+        
+        return resultBytes;
+    }
+
+}

--- a/src/xbot/common/controls/misc/wpi_adapters/CANDeviceWPIAdapter.java
+++ b/src/xbot/common/controls/misc/wpi_adapters/CANDeviceWPIAdapter.java
@@ -26,6 +26,7 @@ public class CANDeviceWPIAdapter implements XCANDevice {
     @Override
     public void send(byte[] data) {
         ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
+        buffer.put(data);
         CANJNI.FRCNetCommCANSessionMuxSendMessage(this.outboundArbitrationId, buffer, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
     }
 

--- a/src/xbot/common/controls/misc/wpi_adapters/CANDeviceWPIAdapter.java
+++ b/src/xbot/common/controls/misc/wpi_adapters/CANDeviceWPIAdapter.java
@@ -3,41 +3,55 @@ package xbot.common.controls.misc.wpi_adapters;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.log4j.Logger;
+
 import xbot.common.controls.misc.XCANDevice;
+import edu.wpi.first.wpilibj.can.CANInvalidBufferException;
 import edu.wpi.first.wpilibj.can.CANJNI;
+import edu.wpi.first.wpilibj.can.CANMessageNotAllowedException;
+import edu.wpi.first.wpilibj.can.CANMessageNotFoundException;
+import edu.wpi.first.wpilibj.can.CANNotInitializedException;
 
 public class CANDeviceWPIAdapter implements XCANDevice {
-
-    private final int arbitrationId;
-    public CANDeviceWPIAdapter(int arbitrationId) {
-        this.arbitrationId = arbitrationId;
+    static Logger log = Logger.getLogger(CANDeviceWPIAdapter.class);
+    
+    private final int inboundArbitrationId;
+    private final int outboundArbitrationId;
+    
+    public CANDeviceWPIAdapter(int inboundArbitrationId, int outboundArbitrationId) {
+        this.inboundArbitrationId = inboundArbitrationId;
+        this.outboundArbitrationId = outboundArbitrationId;
     }
     
     @Override
     public void send(byte[] data) {
         ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
-        CANJNI.FRCNetCommCANSessionMuxSendMessage(this.arbitrationId, buffer, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
+        CANJNI.FRCNetCommCANSessionMuxSendMessage(this.outboundArbitrationId, buffer, CANJNI.CAN_SEND_PERIOD_NO_REPEAT);
     }
 
     @Override
     public byte[] receive() {
         ByteBuffer targetMessageIdBuffer = ByteBuffer.allocateDirect(4);
         targetMessageIdBuffer.order(ByteOrder.LITTLE_ENDIAN);
-        targetMessageIdBuffer.asIntBuffer().put(this.arbitrationId);
+        targetMessageIdBuffer.asIntBuffer().put(this.inboundArbitrationId);
         
         // A buffer is required, but we don't care about the timestamp value.
         ByteBuffer timeStamp = ByteBuffer.allocateDirect(4);
         
-        ByteBuffer resultBuf = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(targetMessageIdBuffer.asIntBuffer(), CANJNI.CAN_IS_FRAME_REMOTE, timeStamp);
-        
-        if(resultBuf == null) {
+        try {
+            ByteBuffer resultBuf = CANJNI.FRCNetCommCANSessionMuxReceiveMessage(targetMessageIdBuffer.asIntBuffer(), CANJNI.CAN_IS_FRAME_REMOTE, timeStamp);
+            
+            byte[] resultBytes = new byte[resultBuf.remaining()];
+            resultBuf.get(resultBytes);
+            
+            return resultBytes;
+        }
+        catch (CANMessageNotFoundException e) {
             return null;
         }
-        
-        byte[] resultBytes = new byte[resultBuf.remaining()];
-        resultBuf.get(resultBytes);
-        
-        return resultBytes;
+        catch(CANInvalidBufferException|CANMessageNotAllowedException|CANNotInitializedException ex) {
+            log.error("Exception encountered while receiving from CAN device (inbound arbid " + this.inboundArbitrationId + ")", ex);
+            return null;
+        }
     }
-
 }

--- a/src/xbot/common/injection/wpi_factories/RealWPIFactory.java
+++ b/src/xbot/common/injection/wpi_factories/RealWPIFactory.java
@@ -19,6 +19,7 @@ import xbot.common.controls.actuators.wpi_adapters.DigitalOutputWPIAdapter;
 import xbot.common.controls.actuators.wpi_adapters.ServoWPIAdapter;
 import xbot.common.controls.actuators.wpi_adapters.SolenoidWPIAdapter;
 import xbot.common.controls.actuators.wpi_adapters.SpeedControllerWPIAdapter;
+import xbot.common.controls.misc.wpi_adapters.CANDeviceWPIAdapter;
 import xbot.common.controls.sensors.AdvancedJoystickButton;
 import xbot.common.controls.sensors.AnalogDistanceSensor;
 import xbot.common.controls.sensors.AnalogHIDButton;
@@ -205,5 +206,10 @@ public class RealWPIFactory implements WPIFactory {
     @Override
     public DistanceSensorPair getMultiplexedLidarPair(Port port, byte lidarMuxIdA, byte lidarMuxIdB) {
         return new MultiplexedLidarPair(port, lidarMuxIdA, lidarMuxIdB, propMan);
+    }
+
+    @Override
+    public XCANDevice getCANDevice(int arbitrationId) {
+        return new CANDeviceWPIAdapter(arbitrationId);
     }
 }

--- a/src/xbot/common/injection/wpi_factories/RealWPIFactory.java
+++ b/src/xbot/common/injection/wpi_factories/RealWPIFactory.java
@@ -19,6 +19,7 @@ import xbot.common.controls.actuators.wpi_adapters.DigitalOutputWPIAdapter;
 import xbot.common.controls.actuators.wpi_adapters.ServoWPIAdapter;
 import xbot.common.controls.actuators.wpi_adapters.SolenoidWPIAdapter;
 import xbot.common.controls.actuators.wpi_adapters.SpeedControllerWPIAdapter;
+import xbot.common.controls.misc.XCANDevice;
 import xbot.common.controls.misc.wpi_adapters.CANDeviceWPIAdapter;
 import xbot.common.controls.sensors.AdvancedJoystickButton;
 import xbot.common.controls.sensors.AnalogDistanceSensor;
@@ -209,7 +210,7 @@ public class RealWPIFactory implements WPIFactory {
     }
 
     @Override
-    public XCANDevice getCANDevice(int arbitrationId) {
-        return new CANDeviceWPIAdapter(arbitrationId);
+    public XCANDevice getCANDevice(int inboundArbitrationId, int outboundArbitrationId) {
+        return new CANDeviceWPIAdapter(inboundArbitrationId, outboundArbitrationId);
     }
 }

--- a/src/xbot/common/injection/wpi_factories/WPIFactory.java
+++ b/src/xbot/common/injection/wpi_factories/WPIFactory.java
@@ -9,6 +9,7 @@ import xbot.common.controls.actuators.XDigitalOutput;
 import xbot.common.controls.actuators.XServo;
 import xbot.common.controls.actuators.XSolenoid;
 import xbot.common.controls.actuators.XSpeedController;
+import xbot.common.controls.misc.XCANDevice;
 import xbot.common.controls.sensors.AdvancedJoystickButton;
 import xbot.common.controls.sensors.AnalogHIDButton;
 import xbot.common.controls.sensors.XXboxController;
@@ -64,5 +65,5 @@ public interface WPIFactory {
 
     public XPowerDistributionPanel getPDP();
 
-    public XCANDevice getCANDevice(int arbitrationId);
+    public XCANDevice getCANDevice(int inboundArbitrationId, int outboundArbitrationId);
 }

--- a/src/xbot/common/injection/wpi_factories/WPIFactory.java
+++ b/src/xbot/common/injection/wpi_factories/WPIFactory.java
@@ -63,4 +63,6 @@ public interface WPIFactory {
     public DistanceSensor getAnalogDistanceSensor(int channel, DoubleFunction<Double> voltageMap);
 
     public XPowerDistributionPanel getPDP();
+
+    public XCANDevice getCANDevice(int arbitrationId);
 }

--- a/tests/edu/wpi/first/wpilibj/MockCANDevice.java
+++ b/tests/edu/wpi/first/wpilibj/MockCANDevice.java
@@ -1,0 +1,17 @@
+package edu.wpi.first.wpilibj;
+
+import xbot.common.controls.misc.XCANDevice;
+
+public class MockCANDevice implements XCANDevice {
+
+    @Override
+    public void send(byte[] data) {
+        
+    }
+
+    @Override
+    public byte[] receive() {
+        return null;
+    }
+
+}

--- a/tests/xbot/common/injection/wpi_factories/MockWPIFactory.java
+++ b/tests/xbot/common/injection/wpi_factories/MockWPIFactory.java
@@ -34,6 +34,7 @@ import xbot.common.injection.wpi_factories.WPIFactory;
 import xbot.common.logging.RobotAssertionManager;
 import edu.wpi.first.wpilibj.I2C.Port;
 import edu.wpi.first.wpilibj.MockAnalogInput;
+import edu.wpi.first.wpilibj.MockCANDevice;
 import edu.wpi.first.wpilibj.MockCompressor;
 import edu.wpi.first.wpilibj.MockDigitalInput;
 import edu.wpi.first.wpilibj.MockDigitalOutput;
@@ -209,5 +210,10 @@ public class MockWPIFactory implements WPIFactory {
     @Override
     public DistanceSensorPair getMultiplexedLidarPair(Port port, byte lidarMuxIdA, byte lidarMuxIdB) {
         return new MockDistanceSensorPair();
+    }
+    
+    @Override
+    public XCANDevice getCANDevice(int arbitrationId) {
+        return new MockCANDevice();
     }
 }

--- a/tests/xbot/common/injection/wpi_factories/MockWPIFactory.java
+++ b/tests/xbot/common/injection/wpi_factories/MockWPIFactory.java
@@ -13,6 +13,7 @@ import xbot.common.controls.actuators.XDigitalOutput;
 import xbot.common.controls.actuators.XServo;
 import xbot.common.controls.actuators.XSolenoid;
 import xbot.common.controls.actuators.XSpeedController;
+import xbot.common.controls.misc.XCANDevice;
 import xbot.common.controls.sensors.AdvancedJoystickButton;
 import xbot.common.controls.sensors.AnalogHIDButton;
 import xbot.common.controls.sensors.DistanceSensor;
@@ -213,7 +214,7 @@ public class MockWPIFactory implements WPIFactory {
     }
     
     @Override
-    public XCANDevice getCANDevice(int arbitrationId) {
+    public XCANDevice getCANDevice(int inboundArbitrationId, int outboundArbitrationId) {
         return new MockCANDevice();
     }
 }


### PR DESCRIPTION
Sending from the RIO to an external custom device is confirmed working. I haven't yet tested the read operation.