### PR TITLE
Adds a velocity-decay version of the HeadingAssistModule

### DIFF
--- a/src/main/java/xbot/common/injection/wpi_factories/CommonLibFactory.java
+++ b/src/main/java/xbot/common/injection/wpi_factories/CommonLibFactory.java
@@ -99,5 +99,6 @@ public interface CommonLibFactory {
             @Assisted("headingDrivePid") PIDManager headingDrivePid);
     
     public HeadingAssistModule createHeadingAssistModule(
-            @Assisted("headingModule") HeadingModule headingModule);
+            @Assisted("headingModule") HeadingModule headingModule,
+            @Assisted("decayModule") HeadingModule decayModule);
 }

--- a/src/main/java/xbot/common/injection/wpi_factories/CommonLibFactory.java
+++ b/src/main/java/xbot/common/injection/wpi_factories/CommonLibFactory.java
@@ -98,6 +98,12 @@ public interface CommonLibFactory {
     public HeadingModule createHeadingModule(
             @Assisted("headingDrivePid") PIDManager headingDrivePid);
     
+    /**
+     * Creates a heading assist module. Can either hold an orientation, or resist rotational motion.
+     * @param headingModule Tune this one to rotate to a target orientation (PD, or PID controller)
+     * @param decayModule Tune this one to resist rotation (D controller)
+     * @return
+     */
     public HeadingAssistModule createHeadingAssistModule(
             @Assisted("headingModule") HeadingModule headingModule,
             @Assisted("decayModule") HeadingModule decayModule);

--- a/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingAssistModule.java
+++ b/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingAssistModule.java
@@ -17,6 +17,10 @@ import xbot.common.subsystems.pose.BasePoseSubsystem;
  * - If the human driver wants the robot to turn (above some small threshold), then the robot should turn
  *   according to human desires.
  * - After a few moments, the robot should memorize its current heading, and attempt to hold it again.
+ * 
+ * The automatic response can take one of two forms:
+ * - Hold a specific heading, as mentioned above, using a PID controller
+ * - Resist changes in rotational velocity using a D-only controller.
  * @author jogilber
  *
  */

--- a/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingAssistModule.java
+++ b/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingAssistModule.java
@@ -102,12 +102,12 @@ public class HeadingAssistModule {
             }
 
             switch (headingMode) {
-            case HoldOrientation:
-                return headingModule.calculateHeadingPower(desiredHeading);
-            case DecayVelocity:
-                return decayModule.calculateHeadingPower(0);
-            default:
-                return 0;
+                case HoldOrientation:
+                    return headingModule.calculateHeadingPower(desiredHeading);
+                case DecayVelocity:
+                    return decayModule.calculateHeadingPower(0);
+                default:
+                    return 0;
             }
         }
     }

--- a/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
+++ b/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
@@ -8,6 +8,13 @@ import xbot.common.math.PIDManager;
 import xbot.common.properties.XPropertyManager;
 import xbot.common.subsystems.pose.BasePoseSubsystem;
 
+/**
+ * Encapsulates the logic needed to rotate the robot to a specific angle.
+ * When using a PD or PID controller, it will attempt to reach that angle.
+ * When using a D-only controller, it will just resist any rotational motion.
+ * @author John
+ *
+ */
 public class HeadingModule {
 
     final BasePoseSubsystem pose;

--- a/src/test/java/xbot/common/subsystems/drive/HeadingAssistModuleTest.java
+++ b/src/test/java/xbot/common/subsystems/drive/HeadingAssistModuleTest.java
@@ -25,6 +25,14 @@ public class HeadingAssistModuleTest extends BaseWPITest {
     }
     
     @Test
+    public void testNoConfig() {
+        ham.setMode(null);
+        step1_humanDrive();
+        step2_humanStops();
+        step3_timePasses();
+        step4_robotRotated();
+    }
+    @Test
     public void testFullStateMachine() {
         step1_humanDrive();
         step2_humanStops();


### PR DESCRIPTION
I've been doing some research into how other teams add automation to the drivetrain, and in a couple places I saw a pattern of using a gyro to automatically add "turning resistance" to the robot, so that when the driver stops rotating, the robot stops turning much faster.

The basic mechanism is to use a D-only PID on the gyro.

I've added this as a variant into our HeadingAssistModule - now we can choose between "hold an orientation after rotating" and "rapidly slow down after rotating"