### PR TITLE
Feature/Add ability to get faults and set status frames on CANCoder

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/XCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XCANCoder.java
@@ -1,0 +1,19 @@
+package xbot.common.controls.sensors;
+
+import com.ctre.phoenix.ErrorCode;
+import com.ctre.phoenix.sensors.CANCoderFaults;
+import com.ctre.phoenix.sensors.CANCoderStatusFrame;
+import com.ctre.phoenix.sensors.CANCoderStickyFaults;
+
+public abstract class XCANCoder extends XAbsoluteEncoder {
+
+    public abstract ErrorCode setStatusFramePeriod(CANCoderStatusFrame frame, int periodMs);
+
+    public abstract int getStatusFramePeriod(CANCoderStatusFrame frame);
+
+    public abstract ErrorCode getFaults(CANCoderFaults toFill);
+
+    public abstract ErrorCode getStickyFaults(CANCoderStickyFaults toFill);
+
+    public abstract ErrorCode clearStickyFaults();
+}

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockCANCoder.java
@@ -1,0 +1,120 @@
+package xbot.common.controls.sensors.mock_adapters;
+
+import com.ctre.phoenix.ErrorCode;
+import com.ctre.phoenix.sensors.CANCoderFaults;
+import com.ctre.phoenix.sensors.CANCoderStatusFrame;
+import com.ctre.phoenix.sensors.CANCoderStickyFaults;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+
+import org.json.JSONObject;
+
+import xbot.common.controls.sensors.XCANCoder;
+import xbot.common.injection.electrical_contract.DeviceInfo;
+import xbot.common.injection.wpi_factories.DevicePolice;
+import xbot.common.injection.wpi_factories.DevicePolice.DeviceType;
+import xbot.common.math.WrappedRotation2d;
+import xbot.common.properties.BooleanProperty;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.PropertyFactory;
+import xbot.common.resiliency.DeviceHealth;
+import xbot.common.simulation.ISimulatableSensor;
+
+public class MockCANCoder extends XCANCoder implements ISimulatableSensor {
+
+    private final int deviceId;
+    private final BooleanProperty inverted;
+    private final DoubleProperty simulationScale;
+    private final DoubleProperty positionOffset;
+
+    private double velocity;
+    private WrappedRotation2d absolutePosition;
+
+    @AssistedInject
+    public MockCANCoder(@Assisted("deviceInfo") DeviceInfo deviceInfo,
+            @Assisted("owningSystemPrefix") String owningSystemPrefix,
+            DevicePolice police, PropertyFactory pf) {
+        pf.setPrefix(owningSystemPrefix);
+
+        this.deviceId = deviceInfo.channel;
+        this.velocity = 0;
+        this.absolutePosition = new WrappedRotation2d(0);
+        this.positionOffset = pf.createEphemeralProperty("PositionOffset", 0);
+        this.inverted = pf.createEphemeralProperty("Inverted", deviceInfo.inverted);
+        this.simulationScale = pf.createEphemeralProperty("SimulationScale", deviceInfo.simulationScalingValue);
+
+        police.registerDevice(DeviceType.CAN, deviceInfo.channel, this);
+    }
+    
+    @Override
+    public int getDeviceId() {
+        return this.deviceId;
+    }
+
+    @Override
+    public double getPosition() {
+        return WrappedRotation2d.fromDegrees(this.absolutePosition.getDegrees() + this.positionOffset.get()).getDegrees() * (inverted.get() ? -1 : 1);
+    }
+
+    @Override
+    public double getAbsolutePosition() {
+        return this.absolutePosition.getDegrees() * (inverted.get() ? -1 : 1);
+    }
+
+    @Override
+    public double getVelocity() {
+        return this.velocity * (inverted.get() ? -1 : 1);
+    }
+
+    @Override
+    public void setPosition(double newPosition) {
+        this.positionOffset.set(WrappedRotation2d.fromDegrees(newPosition).minus(this.absolutePosition).getDegrees());
+    }
+    
+
+    public double getPositionOffset() {
+        return this.positionOffset.get();
+    }
+
+    public void setAbsolutePosition(double position) {
+        this.absolutePosition = WrappedRotation2d.fromDegrees(position * (inverted.get() ? -1 : 1));
+    }
+
+    @Override
+    public void ingestSimulationData(JSONObject payload) {
+        setAbsolutePosition(
+            payload.getBigDecimal("EncoderTicks").doubleValue() * this.simulationScale.get()
+        );
+    }
+
+    @Override
+    public DeviceHealth getHealth() {
+        return DeviceHealth.Healthy;
+    }
+
+    @Override
+    public ErrorCode setStatusFramePeriod(CANCoderStatusFrame frame, int periodMs) {
+        return ErrorCode.OK;
+    }
+
+    @Override
+    public int getStatusFramePeriod(CANCoderStatusFrame frame) {
+        return 20;
+    }
+
+    @Override
+    public ErrorCode getFaults(CANCoderFaults toFill) {
+        return ErrorCode.OK;
+    }
+
+    @Override
+    public ErrorCode getStickyFaults(CANCoderStickyFaults toFill) {
+        return ErrorCode.OK;
+    }
+
+    @Override
+    public ErrorCode clearStickyFaults() {
+        return ErrorCode.OK;
+    }
+    
+}

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
@@ -2,13 +2,16 @@ package xbot.common.controls.sensors.wpi_adapters;
 
 import com.ctre.phoenix.ErrorCode;
 import com.ctre.phoenix.sensors.CANCoder;
