### PR TITLE
Fix generation of Dagger outputs for non-gradle builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ WPI_Native_Libraries.properties
 #Gradle
 .gradle/
 
+#Eclipse (build tools used by VS Code)
 .settings/
 .classpath
 .factorypath

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ WPI_Native_Libraries.properties
 
 .settings/
 .classpath
+.factorypath
 .project
 *.dll

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "java.configuration.updateBuildConfiguration": "automatic",
+    "java.import.generatesMetadataFilesAtProjectRoot": true,
     "java.test.defaultConfig": "SeriouslyCommonLib",
     "java.test.config": [
         {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ import edu.wpi.first.gradlerio.deploy.roborio.RoboRIO
  */
 
 plugins {
-    id "edu.wpi.first.GradleRIO" version "2022.3.1"
+    id "edu.wpi.first.GradleRIO" version "2022.4.1"
     id "eclipse"
     id "com.diffplug.eclipse.apt" version "3.39.0"
     id 'scala'
@@ -133,8 +133,6 @@ sourceSets {
         }
     }
 }
-sourceSets.main.java.srcDirs += "bin/generated/sources/annotationProcessor/java/main"
-sourceSets.test.java.srcDirs += "bin/generated/sources/annotationProcessor/java/test"
 
 task jarSources(type:Jar){
     from sourceSets.main.allSource
@@ -171,6 +169,11 @@ eclipse {
     }
 
     classpath.file {
+        beforeMerged { classpath -> 
+            sourceSets.main.java.srcDirs += "bin/generated/sources/annotationProcessor/java/main"
+            sourceSets.test.java.srcDirs += "bin/generated/sources/annotationProcessor/java/test"
+        }
+
         whenMerged { classpath ->
             classpath.entries.each { entry -> 
                 if (entry.path.contains('bin/generated')) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ import edu.wpi.first.gradlerio.deploy.roborio.RoboRIO
 plugins {
     id "edu.wpi.first.GradleRIO" version "2022.3.1"
     id "eclipse"
+    id "com.diffplug.eclipse.apt" version "3.39.0"
     id 'scala'
     id 'checkstyle'
     id 'jacoco'
@@ -132,8 +133,8 @@ sourceSets {
         }
     }
 }
-sourceSets.main.java.srcDirs += "build/generated/sources/annotationProcessor/java/main"
-sourceSets.test.java.srcDirs += "build/generated/sources/annotationProcessor/java/test"
+sourceSets.main.java.srcDirs += "bin/generated/sources/annotationProcessor/java/main"
+sourceSets.test.java.srcDirs += "bin/generated/sources/annotationProcessor/java/test"
 
 task jarSources(type:Jar){
     from sourceSets.main.allSource
@@ -160,11 +161,21 @@ tasks.withType(Test) {
     }
 }
 
-eclipse.classpath.file {
-    whenMerged { classpath ->
-        classpath.entries.each { entry -> 
-            if (entry.path.contains('build/generated')) {
-                entry.entryAttributes['ignore_optional_problems'] = true
+eclipse {
+	// re-generate APT configuration on Gradle project synchronisation
+	synchronizationTasks eclipseJdtApt, eclipseJdt, eclipseFactorypath
+
+	jdt.apt {
+        genSrcDir = file('bin/generated/sources/annotationProcessor/java/main')
+        genTestSrcDir = file('bin/generated/sources/annotationProcessor/java/test')
+    }
+
+    classpath.file {
+        whenMerged { classpath ->
+            classpath.entries.each { entry -> 
+                if (entry.path.contains('bin/generated')) {
+                    entry.entryAttributes['ignore_optional_problems'] = true
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ import edu.wpi.first.gradlerio.deploy.roborio.RoboRIO
  */
 
 plugins {
-    id "edu.wpi.first.GradleRIO" version "2022.3.1" 
+    id "edu.wpi.first.GradleRIO" version "2022.3.1"
+    id "eclipse"
     id 'scala'
     id 'checkstyle'
     id 'jacoco'
@@ -156,6 +157,16 @@ tasks.withType(Test) {
       if (!desc.parent) { // will match the outermost suite
         println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
       }
+    }
+}
+
+eclipse.classpath.file {
+    whenMerged { classpath ->
+        classpath.entries.each { entry -> 
+            if (entry.path.contains('build/generated')) {
+                entry.entryAttributes['ignore_optional_problems'] = true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
When VS Code builds java code for intellisense / running tests / debugging, it doesn't use Gradle directly. The VS Code java language plugin internally uses Eclipse's Java build tools to try to run a gradle project.

Essentially this change tells the Gradle build to generate eclipse files (.classpath, .factorypath, etc) when run directly, and the VS Code-triggered build (for tests or debugging) can also consume the plugin outputs. The VS Code Java language server also uses this classpath to search for source files (for intellisense). The additional plugins let the Eclipse-driven build also run dagger code generation, which means that intellisense should just work.

Classpath and factorypath are generated at build and not checked in.