### PR TITLE
SimpleCommandGroup

### DIFF
--- a/src/main/java/xbot/common/command/BaseCommandGroup.java
+++ b/src/main/java/xbot/common/command/BaseCommandGroup.java
@@ -39,5 +39,15 @@ public class BaseCommandGroup extends CommandGroup {
         log.info("Interrupted");
         end();
     }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+    }
+
+    @Override
+    public void execute() {
+        super.execute();
+    }
     
 }

--- a/src/main/java/xbot/common/command/SimpleCommandGroup.java
+++ b/src/main/java/xbot/common/command/SimpleCommandGroup.java
@@ -1,0 +1,28 @@
+package xbot.common.command;
+
+public class SimpleCommandGroup extends BaseCommandGroup {
+
+    public enum ExecutionType {
+        Serial,
+        Parallel
+    }
+
+    public SimpleCommandGroup(String name, Iterable<BaseCommand> commands, ExecutionType executionType) {
+        super(name);
+        commands.forEach((command) -> {
+            switch(executionType) {
+                case Serial: {
+                    this.addSequential(command);
+                    break;
+                }
+                case Parallel: {
+                    this.addParallel(command);
+                    break;
+                }
+                default: {
+                    throw new IllegalArgumentException("Unknown executionType");
+                }
+            }
+        });
+    }
+}

--- a/src/test/java/xbot/common/command/SimpleCommandGroupTest.java
+++ b/src/test/java/xbot/common/command/SimpleCommandGroupTest.java
@@ -1,0 +1,46 @@
+package xbot.common.command;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import xbot.common.command.SimpleCommandGroup.ExecutionType;
+import xbot.common.injection.BaseWPITest;
+
+public class SimpleCommandGroupTest extends BaseWPITest {
+
+    @Test
+    public void testBasicSerial() {
+        BaseCommand command1 = injector.getInstance(MockCommand.class);
+        BaseCommand command2 = injector.getInstance(MockCommand.class);
+
+        // Just validate doesn't crash
+        SimpleCommandGroup group = new SimpleCommandGroup(
+            "name", 
+            Arrays.asList(command1, command2), 
+            ExecutionType.Serial
+        );
+        group.initialize();
+
+        group.execute();
+
+    }
+
+    @Test
+    public void testBasicParallel() {
+        BaseCommand command1 = injector.getInstance(MockCommand.class);
+        BaseCommand command2 = injector.getInstance(MockCommand.class);
+
+        // Just validate doesn't crash
+        SimpleCommandGroup group = new SimpleCommandGroup(
+            "name", 
+            Arrays.asList(command1, command2), 
+            ExecutionType.Parallel
+        );
+        group.initialize();
+
+        group.execute();
+
+    }
+
+}


### PR DESCRIPTION
For the scenario of needing to create a quick simple command group to for instance run 2 things in parallel, this class will allow doing so without having to create a new class each time.

For example:
```java
SimpleCommandGroup manualBothLegs = new SimpleCommandGroup("manualBothLegs", Arrays.asList(manualFrontCommand, manualRearCommand), ExecutationType.Parallel);
```