### PR TITLE
Add basic support for simulating solenoids

### DIFF
--- a/src/main/java/edu/wpi/first/wpilibj/MockSolenoid.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockSolenoid.java
@@ -2,10 +2,14 @@ package edu.wpi.first.wpilibj;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+
+import org.json.JSONObject;
+
 import xbot.common.controls.actuators.XSolenoid;
 import xbot.common.injection.wpi_factories.DevicePolice;
+import xbot.common.simulation.ISimulatableSolenoid;
 
-public class MockSolenoid extends XSolenoid {
+public class MockSolenoid extends XSolenoid implements ISimulatableSolenoid {
     final int channel;
     protected boolean on;
 
@@ -27,5 +31,10 @@ public class MockSolenoid extends XSolenoid {
     @Override
     public int getMaxSupportedChannel() {
         return 7;
+    }
+
+    @Override
+    public JSONObject getSimulationData() {
+        return buildMotorObject("Solenoid" + channel, get());
     }
 }

--- a/src/main/java/edu/wpi/first/wpilibj/MockSolenoid.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockSolenoid.java
@@ -35,6 +35,6 @@ public class MockSolenoid extends XSolenoid implements ISimulatableSolenoid {
 
     @Override
     public JSONObject getSimulationData() {
-        return buildMotorObject("Solenoid" + channel, get());
+        return buildMotorObject(channel, get());
     }
 }

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -29,6 +29,7 @@ import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.properties.XPropertyManager;
 import xbot.common.simulation.ISimulatableMotor;
+import xbot.common.simulation.ISimulatableSolenoid;
 import xbot.common.simulation.SimulationPayloadDistributor;
 import xbot.common.simulation.WebotsClient;
 import xbot.common.subsystems.autonomous.AutonomousCommandSelector;
@@ -281,6 +282,9 @@ public class BaseRobot extends TimedRobot {
             Object device = devicePolice.registeredChannels.get(deviceId);
             if (device instanceof ISimulatableMotor) {
                 motors.add(((ISimulatableMotor)device).getSimulationData());
+            }
+            if (device instanceof ISimulatableSolenoid) {
+                motors.add(((ISimulatableSolenoid)device).getSimulationData());
             }
         }
         JSONObject response = webots.sendMotors(motors);

--- a/src/main/java/xbot/common/simulation/ISimulatableSolenoid.java
+++ b/src/main/java/xbot/common/simulation/ISimulatableSolenoid.java
@@ -1,0 +1,21 @@
+package xbot.common.simulation;
+
+import org.json.JSONObject;
+
+public interface ISimulatableSolenoid {
+    public JSONObject getSimulationData();
+
+    default JSONObject buildMotorObject(String name, boolean isOn) {
+        JSONObject result = new JSONObject();
+
+        result.put("id", name); 
+        result.put("mode", 3);
+        if(isOn) {
+            result.put("val", "ON");
+        } else {
+            result.put("val", "OFF");
+        }
+        
+        return result;
+    }
+}

--- a/src/main/java/xbot/common/simulation/ISimulatableSolenoid.java
+++ b/src/main/java/xbot/common/simulation/ISimulatableSolenoid.java
@@ -4,12 +4,13 @@ import org.json.JSONObject;
 
 public interface ISimulatableSolenoid {
     public JSONObject getSimulationData();
+    public final String SOLENOID_POWER_MODE = "VIRTUAL_SOLENOID";
 
-    default JSONObject buildMotorObject(String name, boolean isOn) {
+    default JSONObject buildMotorObject(int channel, boolean isOn) {
         JSONObject result = new JSONObject();
 
-        result.put("id", name); 
-        result.put("mode", 3);
+        result.put("id", "Solenoid" + channel); 
+        result.put("mode", SOLENOID_POWER_MODE);
         if(isOn) {
             result.put("val", "ON");
         } else {

--- a/src/test/java/xbot/common/simulation/SimulatedSolenoidTest.java
+++ b/src/test/java/xbot/common/simulation/SimulatedSolenoidTest.java
@@ -1,0 +1,41 @@
+package xbot.common.simulation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import edu.wpi.first.wpilibj.MockSolenoid;
+
+public class SimulatedSolenoidTest extends BaseSimulationTest {
+
+    MockSolenoid mockSolenoid;
+    final int CHANNEL = 1;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+
+        mockSolenoid = (MockSolenoid)clf.createSolenoid(CHANNEL);
+    }
+
+    @Test
+    public void testOn() {
+        mockSolenoid.set(true);
+        JSONObject result = mockSolenoid.getSimulationData();
+
+        assertEquals("Solenoid1", result.get("id")); 
+        assertEquals("VIRTUAL_SOLENOID", result.get("mode")); 
+        assertEquals("ON", result.get("val")); 
+    }
+
+    @Test
+    public void testOff() {
+        mockSolenoid.set(false);
+        JSONObject result = mockSolenoid.getSimulationData();
+
+        assertEquals("Solenoid1", result.get("id")); 
+        assertEquals("VIRTUAL_SOLENOID", result.get("mode")); 
+        assertEquals("OFF", result.get("val")); 
+    }
+}

--- a/src/test/java/xbot/common/simulation/SimulatedSolenoidTest.java
+++ b/src/test/java/xbot/common/simulation/SimulatedSolenoidTest.java
@@ -10,13 +10,13 @@ import edu.wpi.first.wpilibj.MockSolenoid;
 public class SimulatedSolenoidTest extends BaseSimulationTest {
 
     MockSolenoid mockSolenoid;
-    final int CHANNEL = 1;
+    final int channel = 1;
 
     @Override
     public void setUp() {
         super.setUp();
 
-        mockSolenoid = (MockSolenoid)clf.createSolenoid(CHANNEL);
+        mockSolenoid = (MockSolenoid)clf.createSolenoid(channel);
     }
 
     @Test


### PR DESCRIPTION
We added to webots the ability to control solenoid like motors on the simulated robot by setting them on/off and they'll PID by position to their max or min position.

https://github.com/Team488/Webots/pull/70

This PR adds support in SCL to send those simulated motor values based on solenoid being on or off.