### PR TITLE
Possibly allow people to use intelliJ for programming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ derby.log
 # dynamically generated properties files
 netconsole-host.properties
 WPI_Native_Libraries.properties
+
+# JetBrains
+.idea/
+/*.iml


### PR DESCRIPTION
There is an FRC plugin that has all the necessary libraries for people to use intelliJ