### PR TITLE
Fixed a bug in PurePursuitCommand around forward/reverse modes 

### DIFF
--- a/src/main/java/xbot/common/injection/SeriouslyCommonLibTestModule.java
+++ b/src/main/java/xbot/common/injection/SeriouslyCommonLibTestModule.java
@@ -3,7 +3,7 @@ package xbot.common.injection;
 import xbot.common.subsystems.drive.BaseDriveSubsystem;
 import xbot.common.subsystems.drive.MockDriveSubsystem;
 import xbot.common.subsystems.pose.BasePoseSubsystem;
-import xbot.common.subsystems.pose.TestPoseSubsystem;
+import xbot.common.subsystems.pose.MockBasePoseSubsystem;
 
 public class SeriouslyCommonLibTestModule extends UnitTestModule {
 
@@ -11,7 +11,7 @@ public class SeriouslyCommonLibTestModule extends UnitTestModule {
     protected void configure() {
         super.configure();
         
-        this.bind(BasePoseSubsystem.class).to(TestPoseSubsystem.class);
+        this.bind(BasePoseSubsystem.class).to(MockBasePoseSubsystem.class);
         this.bind(BaseDriveSubsystem.class).to(MockDriveSubsystem.class);
     }
 }

--- a/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
@@ -21,8 +21,8 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements Periodi
     private final DoubleProperty leftDriveDistance;
     private final DoubleProperty rightDriveDistance;
     
-    private final DoubleProperty totalDistanceX;
-    private final DoubleProperty totalDistanceY;
+    protected final DoubleProperty totalDistanceX;
+    protected final DoubleProperty totalDistanceY;
     private final DoubleProperty totalVelocity;
     
     private ContiguousHeading currentHeading;

--- a/src/main/java/xbot/common/subsystems/pose/MockBasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/MockBasePoseSubsystem.java
@@ -11,13 +11,13 @@ import xbot.common.properties.XPropertyManager;
 import xbot.common.subsystems.pose.BasePoseSubsystem;
 
 @Singleton
-public class TestPoseSubsystem extends BasePoseSubsystem {
+public class MockBasePoseSubsystem extends BasePoseSubsystem {
 
     private XCANTalon left;
     private XCANTalon right;
     
     @Inject
-    public TestPoseSubsystem(CommonLibFactory factory, XPropertyManager propManager) {
+    public MockBasePoseSubsystem(CommonLibFactory factory, XPropertyManager propManager) {
         super(factory, propManager);
     }
     
@@ -43,5 +43,10 @@ public class TestPoseSubsystem extends BasePoseSubsystem {
         ((MockCANTalon)this.left).setPosition(left);
         ((MockCANTalon)this.right).setPosition(right);
         updatePeriodicData();
+    }
+    
+    public void forceTotalXandY(double x, double y) {
+        totalDistanceX.set(x);
+        totalDistanceY.set(y);
     }
 }

--- a/src/test/java/xbot/common/subsystems/pose/BasePoseTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/BasePoseTest.java
@@ -14,13 +14,13 @@ import xbot.common.injection.BaseWPITest;
 @Ignore
 public class BasePoseTest extends BaseWPITest {
 
-    protected TestPoseSubsystem pose;
+    protected MockBasePoseSubsystem pose;
     protected MockTimer mockTimer;
     
     @Before
     public void setup() {
         mockTimer = injector.getInstance(MockTimer.class);
-        pose = injector.getInstance(TestPoseSubsystem.class);
+        pose = injector.getInstance(MockBasePoseSubsystem.class);
         
         XCANTalon left = clf.createCANTalon(0);
         left.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, 0, 0);

--- a/src/test/java/xbot/common/subsystems/pose/PoseSubsystemTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/PoseSubsystemTest.java
@@ -6,11 +6,11 @@ import org.junit.Test;
 
 public class PoseSubsystemTest extends BasePoseTest {
         
-    TestPoseSubsystem pose;
+    MockBasePoseSubsystem pose;
     
     public void setup() {
         super.setup();
-        pose = injector.getInstance(TestPoseSubsystem.class);
+        pose = injector.getInstance(MockBasePoseSubsystem.class);
     }    
     
     @Test


### PR DESCRIPTION
there could be rotational thrashing as the robot was settling on a point and was alternating between tracking a rabbit ahead/behind of it.