### PR TITLE
Smarter Device Police & SimulationPayloadDistributor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ dependencies {
     
     compile group: 'log4j', name: 'log4j', version: '1.2.17'
 
+    compile group: 'org.json', name:'json', version: '20201115'
+
     compile group: 'org.zeromq', name: 'jeromq', version: '0.4.3'
     
     compile 'edu.wpi.first.wpiutil:wpiutil-java:2020.1.2'

--- a/src/main/java/xbot/common/controls/sensors/XEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XEncoder.java
@@ -23,8 +23,8 @@ public abstract class XEncoder {
         propMan.setPrefix(name);
         distancePerPulse = propMan.createPersistentProperty("DistancePerPulse", defaultDistancePerPulse);
         setDistancePerPulseSupplier(() -> distancePerPulse.get());
-        police.registerDevice(DeviceType.DigitalIO, aChannel);
-        police.registerDevice(DeviceType.DigitalIO, bChannel);
+        police.registerDevice(DeviceType.DigitalIO, aChannel, this);
+        police.registerDevice(DeviceType.DigitalIO, bChannel, this);
     }
 
     public void setDistancePerPulseSupplier(Supplier<Double> supplier) {

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
@@ -9,9 +9,9 @@ import org.json.JSONObject;
 import xbot.common.controls.sensors.XEncoder;
 import xbot.common.injection.wpi_factories.DevicePolice;
 import xbot.common.properties.PropertyFactory;
-import xbot.common.simulation.IWebotsSensor;
+import xbot.common.simulation.ISimulatableSensor;
 
-public class MockEncoder extends XEncoder implements IWebotsSensor {
+public class MockEncoder extends XEncoder implements ISimulatableSensor {
 
     private double distance;
     private double rate;

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
@@ -3,26 +3,26 @@ package xbot.common.controls.sensors.mock_adapters;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import xbot.common.controls.sensors.XEncoder;
 import xbot.common.injection.wpi_factories.DevicePolice;
 import xbot.common.properties.PropertyFactory;
+import xbot.common.simulation.IWebotsSensor;
 
-public class MockEncoder extends XEncoder {
+public class MockEncoder extends XEncoder implements IWebotsSensor {
 
     private double distance;
     private double rate;
 
     @AssistedInject
-    public MockEncoder(
-            @Assisted("name")String name, 
-            @Assisted("aChannel") int aChannel, 
-            @Assisted("bChannel") int bChannel, 
-            @Assisted("defaultDistancePerPulse") double defaultDistancePerPulse, 
-            PropertyFactory propMan, 
-            DevicePolice police) {
+    public MockEncoder(@Assisted("name") String name, @Assisted("aChannel") int aChannel,
+            @Assisted("bChannel") int bChannel, @Assisted("defaultDistancePerPulse") double defaultDistancePerPulse,
+            PropertyFactory propMan, DevicePolice police) {
         super(name, aChannel, bChannel, defaultDistancePerPulse, propMan, police);
     }
-    
+
     @AssistedInject
     public MockEncoder(PropertyFactory propMan) {
         super(propMan);
@@ -39,10 +39,16 @@ public class MockEncoder extends XEncoder {
     public void setRate(double newRate) {
         this.rate = newRate;
     }
-    
+
     protected double getDistance() {
         return distance;
     }
 
-    public void setSamplesToAverage(int samples) {}
+    public void setSamplesToAverage(int samples) {
+    }
+
+    @Override
+    public void ingestSimulationData(JSONObject payload) {
+        setDistance((double)payload.get("EncoderTicks"));
+    }
 }

--- a/src/main/java/xbot/common/simulation/ISimulatableSensor.java
+++ b/src/main/java/xbot/common/simulation/ISimulatableSensor.java
@@ -2,6 +2,6 @@ package xbot.common.simulation;
 
 import org.json.JSONObject;
 
-public interface IWebotsSensor {
+public interface ISimulatableSensor {
     public void ingestSimulationData(JSONObject payload);
 }

--- a/src/main/java/xbot/common/simulation/IWebotsSensor.java
+++ b/src/main/java/xbot/common/simulation/IWebotsSensor.java
@@ -1,0 +1,7 @@
+package xbot.common.simulation;
+
+import org.json.JSONObject;
+
+public interface IWebotsSensor {
+    public void ingestSimulationData(JSONObject payload);
+}

--- a/src/main/java/xbot/common/simulation/SimulationPayloadDistributor.java
+++ b/src/main/java/xbot/common/simulation/SimulationPayloadDistributor.java
@@ -5,31 +5,47 @@ import com.google.inject.Inject;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import org.apache.log4j.Logger;
+
 import xbot.common.injection.wpi_factories.DevicePolice;
 
 public class SimulationPayloadDistributor {
 
     private DevicePolice police;
+    private static Logger log = Logger.getLogger(SimulationPayloadDistributor.class);
 
     @Inject
     public SimulationPayloadDistributor(DevicePolice police) {
         this.police = police;
     }
 
+    /**
+     * Fans out data from a simulation (like Webots) to all the simulatable devices registered on the robot.
+     * @param allSensorsPayload The JSON sensor payload, containing all sensor data from the simulation environment
+     */
     public void distributeSimulationPayload(JSONObject allSensorsPayload) {
-        // For each type underneath
-
+        
+        // This assumes that the element containing the array of sensor data is called "Sensors".
         JSONArray allSensorsArray = (JSONArray)allSensorsPayload.get("Sensors");
         allSensorsArray.forEach(item -> {
-            JSONObject sensor = (JSONObject)item;
-            String id = (String)sensor.get("ID");
-            JSONObject payload = (JSONObject)sensor.get("Payload");
+            JSONObject sensorJson = (JSONObject)item;
+            String id = (String)sensorJson.get("ID");
+            JSONObject payload = (JSONObject)sensorJson.get("Payload");
 
-            System.out.println("ID:"+id+", Value:"+payload);
-
-            IWebotsSensor device = (IWebotsSensor)police.registeredChannels.get(id);
-
-            device.ingestSimulationData(payload);
+            Object device = police.registeredChannels.get(id);
+            if (device == null) {
+                log.error("Unable to find device with ID" + id + " in the DevicePolice. Make sure it's being properly created somewhere.");
+            } else {
+                ISimulatableSensor robotSensor = null;
+                try {
+                    robotSensor = (ISimulatableSensor)device;
+                }
+                catch (Exception e) {
+                    log.error("Unable to cast device with ID " + id + " to an ISimulatableSensor. Make sure that sensor implements ISimulatableSensor.");
+                    throw e;
+                }
+                robotSensor.ingestSimulationData(payload);
+            }
         });
     }
 }

--- a/src/main/java/xbot/common/simulation/SimulationPayloadDistributor.java
+++ b/src/main/java/xbot/common/simulation/SimulationPayloadDistributor.java
@@ -1,0 +1,35 @@
+package xbot.common.simulation;
+
+import com.google.inject.Inject;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import xbot.common.injection.wpi_factories.DevicePolice;
+
+public class SimulationPayloadDistributor {
+
+    private DevicePolice police;
+
+    @Inject
+    public SimulationPayloadDistributor(DevicePolice police) {
+        this.police = police;
+    }
+
+    public void distributeSimulationPayload(JSONObject allSensorsPayload) {
+        // For each type underneath
+
+        JSONArray allSensorsArray = (JSONArray)allSensorsPayload.get("Sensors");
+        allSensorsArray.forEach(item -> {
+            JSONObject sensor = (JSONObject)item;
+            String id = (String)sensor.get("ID");
+            JSONObject payload = (JSONObject)sensor.get("Payload");
+
+            System.out.println("ID:"+id+", Value:"+payload);
+
+            IWebotsSensor device = (IWebotsSensor)police.registeredChannels.get(id);
+
+            device.ingestSimulationData(payload);
+        });
+    }
+}

--- a/src/test/java/xbot/common/simulation/SimulationPayloadDistributorTest.java
+++ b/src/test/java/xbot/common/simulation/SimulationPayloadDistributorTest.java
@@ -1,0 +1,40 @@
+package xbot.common.simulation;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import xbot.common.controls.sensors.mock_adapters.MockEncoder;
+import xbot.common.injection.BaseWPITest;
+
+public class SimulationPayloadDistributorTest extends BaseWPITest {
+
+    MockEncoder encoder;
+    SimulationPayloadDistributor distributor;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+
+        encoder = (MockEncoder)clf.createEncoder("Test", 3, 4, 1);
+        distributor = injector.getInstance(SimulationPayloadDistributor.class);
+    }
+
+    @Test
+    public void simpleTest() {
+        JSONObject overallPayload = new JSONObject();
+        JSONObject singleSensor = new JSONObject();
+        singleSensor.put("ID", "DigitalIO3");
+        JSONObject singleSensorPayload = new JSONObject();
+        singleSensorPayload.put("EncoderTicks", 123.0);
+        singleSensor.put("Payload", singleSensorPayload);
+        JSONArray sensorList = new JSONArray();
+        sensorList.put(singleSensor);
+        overallPayload.put("Sensors", sensorList);
+
+
+        System.out.println(overallPayload.toString());
+
+        distributor.distributeSimulationPayload(overallPayload);
+    }
+}

--- a/src/test/java/xbot/common/simulation/SimulationPayloadDistributorTest.java
+++ b/src/test/java/xbot/common/simulation/SimulationPayloadDistributorTest.java
@@ -32,7 +32,6 @@ public class SimulationPayloadDistributorTest extends BaseWPITest {
         sensorList.put(singleSensor);
         overallPayload.put("Sensors", sensorList);
 
-
         System.out.println(overallPayload.toString());
 
         distributor.distributeSimulationPayload(overallPayload);


### PR DESCRIPTION
Basic idea:

Both sides refer to sensors using their DevicePolice IDs, which are a combination of the kind of port they use (e.g. USB, DigitalIO, CAN, etc..) and the number of the port. The server packages this up into a JSON array of sensors.

The payload is read by a client somewhere, then handed off to the SimulationPayloadDistributor. This reads each sensor entry, gets the full ID, and retrieves the base object.

Each mock sensor will now implement IWebotsSensor (name suggestions welcome), which has one method: `public void  ingestSimulationData(JSONObject payload);` Each actual device will know how to read their specific payload.

Encoders might only need one value - the # of ticks. Our IMU might need a dozen.