### PR TITLE
Property system: Add property level capability

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
     "recommendations": [
       "ryanluker.vscode-coverage-gutters",
       "vscjava.vscode-java-test",
-	  "shengchen.vscode-checkstyle"
+	    "shengchen.vscode-checkstyle"
     ]
   }

--- a/src/main/java/xbot/common/injection/RobotModule.java
+++ b/src/main/java/xbot/common/injection/RobotModule.java
@@ -61,15 +61,31 @@ import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.PreferenceStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
 import xbot.common.properties.TableProxy;
+import xbot.common.properties.XPropertyManager;
 
 public class RobotModule extends AbstractModule {
+
+    protected final boolean debugMode;
+
+    public RobotModule() {
+        debugMode = false;
+    }
+
+    public RobotModule(boolean debugMode) {
+        this.debugMode = debugMode;
+    }
 
     @Override
     protected void configure() {
         this.bind(XTimerImpl.class).to(TimerWpiAdapter.class);
         this.bind(XSettableTimerImpl.class).to(TimerWpiAdapter.class);
         this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class).in(Singleton.class);
-        this.bind(ITableProxy.class).annotatedWith(Names.named("InMemory")).to(TableProxy.class).in(Singleton.class);
+        if(debugMode) {
+            // send all debug properties to the smart dashboard
+            this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(SmartDashboardTableWrapper.class).in(Singleton.class);
+        } else {
+            this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(TableProxy.class).in(Singleton.class);
+        }
         this.bind(PermanentStorage.class).to(PreferenceStorage.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(SilentRobotAssertionManager.class);

--- a/src/main/java/xbot/common/injection/RobotModule.java
+++ b/src/main/java/xbot/common/injection/RobotModule.java
@@ -82,9 +82,15 @@ public class RobotModule extends AbstractModule {
         this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class).in(Singleton.class);
         if(debugMode) {
             // send all debug properties to the smart dashboard
-            this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(SmartDashboardTableWrapper.class).in(Singleton.class);
+            this.bind(ITableProxy.class)
+                .annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME))
+                .to(SmartDashboardTableWrapper.class)
+                .in(Singleton.class);
         } else {
-            this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(TableProxy.class).in(Singleton.class);
+            this.bind(ITableProxy.class)
+                .annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME))
+                .to(TableProxy.class)
+                .in(Singleton.class);
         }
         this.bind(PermanentStorage.class).to(PreferenceStorage.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);

--- a/src/main/java/xbot/common/injection/RobotModule.java
+++ b/src/main/java/xbot/common/injection/RobotModule.java
@@ -3,6 +3,7 @@ package xbot.common.injection;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
 
 import xbot.common.command.RealSmartDashboardCommandPutter;
 import xbot.common.command.SmartDashboardCommandPutter;
@@ -59,6 +60,7 @@ import xbot.common.properties.ITableProxy;
 import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.PreferenceStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
