### PR TITLE
Fix CAN talon telemetry

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANTalon.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANTalon.java
@@ -29,7 +29,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 import xbot.common.injection.wpi_factories.DevicePolice;
 import xbot.common.injection.wpi_factories.DevicePolice.DeviceType;
 import xbot.common.properties.DoubleProperty;
-import xbot.common.properties.StringProperty;
 import xbot.common.properties.XPropertyManager;
 
 
@@ -50,7 +49,6 @@ public abstract class XCANTalon extends SendableBase implements IMotorController
     protected int deviceId;
     protected XPropertyManager propMan;
     
-    private StringProperty controlModeProperty = null;
     private DoubleProperty currentProperty = null;
     private DoubleProperty outVoltageProperty = null;
     private DoubleProperty temperatureProperty = null;
@@ -86,10 +84,11 @@ public abstract class XCANTalon extends SendableBase implements IMotorController
     }
     
     public void updateTelemetryProperties() {
-        if(controlModeProperty == null
-                || currentProperty == null
+        if(currentProperty == null
                 || outVoltageProperty == null
-                || temperatureProperty == null) {
+                || temperatureProperty == null
+                || positionProperty == null
+                || velocityProperty == null) {
             return;
         }
         


### PR DESCRIPTION
When the class was updated to the new API the "mode" property wasn't fully removed, causing telemetry to never be updated because it checked whether that property was initialized.