### PR TITLE
Always run coverage report

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         gradleOptions: '-Xmx3072m'
         publishJUnitResults: true
         testResultsFiles: '**/TEST-*.xml'
-        tasks: 'build jacocoTestReport --stacktrace --info'
+        tasks: 'build --stacktrace --info'
         # checkStyleRunAnalysis: true
         # pmdRunAnalysis: true
     - task: PublishCodeCoverageResults@1

--- a/build.gradle
+++ b/build.gradle
@@ -122,3 +122,6 @@ jacocoTestReport {
         xml.enabled true
     }
 }
+
+// always generate the coverage report after the tests run
+test.finalizedBy { jacocoTestReport }


### PR DESCRIPTION
So people don't have to remember to run the report task afterwards all the time, doesn't seem to talk even a second to generate and that way it'll support viewing it in the gui.