+import com.ctre.phoenix.sensors.CANCoderFaults;
+import com.ctre.phoenix.sensors.CANCoderStatusFrame;
+import com.ctre.phoenix.sensors.CANCoderStickyFaults;
 import com.ctre.phoenix.sensors.WPI_CANCoder;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 
 import org.apache.log4j.Logger;
 
-import xbot.common.controls.sensors.XAbsoluteEncoder;
+import xbot.common.controls.sensors.XCANCoder;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.injection.wpi_factories.DevicePolice;
 import xbot.common.injection.wpi_factories.DevicePolice.DeviceType;
@@ -17,7 +20,7 @@ import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.resiliency.DeviceHealth;
 
-public class CANCoderAdapter extends XAbsoluteEncoder {
+public class CANCoderAdapter extends XCANCoder {
     
     private static final Logger log = Logger.getLogger(CANCoderAdapter.class);
 
@@ -100,5 +103,30 @@ public class CANCoderAdapter extends XAbsoluteEncoder {
             this.magnetOffset.set(offsetInDegrees);
             return true;
         }
+    }
+
+    @Override
+    public ErrorCode setStatusFramePeriod(CANCoderStatusFrame frame, int periodMs) {
+        return this.cancoder.setStatusFramePeriod(frame, periodMs);
+    }
+
+    @Override
+    public int getStatusFramePeriod(CANCoderStatusFrame frame) {
+        return this.cancoder.getStatusFramePeriod(frame);
+    }
+
+    @Override
+    public ErrorCode getFaults(CANCoderFaults toFill) {
+        return this.cancoder.getFaults(toFill);
+    }
+
+    @Override
+    public ErrorCode getStickyFaults(CANCoderStickyFaults toFill) {
+        return this.cancoder.getStickyFaults(toFill);
+    }
+
+    @Override
+    public ErrorCode clearStickyFaults() {
+        return this.cancoder.clearStickyFaults();
     }
 }

--- a/src/main/java/xbot/common/injection/RobotModule.java
+++ b/src/main/java/xbot/common/injection/RobotModule.java
@@ -29,6 +29,7 @@ import xbot.common.controls.actuators.wpi_adapters.SolenoidWPIAdapter;
 import xbot.common.controls.actuators.wpi_adapters.SpeedControllerWPIAdapter;
 import xbot.common.controls.sensors.XAbsoluteEncoder;
 import xbot.common.controls.sensors.XAnalogInput;
+import xbot.common.controls.sensors.XCANCoder;
 import xbot.common.controls.sensors.XDigitalInput;
 import xbot.common.controls.sensors.XEncoder;
 import xbot.common.controls.sensors.XFTCGamepad;
@@ -119,6 +120,7 @@ public class RobotModule extends AbstractModule {
                 .implement(XCANSparkMax.class, CANSparkMaxWpiAdapter.class)
                 .implement(XCANVictorSPX.class, CANVictorSPXWpiAdapter.class)
                 .implement(XAbsoluteEncoder.class, CANCoderAdapter.class)
+                .implement(XCANCoder.class, CANCoderAdapter.class)
                 .build(CommonLibFactory.class)
                 );
     }

--- a/src/main/java/xbot/common/injection/SimulatorModule.java
+++ b/src/main/java/xbot/common/injection/SimulatorModule.java
@@ -38,6 +38,7 @@ import xbot.common.controls.sensors.SimulatedAnalogDistanceSensor;
 import xbot.common.controls.sensors.XAbsoluteEncoder;
 import xbot.common.controls.sensors.XAnalogDistanceSensor;
 import xbot.common.controls.sensors.XAnalogInput;
+import xbot.common.controls.sensors.XCANCoder;
 import xbot.common.controls.sensors.XDigitalInput;
 import xbot.common.controls.sensors.XEncoder;
 import xbot.common.controls.sensors.XFTCGamepad;
@@ -49,6 +50,7 @@ import xbot.common.controls.sensors.XSettableTimerImpl;
 import xbot.common.controls.sensors.XTimerImpl;
 import xbot.common.controls.sensors.XXboxController;
 import xbot.common.controls.sensors.mock_adapters.MockAbsoluteEncoder;
