### PR TITLE
Add settings to use coverage gutters in vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+      "ryanluker.vscode-coverage-gutters"
+    ]
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
     "java.configuration.updateBuildConfiguration": "automatic",
-    "java.test.defaultConfig": "default"
+    "java.test.defaultConfig": "default",
+    "coverage-gutters.coverageReportFileName": "**/jacoco/**/html/index.html",
+    "coverage-gutters.xmlname": "**/jacocoTestReport.xml"
 }


### PR DESCRIPTION
VScode settings to display code coverage inline using the Coverage Gutters extension (seems to be the most popular coverage extension at this time).

![image](https://user-images.githubusercontent.com/399279/65822486-db11e480-e1f9-11e9-9fe2-8af87d2e9040.png)
