### PR TITLE
Allow accessing internal HID in joystick objects

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/XFTCGamepad.java
+++ b/src/main/java/xbot/common/controls/sensors/XFTCGamepad.java
@@ -1,5 +1,6 @@
 package xbot.common.controls.sensors;
 
+import edu.wpi.first.wpilibj.Joystick;
 import xbot.common.injection.wpi_factories.CommonLibFactory;
 import xbot.common.injection.wpi_factories.DevicePolice;
 import xbot.common.logging.RobotAssertionManager;

--- a/src/main/java/xbot/common/controls/sensors/XJoystick.java
+++ b/src/main/java/xbot/common/controls/sensors/XJoystick.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 
 import org.apache.log4j.Logger;
 
+import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.buttons.Button;
 
 public abstract class XJoystick
@@ -92,6 +93,8 @@ public abstract class XJoystick
     protected abstract boolean getButton(int button);
     
     protected abstract double getRawAxis(int axisNumber);
+    
+    public abstract GenericHID getRawWPILibJoystick();
     
     public abstract int getPOV();    
 

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockFTCGamepad.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockFTCGamepad.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
+import edu.wpi.first.wpilibj.GenericHID;
 import xbot.common.controls.sensors.XFTCGamepad;
 import xbot.common.injection.wpi_factories.CommonLibFactory;
 import xbot.common.injection.wpi_factories.DevicePolice;
@@ -91,4 +92,9 @@ public class MockFTCGamepad extends XFTCGamepad {
         return 0;
     }
 
+    @Override
+    public GenericHID getRawWPILibJoystick() {
+        // We don't have a real HID
+        return null;
+    }
 }

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockJoystick.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockJoystick.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
+import edu.wpi.first.wpilibj.GenericHID;
 import xbot.common.controls.sensors.XJoystick;
 import xbot.common.injection.wpi_factories.CommonLibFactory;
 import xbot.common.injection.wpi_factories.DevicePolice;
@@ -78,5 +79,11 @@ public class MockJoystick extends XJoystick {
     @Override
     public int getPOV() {
         return 0;
+    }
+
+    @Override
+    public GenericHID getRawWPILibJoystick() {
+        // We don't have a real HID
+        return null;
     }
 }

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/FTCGamepadWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/FTCGamepadWpiAdapter.java
@@ -46,4 +46,9 @@ public class FTCGamepadWpiAdapter extends XFTCGamepad {
     public int getPOV() {
         return this.internalHID.getPOV();
     }
+
+    @Override
+    public GenericHID getRawWPILibJoystick() {
+        return internalHID;
+    }
 }

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/JoystickWPIAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/JoystickWPIAdapter.java
@@ -47,4 +47,9 @@ public class JoystickWPIAdapter extends XJoystick {
     public int getPOV() {
         return this.internalHID.getPOV();
     }
+
+    @Override
+    public GenericHID getRawWPILibJoystick() {
+        return internalHID;
+    }
 }


### PR DESCRIPTION
This is intended to allow rumbling of devices we use as plain joysticks but know in reality are rumble-able controllers. This is pretty much a hack. For the alternative (which I want to look at _after_ competition as it makes some code cleaner), see https://github.com/Team488/SeriouslyCommonLib/tree/xbox-controller-rumble-dpad and https://github.com/Team488/TeamXbot2018/tree/adopt-xbox-controller-class. The primary issue here is that the Xbox controller class's inheritance tree is entirely separate from our other HIDs.