+import xbot.common.controls.sensors.mock_adapters.MockCANCoder;
 import xbot.common.controls.sensors.mock_adapters.MockEncoder;
 import xbot.common.controls.sensors.mock_adapters.MockGyro;
 import xbot.common.controls.sensors.wpi_adapters.FTCGamepadWpiAdapter;
@@ -64,7 +66,6 @@ import xbot.common.properties.ITableProxy;
 import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.PreferenceStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
-import xbot.common.properties.TableProxy;
 import xbot.common.properties.XPropertyManager;
 
 @Ignore
@@ -100,6 +101,7 @@ public class SimulatorModule extends AbstractModule {
                 .implement(XCANVictorSPX.class, MockCANVictorSPX.class)
                 .implement(XAnalogDistanceSensor.class, SimulatedAnalogDistanceSensor.class)
                 .implement(XAbsoluteEncoder.class, MockAbsoluteEncoder.class)
+                .implement(XCANCoder.class, MockCANCoder.class)
                 .build(CommonLibFactory.class));
     }
 }

--- a/src/main/java/xbot/common/injection/UnitTestModule.java
+++ b/src/main/java/xbot/common/injection/UnitTestModule.java
@@ -39,6 +39,7 @@ import xbot.common.controls.sensors.AnalogDistanceSensor;
 import xbot.common.controls.sensors.XAbsoluteEncoder;
 import xbot.common.controls.sensors.XAnalogDistanceSensor;
 import xbot.common.controls.sensors.XAnalogInput;
+import xbot.common.controls.sensors.XCANCoder;
 import xbot.common.controls.sensors.XDigitalInput;
 import xbot.common.controls.sensors.XEncoder;
 import xbot.common.controls.sensors.XFTCGamepad;
@@ -50,6 +51,7 @@ import xbot.common.controls.sensors.XSettableTimerImpl;
 import xbot.common.controls.sensors.XTimerImpl;
 import xbot.common.controls.sensors.XXboxController;
 import xbot.common.controls.sensors.mock_adapters.MockAbsoluteEncoder;
+import xbot.common.controls.sensors.mock_adapters.MockCANCoder;
 import xbot.common.controls.sensors.mock_adapters.MockEncoder;
 import xbot.common.controls.sensors.mock_adapters.MockFTCGamepad;
 import xbot.common.controls.sensors.mock_adapters.MockGyro;
@@ -98,6 +100,7 @@ public class UnitTestModule extends AbstractModule {
                 .implement(XCANVictorSPX.class, MockCANVictorSPX.class)
                 .implement(XAnalogDistanceSensor.class, AnalogDistanceSensor.class)
                 .implement(XAbsoluteEncoder.class, MockAbsoluteEncoder.class)
+                .implement(XCANCoder.class, MockCANCoder.class)
                 .build(CommonLibFactory.class));
     }
 }

--- a/src/main/java/xbot/common/injection/wpi_factories/CommonLibFactory.java
+++ b/src/main/java/xbot/common/injection/wpi_factories/CommonLibFactory.java
@@ -25,6 +25,7 @@ import xbot.common.controls.sensors.VirtualButton;
 import xbot.common.controls.sensors.XAS5600;
 import xbot.common.controls.sensors.XAbsoluteEncoder;
 import xbot.common.controls.sensors.XAnalogInput;
+import xbot.common.controls.sensors.XCANCoder;
 import xbot.common.controls.sensors.XDigitalInput;
 import xbot.common.controls.sensors.XEncoder;
 import xbot.common.controls.sensors.XFTCGamepad;
@@ -163,4 +164,6 @@ public interface CommonLibFactory extends PIDFactory {
         public XCANVictorSPX createCANVictorSPX(@Assisted("deviceId") int deviceId);
 
         public XAbsoluteEncoder createAbsoluteEncoder(@Assisted("deviceInfo") DeviceInfo deviceInfo, @Assisted("owningSystemPrefix") String owningSystemPrefix);
+        
+        public XCANCoder createCANCoder(@Assisted("deviceInfo") DeviceInfo deviceInfo, @Assisted("owningSystemPrefix") String owningSystemPrefix);
 }

--- a/src/test/java/xbot/common/injection/wpi_factories/TestCommonLibFactory.java
+++ b/src/test/java/xbot/common/injection/wpi_factories/TestCommonLibFactory.java
@@ -56,6 +56,7 @@ public class TestCommonLibFactory extends BaseWPITest {
         clf.createXAS5600(talon);
         clf.createCANVictorSPX(5);
         clf.createAbsoluteEncoder(new DeviceInfo(6), "test");
+        clf.createCANCoder(new DeviceInfo(7), "test");
     }
     
     @Test(expected = RobotAssertionException.class)


### PR DESCRIPTION
I've added a new XCANCoder here to keep XAbsoluteEncoder from being tightly coupled to CANCoder.