### PR TITLE
Heading Module uses Degrees instead of normalized error

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
+++ b/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
@@ -56,12 +56,9 @@ public class HeadingModule {
         
         targetHeading.setValue(desiredHeading);
         double errorInDegrees = targetHeading.difference(pose.getCurrentHeading());
-        
-        // Let's normalize the error into a -1 to 1 range. Convenient for further math.
-        double normalizedError = errorInDegrees / 180;
-        
+                
         // Now we feed it into a PID system, where the goal is to have 0 error.
-        double rotationalPower = headingDrivePid.calculate(0, normalizedError);
+        double rotationalPower = headingDrivePid.calculate(0, errorInDegrees);
         
         return rotationalPower;        
     }

--- a/src/test/java/xbot/common/subsystems/drive/HeadingModuleTest.java
+++ b/src/test/java/xbot/common/subsystems/drive/HeadingModuleTest.java
@@ -21,7 +21,7 @@ public class HeadingModuleTest extends BaseWPITest {
         super.setUp();
         
         PIDManager pid = pf.createPIDManager("Testo", 100, 0, 0);
-        pid.setErrorThreshold(.03);
+        pid.setErrorThreshold(3);
         pid.setEnableErrorThreshold(true);
         
         headingModule = clf.createHeadingModule(pid);


### PR DESCRIPTION
For the longest time, this module has normalized error from a -1 to 1 scale, which has made tuning PID challenging. Now that it's in degrees, setting an error threshold of 5 will mean 5 degrees.