### PR TITLE
Prevent solenoids from being created with an invalid channel

### DIFF
--- a/src/main/java/edu/wpi/first/wpilibj/MockSolenoid.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockSolenoid.java
@@ -26,4 +26,9 @@ public class MockSolenoid extends XSolenoid {
     public boolean get() {
         return this.mockRobotIO.getSolenoid(channel);
     }
+
+    @Override
+    public int getMaxSupportedChannel() {
+        return 7;
+    }
 }

--- a/src/main/java/xbot/common/controls/actuators/XSolenoid.java
+++ b/src/main/java/xbot/common/controls/actuators/XSolenoid.java
@@ -8,10 +8,10 @@ public abstract class XSolenoid implements XBaseIO {
     
     protected boolean isInverted = false;
     protected final int channel;
-    
+
     public XSolenoid(int channel, DevicePolice police) {
         this.channel = channel;
-        police.registerDevice(DeviceType.Solenoid, channel);
+        police.registerDevice(DeviceType.Solenoid, this.channel, 0, getMaxSupportedChannel());
     }
     
     public void setOn(boolean on) {
@@ -32,4 +32,5 @@ public abstract class XSolenoid implements XBaseIO {
     
     protected abstract void set(boolean on);
     protected abstract boolean get();
+    protected abstract int getMaxSupportedChannel();
 }

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/SolenoidWPIAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/SolenoidWPIAdapter.java
@@ -9,6 +9,8 @@ import xbot.common.injection.wpi_factories.DevicePolice;
 
 public class SolenoidWPIAdapter extends XSolenoid {
 
+    private static final int SOLENOID_CHANNEL_COUNT = 8;
+
     Solenoid solenoid;
 
     @Inject
@@ -25,5 +27,10 @@ public class SolenoidWPIAdapter extends XSolenoid {
     @Override
     public boolean get() {
         return this.solenoid.get();
+    }
+
+    @Override
+    public int getMaxSupportedChannel() {
+        return SOLENOID_CHANNEL_COUNT - 1;
     }
 }

--- a/src/main/java/xbot/common/injection/wpi_factories/DevicePolice.java
+++ b/src/main/java/xbot/common/injection/wpi_factories/DevicePolice.java
@@ -63,7 +63,8 @@ public class DevicePolice {
      */
     public void registerDevice(DeviceType type, int id, int minId, int maxId) {
         if (id > maxId || id < minId) {
-            assertionManager.fail("A device has been added with an invalid id that uses " + type.toString() + " port/id " + id + ". Allowed range: [" + minId + ", " + maxId + "]");
+            assertionManager.fail("A device has been added with an invalid id that uses " + type.toString() + " port/id " + id + ". "
+                + "Allowed range: [" + minId + ", " + maxId + "]");
         }
 
         registerDevice(type, id);

--- a/src/main/java/xbot/common/injection/wpi_factories/DevicePolice.java
+++ b/src/main/java/xbot/common/injection/wpi_factories/DevicePolice.java
@@ -8,12 +8,18 @@ import com.google.inject.Singleton;
 
 import xbot.common.logging.RobotAssertionManager;
 
+/**
+ * Tracks how many devices are registered and prevents incorrectly re-using devices
+ */
 @Singleton
 public class DevicePolice {
 
     RobotAssertionManager assertionManager;
     List<String> registeredDevices;
     
+    /**
+     * Types of devices
+     */
     public enum DeviceType {
         CAN,
         PWM,
@@ -25,12 +31,20 @@ public class DevicePolice {
         USB
     }
     
+    /**
+     * Creates a new DevicePolice instance
+     */
     @Inject
     public DevicePolice(RobotAssertionManager assertionManager) {
         this.assertionManager = assertionManager;
         registeredDevices = new LinkedList<String>();
     }
     
+    /**
+     * Register a device
+     * @param type Device type
+     * @param id Device id
+     */
     public void registerDevice(DeviceType type, int id) {
         String entry = type.toString() + id;
         if (registeredDevices.contains(entry)) {
@@ -38,6 +52,20 @@ public class DevicePolice {
         } else {
             registeredDevices.add(entry);
         }
-        
+    }
+
+    /**
+     * Register a device with an id falling into an allowable range
+     * @param type Device type
+     * @param id Device id
+     * @param minId Minimum allowable id
+     * @param maxId Maximum allowable id
+     */
+    public void registerDevice(DeviceType type, int id, int minId, int maxId) {
+        if (id > maxId || id < minId) {
+            assertionManager.fail("A device has been added with an invalid id that uses " + type.toString() + " port/id " + id + ". Allowed range: [" + minId + ", " + maxId + "]");
+        }
+
+        registerDevice(type, id);
     }
 }

--- a/src/test/java/xbot/common/injection/wpi_factories/TestDevicePolice.java
+++ b/src/test/java/xbot/common/injection/wpi_factories/TestDevicePolice.java
@@ -1,0 +1,54 @@
+package xbot.common.injection.wpi_factories;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import xbot.common.injection.BaseWPITest;
+import xbot.common.injection.wpi_factories.DevicePolice.DeviceType;
+import xbot.common.logging.RobotAssertionException;
+import xbot.common.logging.RobotAssertionManager;
+
+/**
+ * Unit tests for DevicePolice
+ */
+public class TestDevicePolice extends BaseWPITest {
+
+    /**
+     * Test that the same device cannot be registered twice
+     */
+    @Test(expected = RobotAssertionException.class)
+    public void doubleAllocate() {
+        RobotAssertionManager ram = injector.getInstance(RobotAssertionManager.class);
+        DevicePolice police = new DevicePolice(ram);
+
+        police.registerDevice(DeviceType.Solenoid, 0);
+        police.registerDevice(DeviceType.Solenoid, 0);
+        assertTrue("You shouldn't be able to double-allocate!", false);
+    }
+
+    /**
+     * Test that a device cannot be registered with an id greater than the maximum allowed
+     */
+    @Test(expected = RobotAssertionException.class)
+    public void allocateGreaterThanMax() {
+        RobotAssertionManager ram = injector.getInstance(RobotAssertionManager.class);
+        DevicePolice police = new DevicePolice(ram);
+
+        police.registerDevice(DeviceType.Solenoid, 9000, 0, 7);
+        assertTrue("You shouldn't be able to allocate a value greater than the maximum!", false);
+    }
+    
+    /**
+     * Test that a device cannot be registered with an id less than the minimum allowed
+     */
+    @Test(expected = RobotAssertionException.class)
+    public void allocateLessThanMin() {
+        RobotAssertionManager ram = injector.getInstance(RobotAssertionManager.class);
+        DevicePolice police = new DevicePolice(ram);
+
+        police.registerDevice(DeviceType.Solenoid, 0, 3, 7);
+        assertTrue("You shouldn't be able to allocate a value less than the minimum!", false);
+    }
+}


### PR DESCRIPTION
* Added capability to DevicePolice to check channel numbers against a minimum and maximum allowed channel value
* Set WPI solenoid adapter to allow channels from 0-7
* Unit tests for DevicePolice