### PR TITLE
Pure Pursuit can make 3-point turns

### DIFF
--- a/src/main/java/xbot/common/math/ContiguousHeading.java
+++ b/src/main/java/xbot/common/math/ContiguousHeading.java
@@ -20,5 +20,11 @@ public class ContiguousHeading extends ContiguousDouble {
         super.shiftValue(shiftMagnitude);
         return this;
     }
+
+    public XYPair getUnitVector() {
+        double x = Math.cos(this.getValue() / 180 * Math.PI);
+        double y = Math.sin(this.getValue() / 180 * Math.PI);
+        return new XYPair(x, y);
+    }
     
 }

--- a/src/main/java/xbot/common/math/PlanarTestVisualizer.java
+++ b/src/main/java/xbot/common/math/PlanarTestVisualizer.java
@@ -25,7 +25,7 @@ public class PlanarTestVisualizer {
         EventQueue.invokeLater(new Runnable() {
             public void run() {
                 try {
-                    RabbitPoint p = new RabbitPoint(new FieldPose(new XYPair(144, 0), new ContiguousHeading(90)));
+                    RabbitPoint p = new RabbitPoint(new FieldPose(new XYPair(50, -100), new ContiguousHeading(90)));
                     PlanarTestVisualizer window = new PlanarTestVisualizer(new ArrayList<RabbitPoint>(Arrays.asList(p)));
                     window.frmLinearTestVisualizer.setVisible(true);
                 } catch (Exception e) {

--- a/src/main/java/xbot/common/math/PlanarTestVisualizer.java
+++ b/src/main/java/xbot/common/math/PlanarTestVisualizer.java
@@ -25,7 +25,7 @@ public class PlanarTestVisualizer {
         EventQueue.invokeLater(new Runnable() {
             public void run() {
                 try {
-                    RabbitPoint p = new RabbitPoint(new FieldPose(new XYPair(50, -100), new ContiguousHeading(90)));
+                    RabbitPoint p = new RabbitPoint(new FieldPose(new XYPair(100, 100), new ContiguousHeading(135)));
                     PlanarTestVisualizer window = new PlanarTestVisualizer(new ArrayList<RabbitPoint>(Arrays.asList(p)));
                     window.frmLinearTestVisualizer.setVisible(true);
                 } catch (Exception e) {

--- a/src/main/java/xbot/common/math/PlanarVisualizationPanel.java
+++ b/src/main/java/xbot/common/math/PlanarVisualizationPanel.java
@@ -48,7 +48,8 @@ public class PlanarVisualizationPanel extends JPanel {
                 robotCurrentPosition.getPoint().x, 
                 robotCurrentPosition.getPoint().y, 
                 robotCurrentPosition.getHeading().getValue());;
-        rabbitStats = String.format("Angle to Rabbit: %.2f, TurnPower: %.2f", state.rabbitAngle, state.turnPower);
+        rabbitStats = String.format("Angle to Rabbit: %.2f, TurnPower: %.2f, Translate: %.2f", 
+            state.rabbitAngle, state.turnPower, state.translatePower);
     }
     
     @Override

--- a/src/main/java/xbot/common/math/PurePursuitTest.java
+++ b/src/main/java/xbot/common/math/PurePursuitTest.java
@@ -36,14 +36,17 @@ public class PurePursuitTest extends BaseWPITest {
         public int loops;
         public double rabbitAngle;
         public double turnPower;
+        public double translatePower;
                 
-        public PursuitEnvironmentState(FieldPose robot, FieldPose goal, FieldPose rabbit, int loops, double rabbitAngle, double turnPower) {
+        public PursuitEnvironmentState(FieldPose robot, FieldPose goal, FieldPose rabbit, 
+        int loops, double rabbitAngle, double turnPower, double translatePower) {
             this.robot = robot;
             this.goal = goal;
             this.loops = loops;
             this.rabbit = rabbit;
             this.rabbitAngle = rabbitAngle;
             this.turnPower = turnPower;
+            this.translatePower = translatePower;
         }
     }
     
@@ -76,6 +79,7 @@ public class PurePursuitTest extends BaseWPITest {
         b.changeRotationalPid(pf.createPIDManager("testRot", 0.05, 0, 0));
         b.changePositionalPid(pf.createPIDManager("testPos", 0.1, 0, 0.1));
         command = injector.getInstance(ConfigurablePurePursuitCommand.class);
+        command.setDotProductDrivingEnabled(true);
         setPoints();
         command.initialize();
         startAsyncTimer();    
@@ -106,7 +110,8 @@ public class PurePursuitTest extends BaseWPITest {
                             info.rabbit,
                             engine.loops,
                             angleToRabbit,
-                            info.rotation);
+                            info.rotation,
+                            info.translation);
                     
                     asyncJob.onNewStep(state);
                 }

--- a/src/main/java/xbot/common/math/XYPair.java
+++ b/src/main/java/xbot/common/math/XYPair.java
@@ -99,7 +99,7 @@ public class XYPair {
     }
 
     public double dotProduct(XYPair otherPoint) {
-        
+        return (this.x * otherPoint.x) + (this.y * otherPoint.y);
     }
 
     @Override

--- a/src/main/java/xbot/common/math/XYPair.java
+++ b/src/main/java/xbot/common/math/XYPair.java
@@ -98,6 +98,10 @@ public class XYPair {
         return normalizedPoint.getMagnitude();
     }
 
+    public double dotProduct(XYPair otherPoint) {
+        
+    }
+
     @Override
     public String toString() {
         return "(X:" + x + ", Y:" + y + ")";

--- a/src/main/java/xbot/common/subsystems/drive/PurePursuitCommand.java
+++ b/src/main/java/xbot/common/subsystems/drive/PurePursuitCommand.java
@@ -439,8 +439,10 @@ public abstract class PurePursuitCommand extends BaseCommand {
         // rather than turn in place. And, when we are at 90 degrees to the rabbit, we shouldn't be driving forward
         // or backward at all.
         XYPair robotUnitVector = robot.getHeading().getUnitVector();
+        double dotProduct = robotUnitVector.dotProduct(vectorToRabbit.clone().scale(1/vectorToRabbit.getMagnitude()));
 
         double translationPower = positionalPid.calculate(distanceRemainingToPointAlongPath, 0);
+        translationPower *= dotProduct;
         double constrainedTranslation = constrainToMotionBudget(turnPower, translationPower);
         
         // Log the output. This could be commented out, but for now, it has been very useful for debugging why the robot is driving

--- a/src/test/java/xbot/common/math/XYPairTest.java
+++ b/src/test/java/xbot/common/math/XYPairTest.java
@@ -1,0 +1,31 @@
+package xbot.common.math;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import xbot.common.injection.BaseWPITest;
+
+public class XYPairTest extends BaseWPITest {
+
+    @Test
+    public void testDotProduct() {
+        XYPair a = new XYPair(5,5);
+        XYPair b = new XYPair(10,10);
+
+        a.scale(1/a.getMagnitude());
+        b.scale(1/b.getMagnitude());
+
+        assertEquals(1, a.dotProduct(b), 0.001);
+
+        a = new XYPair(1,0);
+        b = new XYPair(0,1);
+
+        assertEquals(0, a.dotProduct(b), 0.001);
+
+        a = new XYPair(1,0);
+        b = new XYPair(-1,0);
+
+        assertEquals(-1, a.dotProduct(b), 0.001);
+    }
+}

--- a/src/test/java/xbot/common/subsystems/drive/PurePursuitCommandTest.java
+++ b/src/test/java/xbot/common/subsystems/drive/PurePursuitCommandTest.java
@@ -153,7 +153,6 @@ public class PurePursuitCommandTest extends BaseWPITest {
     }
 
     @Test
-    @Ignore
     public void testDriveOffset() {
         pose.setCurrentHeading(0);
         command.addPoint(
@@ -162,6 +161,30 @@ public class PurePursuitCommandTest extends BaseWPITest {
         command.execute();
         // Even though we're pointed right at the goal, we should veer left because we are completely perpindicular to it.
         verifyTankDrive(-1, 1);
+    }
+
+    @Test
+    public void testThreePointBehind() {
+        command.addPoint(
+            new RabbitPoint(new FieldPose(new XYPair(100, -100), new ContiguousHeading(90)), PointType.PositionAndHeading, PointTerminatingType.Stop));
+        command.setDotProductDrivingEnabled(true);
+        command.initialize();
+        command.execute();
+
+        verifyDirection(false);
+        verifyRotation(true);
+    }
+
+    @Test
+    public void testThreePointDirect() {
+        command.addPoint(
+            new RabbitPoint(new FieldPose(new XYPair(100, 0), new ContiguousHeading(-90)), PointType.PositionAndHeading, PointTerminatingType.Stop));
+        command.setDotProductDrivingEnabled(true);
+        command.initialize();
+        command.execute();
+
+        verifyDirection(true);
+        verifyRotation(false);
     }
     
     protected void verifyPose(RabbitPoint poseToTest, double x, double y, double heading) {
@@ -173,6 +196,16 @@ public class PurePursuitCommandTest extends BaseWPITest {
     protected void verifyTankDrive(double left, double right) {
         assertEquals("Checking Left Drive", left, drive.leftTank.getMotorOutputPercent(), 0.001);
         assertEquals("Checking Right Drive", right, drive.rightTank.getMotorOutputPercent(), 0.001);
+    }
+
+    protected void verifyDirection(boolean forward) {
+        double translation = drive.leftTank.getMotorOutputPercent() + drive.rightTank.getMotorOutputPercent();
+        assertTrue("Checking Driving Forward",  translation > 0 == forward);
+    }
+
+    protected void verifyRotation(boolean turningLeft) {
+        double rotation = -drive.leftTank.getMotorOutputPercent() + drive.rightTank.getMotorOutputPercent();
+        assertTrue("Checking Driving Forward",  rotation > 0 == turningLeft);
     }
 }
 


### PR DESCRIPTION
The Pure Pursuit command now has another (potentially more efficient) way of navigating the field. Before, due to the motion budget, it had to finish most of its rotation before it began translating.

Now, it translates proportional to the dot product of the robot's vector and the vector to the rabbit. This means that if the rabbit is behind it, it will back up while turning, at 90 degrees it will not translate, and then it will start driving forward as it finishes the turn.