+import xbot.common.properties.TableProxy;
 
 public class RobotModule extends AbstractModule {
 
@@ -67,7 +69,7 @@ public class RobotModule extends AbstractModule {
         this.bind(XTimerImpl.class).to(TimerWpiAdapter.class);
         this.bind(XSettableTimerImpl.class).to(TimerWpiAdapter.class);
         this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class).in(Singleton.class);
-        ;
+        this.bind(ITableProxy.class).annotatedWith(Names.named("InMemory")).to(TableProxy.class).in(Singleton.class);
         this.bind(PermanentStorage.class).to(PreferenceStorage.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(SilentRobotAssertionManager.class);

--- a/src/main/java/xbot/common/injection/SimulatorModule.java
+++ b/src/main/java/xbot/common/injection/SimulatorModule.java
@@ -3,6 +3,7 @@ package xbot.common.injection;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
 
 import org.junit.Ignore;
 
@@ -63,6 +64,8 @@ import xbot.common.properties.ITableProxy;
 import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.PreferenceStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
+import xbot.common.properties.TableProxy;
+import xbot.common.properties.XPropertyManager;
 
 @Ignore
 public class SimulatorModule extends AbstractModule {
@@ -74,6 +77,7 @@ public class SimulatorModule extends AbstractModule {
         this.bind(XTimerImpl.class).to(MockTimer.class);
         this.bind(XSettableTimerImpl.class).to(MockTimer.class);
         this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class).in(Singleton.class);
+        this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(TableProxy.class).in(Singleton.class);
         this.bind(PermanentStorage.class).to(PreferenceStorage.class).in(Singleton.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(LoudRobotAssertionManager.class);

--- a/src/main/java/xbot/common/injection/SimulatorModule.java
+++ b/src/main/java/xbot/common/injection/SimulatorModule.java
@@ -77,7 +77,7 @@ public class SimulatorModule extends AbstractModule {
         this.bind(XTimerImpl.class).to(MockTimer.class);
         this.bind(XSettableTimerImpl.class).to(MockTimer.class);
         this.bind(ITableProxy.class).to(SmartDashboardTableWrapper.class).in(Singleton.class);
-        this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(TableProxy.class).in(Singleton.class);
+        this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(SmartDashboardTableWrapper.class).in(Singleton.class);
         this.bind(PermanentStorage.class).to(PreferenceStorage.class).in(Singleton.class);
         this.bind(SmartDashboardCommandPutter.class).to(RealSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(LoudRobotAssertionManager.class);

--- a/src/main/java/xbot/common/injection/UnitTestModule.java
+++ b/src/main/java/xbot/common/injection/UnitTestModule.java
@@ -3,6 +3,7 @@ package xbot.common.injection;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
 
 import org.junit.Ignore;
 
@@ -63,6 +64,7 @@ import xbot.common.properties.ITableProxy;
 import xbot.common.properties.MockPermamentStorage;
 import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.TableProxy;
+import xbot.common.properties.XPropertyManager;
 
 @Ignore
 public class UnitTestModule extends AbstractModule {
@@ -74,6 +76,7 @@ public class UnitTestModule extends AbstractModule {
         this.bind(XTimerImpl.class).to(MockTimer.class);
         this.bind(XSettableTimerImpl.class).to(MockTimer.class);
         this.bind(ITableProxy.class).to(TableProxy.class).in(Singleton.class);
+        this.bind(ITableProxy.class).annotatedWith(Names.named(XPropertyManager.IN_MEMORY_STORE_NAME)).to(TableProxy.class).in(Singleton.class);
         this.bind(PermanentStorage.class).to(MockPermamentStorage.class).in(Singleton.class);
         this.bind(SmartDashboardCommandPutter.class).to(MockSmartDashboardCommandPutter.class);
         this.bind(RobotAssertionManager.class).to(LoudRobotAssertionManager.class);

--- a/src/main/java/xbot/common/properties/BooleanProperty.java
+++ b/src/main/java/xbot/common/properties/BooleanProperty.java
@@ -27,6 +27,13 @@ public class BooleanProperty extends Property {
         load();
     }
 
+    public BooleanProperty(String name, boolean defaultValue, PropertyPersistenceType persistenceType,
+            XPropertyManager manager, PropertyLevel level) {
+        super(name, manager, persistenceType, level);
+        this.defaultValue = defaultValue;
+        load();
+    }
+
     /**
      * 
      * @return the current boolean value

--- a/src/main/java/xbot/common/properties/DoubleProperty.java
+++ b/src/main/java/xbot/common/properties/DoubleProperty.java
@@ -28,6 +28,13 @@ public class DoubleProperty extends Property {
         load();
         lastValue = get();
     }
+
+    public DoubleProperty(String name, double defaultValue, PropertyPersistenceType persistenceType, XPropertyManager manager, PropertyLevel level) {
+        super(name, manager, persistenceType, level);
+        this.defaultValue = defaultValue;
+        load();
+        lastValue = get();
+    }
     
 
     public double get() {

--- a/src/main/java/xbot/common/properties/Property.java
+++ b/src/main/java/xbot/common/properties/Property.java
@@ -32,9 +32,37 @@ public abstract class Property {
         Ephemeral,
         Persistent
     }
+
+    public enum PropertyLevel {
+        Important,
+        Debug
+    }
     
     public PropertyPersistenceType persistenceType;
+    public PropertyLevel level;
     protected static Logger log;
+
+    /**
+     * The name of the property. This should be unique unless you really know
+     * what you're doing.
+     * New builder with persistence type. Old builder will be deprecated.
+     * @author Marc
+     */
+    public Property(String key, XPropertyManager manager, PropertyPersistenceType persistenceType, PropertyLevel level) {
+        this.key = sanitizeKey(key);
+        log =  Logger.getLogger(this.getClass().getSimpleName() + " (\"" + this.key + "\")");
+        
+        this.permanentStore = manager.permanentStore;
+
+        if(level == PropertyLevel.Debug){
+            this.randomAccessStore = manager.inMemoryRandomAccessStore;
+        } else {
+            this.randomAccessStore = manager.randomAccessStore;
+        }
+
+        this.persistenceType = persistenceType;
+        manager.registerProperty(this);
+    }
     
     /**
      * The name of the property. This should be unique unless you really know
@@ -43,13 +71,7 @@ public abstract class Property {
      * @author Marc
      */
     public Property(String key, XPropertyManager manager, PropertyPersistenceType persistenceType) {
-        this.key = sanitizeKey(key);
-        log =  Logger.getLogger(this.getClass().getSimpleName() + " (\"" + this.key + "\")");
-        
-        this.permanentStore = manager.permanentStore;
-        this.randomAccessStore = manager.randomAccessStore;
-        this.persistenceType = persistenceType;
-        manager.registerProperty(this);
+        this(key, manager, persistenceType, PropertyLevel.Important);
     }
 
     /**

--- a/src/main/java/xbot/common/properties/PropertyFactory.java
+++ b/src/main/java/xbot/common/properties/PropertyFactory.java
@@ -118,6 +118,26 @@ public class PropertyFactory {
     }
 
     /**
+     * Method for creating a boolean ephemeral property
+     * 
+     * @author Marc
+     */
+    public BooleanProperty createEphemeralProperty(String key, boolean defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, level);
+    }
+
+    /**
+     * Method for creating a string ephemeral property
+     * 
+     * @author Marc
+     */
+    public StringProperty createEphemeralProperty(String key, String defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager);
+    }
+
+    /**
      * Method for creating a string ephemeral property
      * 
      * @author Marc
@@ -162,6 +182,16 @@ public class PropertyFactory {
      * 
      * @author Marc
      */
+    public BooleanProperty createPersistentProperty(String key, boolean defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, level);
+    }
+
+    /**
+     * Method for creating a double persistent property
+     * 
+     * @author Marc
+     */
     public StringProperty createPersistentProperty(String key, String defaultValue) {
         checkPrefixSet();
         return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager);
@@ -172,9 +202,29 @@ public class PropertyFactory {
      * 
      * @author Marc
      */
+    public StringProperty createPersistentProperty(String key, String defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, level);
+    }
+
+    /**
+     * Method for creating a double persistent property
+     * 
+     * @author Marc
+     */
     public DoubleProperty createPersistentProperty(String key, double defaultValue) {
         checkPrefixSet();
         return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager);
+    }
+
+    /**
+     * Method for creating a double persistent property
+     * 
+     * @author Marc
+     */
+    public DoubleProperty createPersistentProperty(String key, double defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, level);
     }
 
 

--- a/src/main/java/xbot/common/properties/PropertyFactory.java
+++ b/src/main/java/xbot/common/properties/PropertyFactory.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import org.apache.log4j.Logger;
 
 import xbot.common.logging.RobotAssertionManager;
+import xbot.common.properties.Property.PropertyLevel;
 import xbot.common.properties.Property.PropertyPersistenceType;
 
 public class PropertyFactory {
@@ -134,6 +135,16 @@ public class PropertyFactory {
     public DoubleProperty createEphemeralProperty(String key, double defaultValue) {
         checkPrefixSet();
         return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager);
+    }
+
+    /**
+     * Method for creating a double ephemeral property
+     * 
+     * @author Marc
+     */
+    public DoubleProperty createEphemeralProperty(String key, double defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, level);
     }
 
     /**

--- a/src/main/java/xbot/common/properties/StringProperty.java
+++ b/src/main/java/xbot/common/properties/StringProperty.java
@@ -24,6 +24,12 @@ public class StringProperty extends Property {
         this.defaultValue = defaultValue;
         load();
     }
+
+    public StringProperty(String name, String defaultValue, PropertyPersistenceType persistenceType, XPropertyManager manager, PropertyLevel level) {
+        super(name, manager, persistenceType, level);
+        this.defaultValue = defaultValue;
+        load();
+    }
     
     public String get() {
         String nullableTableValue = randomAccessStore.getString(key);

--- a/src/main/java/xbot/common/properties/XPropertyManager.java
+++ b/src/main/java/xbot/common/properties/XPropertyManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 
 import org.apache.log4j.Logger;
 
@@ -16,18 +17,24 @@ import org.apache.log4j.Logger;
  */
 @Singleton
 public class XPropertyManager {
-
+    public static final String IN_MEMORY_STORE_NAME = "InMemoryStore";
     private static final Logger log = Logger.getLogger(XPropertyManager.class);
 
-    public ArrayList<Property> properties;
-    public PermanentStorage permanentStore;
-    public ITableProxy randomAccessStore;
+    public final ArrayList<Property> properties;
+    public final PermanentStorage permanentStore;
+    public final ITableProxy randomAccessStore;
+    public final ITableProxy inMemoryRandomAccessStore;
 
     @Inject
-    public XPropertyManager(PermanentStorage permanentStore, ITableProxy randomAccessStore) {
+    public XPropertyManager(
+        PermanentStorage permanentStore, 
+        ITableProxy randomAccessStore, 
+        @Named(IN_MEMORY_STORE_NAME) ITableProxy inMemoryRandomAccessStore
+    ) {
         this.properties = new ArrayList<Property>();
         this.permanentStore = permanentStore;
         this.randomAccessStore = randomAccessStore;
+        this.inMemoryRandomAccessStore = inMemoryRandomAccessStore;
     }
 
     /**


### PR DESCRIPTION
Allow marking some properties as `Debug`, they'll only ever use inMemory for their random access store.

We could make this more complicated with more levels doing more things later but this is a good start.

There's no unit testing on any of this code right now.

