### PR TITLE
Restructure PurePursuitCommand to allow custom implementations

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/ConfigurablePurePursuitCommand.java
+++ b/src/main/java/xbot/common/subsystems/drive/ConfigurablePurePursuitCommand.java
@@ -1,0 +1,51 @@
+package xbot.common.subsystems.drive;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.google.inject.Inject;
+
+import xbot.common.injection.wpi_factories.CommonLibFactory;
+import xbot.common.math.FieldPose;
+import xbot.common.properties.XPropertyManager;
+import xbot.common.subsystems.pose.BasePoseSubsystem;
+
+public class ConfigurablePurePursuitCommand extends PurePursuitCommand {
+    private List<FieldPose> originalPoints;
+    private PursuitMode mode;
+    private Supplier<List<FieldPose>> externalPointSource;
+
+    @Inject
+    public ConfigurablePurePursuitCommand(CommonLibFactory clf, BasePoseSubsystem pose, BaseDriveSubsystem drive,
+            XPropertyManager propMan) {
+        super(clf, pose, drive, propMan);
+        mode = PursuitMode.Absolute;
+        originalPoints = new ArrayList<>();
+        externalPointSource = null;
+    }
+
+    public void addPoint(FieldPose point) {
+        originalPoints.add(point);
+    }
+
+    public void setMode(PursuitMode mode) {
+        this.mode = mode;
+    }
+    
+    public void setPointSupplier(Supplier<List<FieldPose>> externalPointSource) {
+        this.externalPointSource = externalPointSource;
+    }
+    
+    protected List<FieldPose> getOriginalPoints() {
+        if (externalPointSource != null) {
+            originalPoints = externalPointSource.get();
+        }
+        return originalPoints;
+    }
+    
+    protected PursuitMode getPursuitMode() {
+        return this.mode;
+    }
+
+}

--- a/src/test/java/xbot/common/subsystems/drive/PurePursuitCommandTest.java
+++ b/src/test/java/xbot/common/subsystems/drive/PurePursuitCommandTest.java
@@ -16,14 +16,14 @@ import xbot.common.subsystems.pose.TestPoseSubsystem;
 
 public class PurePursuitCommandTest extends BaseWPITest {
     
-    PurePursuitCommand command;
+    ConfigurablePurePursuitCommand command;
     MockDriveSubsystem drive;
     TestPoseSubsystem pose;
     
     @Override
     public void setUp() {
         super.setUp();
-        command = injector.getInstance(PurePursuitCommand.class);
+        command = injector.getInstance(ConfigurablePurePursuitCommand.class);
         this.drive = (MockDriveSubsystem)injector.getInstance(BaseDriveSubsystem.class);
         this.pose = (TestPoseSubsystem)injector.getInstance(BasePoseSubsystem.class);
         


### PR DESCRIPTION
Existing usages of `PurePursuitCommand` will now instead use `ConfigurablePurePursuitCommand` (will open a PR in 2018 repo). Now the `PurePursuitCommand` is an abstract class which we can subclass for individual uses.