### PR TITLE
Mock Gamepad: apply inversions on set

### DIFF
--- a/src/main/java/edu/wpi/first/wpilibj/MockXboxControllerAdapter.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockXboxControllerAdapter.java
@@ -23,10 +23,20 @@ public class MockXboxControllerAdapter extends XXboxController {
         leftStick.x = x;
         leftStick.y = y;
     }
+
+    public void setLeftStick(XYPair xy) {
+        leftStick.x = xy.x;
+        leftStick.y = xy.y;
+    }
     
     public void setRightStick(double x, double y) {
         rightStick.x = x;
         rightStick.y = y;
+    }
+
+    public void setRightStick(XYPair xy) {
+        rightStick.x = xy.x;
+        rightStick.y = xy.y;
     }
     
     @Inject

--- a/src/main/java/edu/wpi/first/wpilibj/MockXboxControllerAdapter.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockXboxControllerAdapter.java
@@ -27,11 +27,6 @@ public class MockXboxControllerAdapter extends XXboxController {
     public void setLeftStick(XYPair xy) {
         setLeftStick(xy.x, xy.y);
     }
-
-    public void setLeftStick(XYPair xy) {
-        leftStick.x = xy.x;
-        leftStick.y = xy.y;
-    }
     
     public void setRightStick(double x, double y) {
         rightStick.x = x * (rightXInversion ? -1 : 1);
@@ -42,11 +37,6 @@ public class MockXboxControllerAdapter extends XXboxController {
         setRightStick(xy.x, xy.y);
     }
 
-    public void setRightStick(XYPair xy) {
-        rightStick.x = xy.x;
-        rightStick.y = xy.y;
-    }
-    
     @Inject
     public MockXboxControllerAdapter(@Assisted("port") int port, CommonLibFactory clf, RobotAssertionManager manager, DevicePolice police) {
         super(port, clf, manager, police);

--- a/src/main/java/edu/wpi/first/wpilibj/MockXboxControllerAdapter.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockXboxControllerAdapter.java
@@ -20,23 +20,21 @@ public class MockXboxControllerAdapter extends XXboxController {
     private double rightTrigger;
     
     public void setLeftStick(double x, double y) {
-        leftStick.x = x;
-        leftStick.y = y;
+        leftStick.x = x * (leftXInversion ? -1 : 1);
+        leftStick.y = y * (leftYInversion ? -1 : 1);
     }
 
     public void setLeftStick(XYPair xy) {
-        leftStick.x = xy.x;
-        leftStick.y = xy.y;
+        setLeftStick(xy.x, xy.y);
     }
     
     public void setRightStick(double x, double y) {
-        rightStick.x = x;
-        rightStick.y = y;
+        rightStick.x = x * (rightXInversion ? -1 : 1);
+        rightStick.y = y * (rightYInversion ? -1 : 1);
     }
 
     public void setRightStick(XYPair xy) {
-        rightStick.x = xy.x;
-        rightStick.y = xy.y;
+        setRightStick(xy.x, xy.y);
     }
     
     @Inject

--- a/src/main/java/xbot/common/controls/sensors/XXboxController.java
+++ b/src/main/java/xbot/common/controls/sensors/XXboxController.java
@@ -19,10 +19,10 @@ public abstract class XXboxController extends XJoystick implements IRumbler, IGa
 
     public HashMap<XboxButton, AdvancedXboxButton> allocatedButtons;
 
-    boolean leftXInversion = false;
-    boolean leftYInversion = false;
-    boolean rightXInversion = false;
-    boolean rightYInversion = false;
+    protected boolean leftXInversion = false;
+    protected boolean leftYInversion = false;
+    protected boolean rightXInversion = false;
+    protected boolean rightYInversion = false;
 
     RumbleManager rumbleManager;
 

--- a/src/main/java/xbot/common/simulation/ResetSimulatorPositionCommand.java
+++ b/src/main/java/xbot/common/simulation/ResetSimulatorPositionCommand.java
@@ -7,7 +7,6 @@ import com.google.inject.Inject;
 import org.json.JSONObject;
 
 import xbot.common.command.BaseCommand;
-import xbot.common.controls.actuators.mock_adapters.MockCANTalon;
 import xbot.common.math.ContiguousHeading;
 import xbot.common.math.FieldPose;
 import xbot.common.math.XYPair;


### PR DESCRIPTION
So test code doesn't have to know if the gamepad is inverted or not. This was messing up the curriculum.