### PR TITLE
Add a class that monitors if packets are being sent from the driver station and warns if it's not

### DIFF
--- a/src/xbot/common/command/BaseRobot.java
+++ b/src/xbot/common/command/BaseRobot.java
@@ -22,6 +22,7 @@ import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import xbot.common.subsystems.ConnectionMonitorSubsystem;
 
 /**
  * Core Robot class which configures logging, properties,
@@ -35,6 +36,7 @@ public class BaseRobot extends IterativeRobot {
 
     protected XPropertyManager propertyManager;
     protected XScheduler xScheduler;
+    private ConnectionMonitorSubsystem connectionMonitorSubsystem;
 
     protected AbstractModule injectionModule;
 
@@ -101,6 +103,7 @@ public class BaseRobot extends IterativeRobot {
         // Get the property manager and get all properties from the robot disk
         propertyManager = this.injector.getInstance(XPropertyManager.class);
         xScheduler = this.injector.getInstance(XScheduler.class);
+        connectionMonitorSubsystem = this.injector.getInstance(ConnectionMonitorSubsystem.class);
     }
 
     @Override
@@ -169,6 +172,7 @@ public class BaseRobot extends IterativeRobot {
     }
     
     protected void sharedPeriodic() {
+        connectionMonitorSubsystem.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
         xScheduler.run();
         this.updatePeriodicDataSources();
         

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -1,0 +1,40 @@
+package xbot.common.subsystems;
+
+import edu.wpi.first.wpilibj.Timer;
+import xbot.common.command.BaseSubsystem;
+import xbot.common.logic.Latch;
+
+import java.util.Observable;
+import java.util.Observer;
+
+public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
+
+    private double timeOut;
+    private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
+
+    private double lastPacketReceivedTimeStamp = Timer.getFPGATimestamp();
+    private double disconnectionTime = -1;
+
+    public BaseConnectionMonitorSubsystem() {
+        connectionLatch.addObserver(this);
+    }
+
+    public void setTimeOut(double timeOut) {
+        this.timeOut = timeOut;
+    }
+
+    public synchronized void setLastPacketReceivedTimeStamp(double currentTimeStamp) {
+        connectionLatch.setValue((currentTimeStamp - lastPacketReceivedTimeStamp) < timeOut);
+        this.lastPacketReceivedTimeStamp = currentTimeStamp;
+    }
+
+    public double getPreviousDisconnectionTime() {
+        return disconnectionTime;
+    }
+
+    @Override
+    public void update(Observable o, Object arg) {
+        log.warn("The DriverStation has been disconnected for greater than " + timeOut + " seconds");
+        disconnectionTime = lastPacketReceivedTimeStamp;
+    }
+}

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -19,7 +19,7 @@ public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem imple
 
     public BaseConnectionMonitorSubsystem(XPropertyManager propertyManager) {
         log.info("Creating");
-        timeOut = propertyManager.createPersistentProperty("ConnectionMontiorTimeOut", 1.0);
+        timeOut = propertyManager.createPersistentProperty("ConnectionMontiorTimeOut Seconds", 1.0);
         connectionLatch.addObserver(this);
     }
 

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -3,38 +3,37 @@ package xbot.common.subsystems;
 import edu.wpi.first.wpilibj.Timer;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.logic.Latch;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.XPropertyManager;
 
 import java.util.Observable;
 import java.util.Observer;
 
 public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
 
-    private double timeOut;
+    private DoubleProperty timeOut;
     private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
 
     private double lastPacketReceivedTimeStamp = Timer.getFPGATimestamp();
-    private double disconnectionTime = -1;
+    private double previousDisconnectionTimeStamp = -1;
 
-    public BaseConnectionMonitorSubsystem() {
+    public BaseConnectionMonitorSubsystem(XPropertyManager propertyManager) {
+        timeOut = propertyManager.createPersistentProperty("ConnectionMontiorTimeOut", 1.0);
         connectionLatch.addObserver(this);
     }
 
-    public void setTimeOut(double timeOut) {
-        this.timeOut = timeOut;
-    }
-
     public synchronized void setLastPacketReceivedTimeStamp(double currentTimeStamp) {
-        connectionLatch.setValue((currentTimeStamp - lastPacketReceivedTimeStamp) < timeOut);
+        connectionLatch.setValue((currentTimeStamp - lastPacketReceivedTimeStamp) < timeOut.get());
         this.lastPacketReceivedTimeStamp = currentTimeStamp;
     }
 
     public double getPreviousDisconnectionTime() {
-        return disconnectionTime;
+        return previousDisconnectionTimeStamp;
     }
 
     @Override
     public void update(Observable o, Object arg) {
         log.warn("The DriverStation has been disconnected for greater than " + timeOut + " seconds");
-        disconnectionTime = lastPacketReceivedTimeStamp;
+        previousDisconnectionTimeStamp = lastPacketReceivedTimeStamp;
     }
 }

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -18,6 +18,7 @@ public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem imple
     private double previousDisconnectionTimeStamp = -1;
 
     public BaseConnectionMonitorSubsystem(XPropertyManager propertyManager) {
+        log.info("Creating");
         timeOut = propertyManager.createPersistentProperty("ConnectionMontiorTimeOut", 1.0);
         connectionLatch.addObserver(this);
     }

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -14,8 +14,8 @@ public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem imple
     private DoubleProperty timeOut;
     private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
 
-    private double lastPacketReceivedTimeStamp = Timer.getFPGATimestamp();
-    private double previousDisconnectionTimeStamp = -1;
+    private double lastPacketReceivedTimestamp = Timer.getFPGATimestamp();
+    private double previousDisconnectionTimestamp = -1;
 
     public BaseConnectionMonitorSubsystem(XPropertyManager propertyManager) {
         log.info("Creating");
@@ -23,18 +23,18 @@ public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem imple
         connectionLatch.addObserver(this);
     }
 
-    public synchronized void setLastPacketReceivedTimeStamp(double currentTimeStamp) {
-        connectionLatch.setValue((currentTimeStamp - lastPacketReceivedTimeStamp) < timeOut.get());
-        this.lastPacketReceivedTimeStamp = currentTimeStamp;
+    public synchronized void setLastPacketReceivedTimestamp(double currentTimestamp) {
+        connectionLatch.setValue((currentTimestamp - lastPacketReceivedTimestamp) < timeOut.get());
+        this.lastPacketReceivedTimestamp = currentTimestamp;
     }
 
     public double getPreviousDisconnectionTime() {
-        return previousDisconnectionTimeStamp;
+        return previousDisconnectionTimestamp;
     }
 
     @Override
     public void update(Observable o, Object arg) {
         log.warn("The Driver Station has been disconnected for greater than " + timeOut + " Second(s)");
-        previousDisconnectionTimeStamp = lastPacketReceivedTimeStamp;
+        previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
     }
 }

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -11,7 +11,7 @@ import java.util.Observer;
 
 public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
 
-    private DoubleProperty timeOut;
+    private final DoubleProperty timeOut;
     private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
 
     private double lastPacketReceivedTimestamp = Timer.getFPGATimestamp();

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -1,5 +1,6 @@
 package xbot.common.subsystems;
 
+import com.google.inject.Singleton;
 import edu.wpi.first.wpilibj.Timer;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.logic.Latch;
@@ -9,9 +10,10 @@ import xbot.common.properties.XPropertyManager;
 import java.util.Observable;
 import java.util.Observer;
 
-public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
+@Singleton
+public class BaseConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
 
-    private final DoubleProperty timeOut;
+    protected final DoubleProperty timeOut;
     private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
 
     private double lastPacketReceivedTimestamp = Timer.getFPGATimestamp();
@@ -19,7 +21,7 @@ public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem imple
 
     public BaseConnectionMonitorSubsystem(XPropertyManager propertyManager) {
         log.info("Creating");
-        timeOut = propertyManager.createPersistentProperty("ConnectionMontiorTimeOut Seconds", 1.0);
+        timeOut = propertyManager.createPersistentProperty("ConnectionMonitorTimeOut Seconds", 1.0);
         connectionLatch.addObserver(this);
     }
 
@@ -28,7 +30,7 @@ public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem imple
         this.lastPacketReceivedTimestamp = currentTimestamp;
     }
 
-    public double getPreviousDisconnectionTime() {
+    public double getPreviousDisconnectionTimestamp() {
         return previousDisconnectionTimestamp;
     }
 

--- a/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/BaseConnectionMonitorSubsystem.java
@@ -33,7 +33,7 @@ public abstract class BaseConnectionMonitorSubsystem extends BaseSubsystem imple
 
     @Override
     public void update(Observable o, Object arg) {
-        log.warn("The DriverStation has been disconnected for greater than " + timeOut + " seconds");
+        log.warn("The Driver Station has been disconnected for greater than " + timeOut + " Second(s)");
         previousDisconnectionTimeStamp = lastPacketReceivedTimeStamp;
     }
 }

--- a/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
@@ -11,15 +11,15 @@ import java.util.Observable;
 import java.util.Observer;
 
 @Singleton
-public class BaseConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
+public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
 
     protected final DoubleProperty timeOut;
-    private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
+    private final Latch connectionLatch = new Latch(true, Latch.EdgeType.Both);
 
     private double lastPacketReceivedTimestamp = Timer.getFPGATimestamp();
     private double previousDisconnectionTimestamp = -1;
 
-    public BaseConnectionMonitorSubsystem(XPropertyManager propertyManager) {
+    public ConnectionMonitorSubsystem(XPropertyManager propertyManager) {
         log.info("Creating");
         timeOut = propertyManager.createPersistentProperty("ConnectionMonitorTimeOut Seconds", 1.0);
         connectionLatch.addObserver(this);
@@ -36,7 +36,11 @@ public class BaseConnectionMonitorSubsystem extends BaseSubsystem implements Obs
 
     @Override
     public void update(Observable o, Object arg) {
-        log.warn("The Driver Station has been disconnected for greater than " + timeOut + " Second(s)");
-        previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
+        if (arg == Latch.EdgeType.FallingEdge) {
+            log.warn("The Driver Station has been disconnected for greater than " + timeOut.get() + " Second(s)");
+            previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
+        } else {
+            //This Has To Be Here Or Else It Breaks
+        }
     }
 }

--- a/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
@@ -6,8 +6,7 @@ import xbot.common.logic.Latch;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.XPropertyManager;
 
-import java.util.Observable;
-import java.util.Observer;
+import java.util.*;
 
 @Singleton
 public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
@@ -16,7 +15,7 @@ public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observe
     private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
 
     private Double lastPacketReceivedTimestamp = null;
-    private double previousDisconnectionTimestamp = -1;
+    private double previousDisconnectionTimestamp = 0.0;
 
     public ConnectionMonitorSubsystem(XPropertyManager propertyManager) {
         log.info("Creating");
@@ -37,7 +36,8 @@ public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observe
 
     @Override
     public void update(Observable o, Object arg) {
-        log.warn("The Driver Station has been disconnected for greater than " + timeOut.get() + " second(s)");
+        log.warn("Connection with Driver Station restored. " +
+                "The Robot was disconnected from the driver station for at least " + timeOut.get() + " second(s).");
         previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
     }
 }

--- a/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
@@ -14,7 +14,7 @@ import java.util.Observer;
 public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
 
     protected final DoubleProperty timeOut;
-    private final Latch connectionLatch = new Latch(true, Latch.EdgeType.Both);
+    private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
 
     private double lastPacketReceivedTimestamp = Timer.getFPGATimestamp();
     private double previousDisconnectionTimestamp = -1;
@@ -30,15 +30,13 @@ public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observe
         this.lastPacketReceivedTimestamp = currentTimestamp;
     }
 
-    public double getPreviousDisconnectionTimestamp() {
+    public synchronized double getPreviousDisconnectionTimestamp() {
         return previousDisconnectionTimestamp;
     }
 
     @Override
     public void update(Observable o, Object arg) {
-        if (arg == Latch.EdgeType.FallingEdge) {
-            log.warn("The Driver Station has been disconnected for greater than " + timeOut.get() + " Second(s)");
-            previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
-        }
+        log.warn("The Driver Station has been disconnected for greater than " + timeOut.get() + " Second(s)");
+        previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
     }
 }

--- a/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
@@ -15,7 +15,7 @@ public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observe
     protected final DoubleProperty timeOut;
     private final Latch connectionLatch = new Latch(true, Latch.EdgeType.FallingEdge);
 
-    private double lastPacketReceivedTimestamp = -1;
+    private Double lastPacketReceivedTimestamp = null;
     private double previousDisconnectionTimestamp = -1;
 
     public ConnectionMonitorSubsystem(XPropertyManager propertyManager) {
@@ -25,7 +25,7 @@ public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observe
     }
 
     public void setLastPacketReceivedTimestamp(double currentTimestamp) {
-        if (lastPacketReceivedTimestamp != -1) {
+        if (lastPacketReceivedTimestamp != null) {
             connectionLatch.setValue((currentTimestamp - lastPacketReceivedTimestamp) < timeOut.get());
         }
         this.lastPacketReceivedTimestamp = currentTimestamp;

--- a/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
@@ -39,8 +39,6 @@ public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observe
         if (arg == Latch.EdgeType.FallingEdge) {
             log.warn("The Driver Station has been disconnected for greater than " + timeOut.get() + " Second(s)");
             previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
-        } else {
-            //This Has To Be Here Or Else It Breaks
         }
     }
 }

--- a/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
+++ b/src/xbot/common/subsystems/ConnectionMonitorSubsystem.java
@@ -6,7 +6,8 @@ import xbot.common.logic.Latch;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.XPropertyManager;
 
-import java.util.*;
+import java.util.Observable;
+import java.util.Observer;
 
 @Singleton
 public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observer {
@@ -36,8 +37,8 @@ public class ConnectionMonitorSubsystem extends BaseSubsystem implements Observe
 
     @Override
     public void update(Observable o, Object arg) {
-        log.warn("Connection with Driver Station restored. " +
-                "The Robot was disconnected from the driver station for at least " + timeOut.get() + " second(s).");
+        log.warn("Connection with Driver Station restored. "
+                + "The Robot was disconnected from the driver station for at least " + timeOut.get() + " second(s).");
         previousDisconnectionTimestamp = lastPacketReceivedTimestamp;
     }
 }

--- a/tests/xbot/common/subsystems/ConnectionMonitorTest.java
+++ b/tests/xbot/common/subsystems/ConnectionMonitorTest.java
@@ -4,7 +4,9 @@ import edu.wpi.first.wpilibj.MockTimer;
 import edu.wpi.first.wpilibj.Timer;
 import org.junit.Test;
 import xbot.common.injection.BaseWPITest;
+import xbot.common.properties.XPropertyManager;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import static junit.framework.TestCase.assertTrue;
@@ -39,7 +41,8 @@ public class ConnectionMonitorTest extends BaseWPITest {
 @Singleton
 class MockConnectionMonitor extends BaseConnectionMonitorSubsystem {
 
-    public MockConnectionMonitor() {
-        setTimeOut(1.0);
+    @Inject
+    public MockConnectionMonitor(XPropertyManager propertyManager) {
+        super(propertyManager);
     }
 }

--- a/tests/xbot/common/subsystems/ConnectionMonitorTest.java
+++ b/tests/xbot/common/subsystems/ConnectionMonitorTest.java
@@ -1,6 +1,7 @@
 package xbot.common.subsystems;
 
 import edu.wpi.first.wpilibj.MockTimer;
+import edu.wpi.first.wpilibj.Timer;
 import org.junit.Test;
 import xbot.common.injection.BaseWPITest;
 import xbot.common.properties.XPropertyManager;
@@ -40,6 +41,8 @@ public class ConnectionMonitorTest extends BaseWPITest {
     @Test
     public void testShortIntervalDisconnection() {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 1.1);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
@@ -48,6 +51,8 @@ public class ConnectionMonitorTest extends BaseWPITest {
     @Test
     public void testLongIntervalDisconnection() {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 500.0);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
@@ -90,6 +95,7 @@ public class ConnectionMonitorTest extends BaseWPITest {
     @Test
     public void testVaryingTimeOutWithDisconnection() {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
 
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 2);

--- a/tests/xbot/common/subsystems/ConnectionMonitorTest.java
+++ b/tests/xbot/common/subsystems/ConnectionMonitorTest.java
@@ -1,0 +1,45 @@
+package xbot.common.subsystems;
+
+import edu.wpi.first.wpilibj.MockTimer;
+import edu.wpi.first.wpilibj.Timer;
+import org.junit.Test;
+import xbot.common.injection.BaseWPITest;
+
+import javax.inject.Singleton;
+
+import static junit.framework.TestCase.assertTrue;
+
+public class ConnectionMonitorTest extends BaseWPITest {
+
+    private MockTimer mockTimer;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        mockTimer = injector.getInstance(MockTimer.class);
+        mockTimer.advanceTimeInSecondsBy(488);
+    }
+
+    @Test
+    public void testConnectedDriverStation() {
+        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        connectionMonitor.setLastPacketReceivedTimeStamp(Timer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTime() == -1);
+    }
+
+    @Test
+    public void testDisconnectedDriverStation() {
+        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        mockTimer.advanceTimeInSecondsBy(488);
+        connectionMonitor.setLastPacketReceivedTimeStamp(Timer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTime() > 400);
+    }
+}
+
+@Singleton
+class MockConnectionMonitor extends BaseConnectionMonitorSubsystem {
+
+    public MockConnectionMonitor() {
+        setTimeOut(1.0);
+    }
+}

--- a/tests/xbot/common/subsystems/ConnectionMonitorTest.java
+++ b/tests/xbot/common/subsystems/ConnectionMonitorTest.java
@@ -27,7 +27,7 @@ public class ConnectionMonitorTest extends BaseWPITest {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4.0);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
     }
 
     @Test
@@ -35,27 +35,27 @@ public class ConnectionMonitorTest extends BaseWPITest {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 1.1);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
     }
 
     @Test
     public void testShortIntervalDisconnection() {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 1.1);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > 0.0);
     }
 
     @Test
     public void testLongIntervalDisconnection() {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 500.0);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > 0.0);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class ConnectionMonitorTest extends BaseWPITest {
             mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() - (connectionMonitor.timeOut.get() / 2.0));
             connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         }
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
     }
 
     @Test
@@ -78,30 +78,30 @@ public class ConnectionMonitorTest extends BaseWPITest {
             mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() - (connectionMonitor.timeOut.get() / 2.0));
             connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         }
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() >= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() >= 0.0);
     }
 
     @Test
     public void testVaryingTimeOutWithNoDisconnection() {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4.0);
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
         connectionMonitor.timeOut.set(500);
         assertTrue(connectionMonitor.timeOut.get() >= 500);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 2.0);
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
     }
 
     @Test
     public void testVaryingTimeOutWithDisconnection() {
         ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= 0.0);
 
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 2);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         double previousVal = connectionMonitor.getPreviousDisconnectionTimestamp();
-        assertTrue(previousVal > -1.0);
+        assertTrue(previousVal > 0.0);
 
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4.0);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
@@ -111,7 +111,7 @@ public class ConnectionMonitorTest extends BaseWPITest {
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 2.0);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         double currentVal = connectionMonitor.getPreviousDisconnectionTimestamp();
-        assertTrue(currentVal > -1.0 && currentVal != previousVal);
+        assertTrue(currentVal > 0.0 && currentVal != previousVal);
     }
 }
 

--- a/tests/xbot/common/subsystems/ConnectionMonitorTest.java
+++ b/tests/xbot/common/subsystems/ConnectionMonitorTest.java
@@ -23,15 +23,15 @@ public class ConnectionMonitorTest extends BaseWPITest {
 
     @Test
     public void testShortIntervalNoDisconnection() {
-        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
-        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4);
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4.0);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
     }
 
     @Test
     public void testLongIntervalNoDisconnection() {
-        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 1.1);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
@@ -39,7 +39,7 @@ public class ConnectionMonitorTest extends BaseWPITest {
 
     @Test
     public void testShortIntervalDisconnection() {
-        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 1.1);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
@@ -47,15 +47,70 @@ public class ConnectionMonitorTest extends BaseWPITest {
 
     @Test
     public void testLongIntervalDisconnection() {
-        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
-        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 500);
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 500.0);
         connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
+    }
+
+    @Test
+    public void testMultipleSetPacketCallsWithNoDisconnection() {
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        for (int i = 0; i < 488; i++) {
+            mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() - (connectionMonitor.timeOut.get() / 2.0));
+            connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        }
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+    }
+
+    @Test
+    public void testMultipleSetPacketCallsWithDisconnection() {
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        for (int i = 0; i < 488; i++) {
+            if (i == 244) {
+                mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 2.0);
+            }
+            mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() - (connectionMonitor.timeOut.get() / 2.0));
+            connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        }
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() >= -1.0);
+    }
+
+    @Test
+    public void testVaryingTimeOutWithNoDisconnection() {
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+        connectionMonitor.timeOut.set(500);
+        assertTrue(connectionMonitor.timeOut.get() >= 500);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 2.0);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+    }
+
+    @Test
+    public void testVaryingTimeOutWithDisconnection() {
+        ConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 2);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        double previousVal = connectionMonitor.getPreviousDisconnectionTimestamp();
+        assertTrue(previousVal > -1.0);
+
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4.0);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        connectionMonitor.timeOut.set(500);
+        assertTrue(connectionMonitor.timeOut.get() >= 500);
+
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 2.0);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        double currentVal = connectionMonitor.getPreviousDisconnectionTimestamp();
+        assertTrue(currentVal > -1.0 && currentVal != previousVal);
     }
 }
 
 @Singleton
-class MockConnectionMonitor extends BaseConnectionMonitorSubsystem {
+class MockConnectionMonitor extends ConnectionMonitorSubsystem {
 
     @Inject
     public MockConnectionMonitor(XPropertyManager propertyManager) {

--- a/tests/xbot/common/subsystems/ConnectionMonitorTest.java
+++ b/tests/xbot/common/subsystems/ConnectionMonitorTest.java
@@ -1,7 +1,6 @@
 package xbot.common.subsystems;
 
 import edu.wpi.first.wpilibj.MockTimer;
-import edu.wpi.first.wpilibj.Timer;
 import org.junit.Test;
 import xbot.common.injection.BaseWPITest;
 import xbot.common.properties.XPropertyManager;
@@ -23,18 +22,35 @@ public class ConnectionMonitorTest extends BaseWPITest {
     }
 
     @Test
-    public void testConnectedDriverStation() {
+    public void testShortIntervalNoDisconnection() {
         BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
-        connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTime() == -1);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 4);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
     }
 
     @Test
-    public void testDisconnectedDriverStation() {
+    public void testLongIntervalNoDisconnection() {
         BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
-        mockTimer.advanceTimeInSecondsBy(488);
-        connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
-        assertTrue(connectionMonitor.getPreviousDisconnectionTime() > 400);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() / 1.1);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() <= -1.0);
+    }
+
+    @Test
+    public void testShortIntervalDisconnection() {
+        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 1.1);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
+    }
+
+    @Test
+    public void testLongIntervalDisconnection() {
+        BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
+        mockTimer.advanceTimeInSecondsBy(connectionMonitor.timeOut.get() * 500);
+        connectionMonitor.setLastPacketReceivedTimestamp(mockTimer.getFPGATimestamp());
+        assertTrue(connectionMonitor.getPreviousDisconnectionTimestamp() > -1.0);
     }
 }
 

--- a/tests/xbot/common/subsystems/ConnectionMonitorTest.java
+++ b/tests/xbot/common/subsystems/ConnectionMonitorTest.java
@@ -25,7 +25,7 @@ public class ConnectionMonitorTest extends BaseWPITest {
     @Test
     public void testConnectedDriverStation() {
         BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
-        connectionMonitor.setLastPacketReceivedTimeStamp(Timer.getFPGATimestamp());
+        connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTime() == -1);
     }
 
@@ -33,7 +33,7 @@ public class ConnectionMonitorTest extends BaseWPITest {
     public void testDisconnectedDriverStation() {
         BaseConnectionMonitorSubsystem connectionMonitor = injector.getInstance(MockConnectionMonitor.class);
         mockTimer.advanceTimeInSecondsBy(488);
-        connectionMonitor.setLastPacketReceivedTimeStamp(Timer.getFPGATimestamp());
+        connectionMonitor.setLastPacketReceivedTimestamp(Timer.getFPGATimestamp());
         assertTrue(connectionMonitor.getPreviousDisconnectionTime() > 400);
     }
 }


### PR DESCRIPTION
- Added ConnectionMonitor class:
  The purpose of the class is to have a subsystem that keeps checking if we're connected to the drive 
  station. We can add some logic some where it vibrates the Xbox controllers or something to warn the 
  drivers. Then we can log when we were disconnecting.

- Added ConnectionMonitor Tests