### PR TITLE
Better logging

### DIFF
--- a/lib/log4jConfig/log4j.xml
+++ b/lib/log4jConfig/log4j.xml
@@ -24,9 +24,9 @@
       <param name="File" value="/home/lvuser/488Logs/default.log"/>
       <param name="bufferedIO" value="false"/>
       <param name="bufferSize" value="100"/>
-      <param name="MaxFileSize" value="1000KB"/>
+      <param name="MaxFileSize" value="500KB"/>
       <!-- Keep ten backup files-->
-      <param name="MaxBackupIndex" value="30"/>
+      <param name="MaxBackupIndex" value="50"/>
       <param name="append" value="true"/>
       <layout class="org.apache.log4j.PatternLayout">
          <param name="ConversionPattern" value="%5p | %d [%X{matchContext}] | %-38.38F | %L | %m%n" />

--- a/lib/log4jConfig/log4j.xml
+++ b/lib/log4jConfig/log4j.xml
@@ -19,14 +19,14 @@
    </appender>
 
    <appender name="fileAppender"
-           class="org.apache.log4j.RollingFileAppender">
+           class="xbot.common.logging.OneLogFilePerRunRollingFileAppender">
       <param name="Threshold" value="INFO" />
       <param name="File" value="/home/lvuser/488Logs/default.log"/>
       <param name="bufferedIO" value="false"/>
       <param name="bufferSize" value="100"/>
       <param name="MaxFileSize" value="1000KB"/>
       <!-- Keep ten backup files-->
-      <param name="MaxBackupIndex" value="10"/>
+      <param name="MaxBackupIndex" value="30"/>
       <param name="append" value="true"/>
       <layout class="org.apache.log4j.PatternLayout">
          <param name="ConversionPattern" value="%5p | %d [%X{matchContext}] | %-38.38F | %L | %m%n" />

--- a/lib/log4jConfig/log4j.xml
+++ b/lib/log4jConfig/log4j.xml
@@ -29,7 +29,7 @@
       <param name="MaxBackupIndex" value="10"/>
       <param name="append" value="true"/>
       <layout class="org.apache.log4j.PatternLayout">
-         <param name="ConversionPattern" value="%5p | %d | %-38.38F | %L | %m%n" />
+         <param name="ConversionPattern" value="%5p | %d [%X{matchContext}] | %-38.38F | %L | %m%n" />
       </layout>
    </appender>
    

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -103,13 +103,35 @@ public class BaseRobot extends TimedRobot {
         outsidePeriodicMonitor = new TimeLogger("OutsidePeriodic", 20);
     }
     
+    protected String getEnableTypeString() {
+        DriverStation ds = DriverStation.getInstance();
+        if (!ds.isEnabled()) {
+            return "disabled";
+        }
+        
+        if (ds.isAutonomous()) {
+            return "auto";
+        }
+        
+        if (ds.isOperatorControl()) {
+            return "teleop";
+        }
+        
+        if (ds.isTest()) {
+            return "test";
+        }
+        
+        return "enabled/unknown";
+    }
+    
     protected void updateLoggingContext() {
         DriverStation ds = DriverStation.getInstance();
 
         String dsStatus = ds.isDSAttached() ? "DS" : "no DS";
         String fmsStatus = ds.isFMSAttached() ? "FMS" : "no FMS";
-        String matchStatus = ds.getMatchType().toString() + " " + ds.getMatchNumber();
-        String matchContext = dsStatus + ", " + fmsStatus + ", " + matchStatus;
+        String matchStatus = ds.getMatchType().toString() + " " + ds.getMatchNumber() + " " + ds.getReplayNumber();
+        String enableStatus = getEnableTypeString();
+        String matchContext = dsStatus + ", " + fmsStatus + ", " + enableStatus + ", " + matchStatus;
         MDC.put("matchContext", matchContext);
     }
 

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -2,10 +2,8 @@ package xbot.common.command;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Observable;
 
 import org.apache.log4j.Logger;
-import org.apache.log4j.MDC;
 import org.apache.log4j.xml.DOMConfigurator;
 
 import com.google.inject.AbstractModule;
@@ -132,7 +130,7 @@ public class BaseRobot extends TimedRobot {
         String matchStatus = ds.getMatchType().toString() + " " + ds.getMatchNumber() + " " + ds.getReplayNumber();
         String enableStatus = getEnableTypeString();
         String matchContext = dsStatus + ", " + fmsStatus + ", " + enableStatus + ", " + matchStatus;
-        MDC.put("matchContext", matchContext);
+        org.apache.log4j.MDC.put("matchContext", matchContext);
     }
 
     protected void initializeSystems() {

--- a/src/main/java/xbot/common/logging/OneLogFilePerRunRollingFileAppender.java
+++ b/src/main/java/xbot/common/logging/OneLogFilePerRunRollingFileAppender.java
@@ -1,0 +1,25 @@
+package xbot.common.logging;
+
+import java.io.IOException;
+
+import org.apache.log4j.Layout;
+import org.apache.log4j.RollingFileAppender;
+
+public class OneLogFilePerRunRollingFileAppender extends RollingFileAppender {
+
+    public OneLogFilePerRunRollingFileAppender() {
+        super();
+        this.rollOver();
+    }
+
+    public OneLogFilePerRunRollingFileAppender(Layout layout, String filename, boolean append) throws IOException {
+        super(layout, filename, append);
+        this.rollOver();
+    }
+
+    public OneLogFilePerRunRollingFileAppender(Layout layout, String filename) throws IOException {
+        super(layout, filename);
+        this.rollOver();
+    }
+
+}


### PR DESCRIPTION
This aims to fix a few problems:

- It's hard to find where an individual session started
- It's hard to understand what the robot's overall match state was at a given time
- Searching for a particular match is almost impossible

There are two primary changes here:
- The log file is "rolled over" every time the code loads. The most recent load will be called `default.log`, the previous will be `default.log.1`, then `default.log.2` and so on. We now allow 50 log files to be stored, each up to 0.5MB. In total, this allows us to store _less history_ than we did before, in the typical case; I'm worried that increasing the file count too high will have a performance impact because it must rename every existing file whenever the code starts.
- Each log line now includes some match context after the date. It tells you whether the DS and/or FMS are connected, the match type/number/replay count, and the enable state. This string is only updated when the system transitions between disabled, teleop, auto and test mode.

**Important note:** I believe we will have to re-run our logging deploy script for these changes to have an effect. I haven't yet tested this code.
