### PR TITLE
Use FRC Coordinate System

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/PurePursuitCommand.java
+++ b/src/main/java/xbot/common/subsystems/drive/PurePursuitCommand.java
@@ -176,17 +176,16 @@ public abstract class PurePursuitCommand extends BaseCommand {
                 pointsToVisit = new ArrayList<>();
                 FieldPose currentRobotPose = poseSystem.getCurrentFieldPose();
                 for (RabbitPoint originalPoint : originalPoints) {
-                    // First, rotate the point according to the robot's current heading - 90
+                    // First, rotate the point according to the robot's current heading
                     XYPair updatedPoint = originalPoint.pose.getPoint().clone().rotate(
-                            currentRobotPose.getHeading().getDegrees()-BasePoseSubsystem.FACING_AWAY_FROM_DRIVERS);
+                            currentRobotPose.getHeading().getDegrees());
                     
                     // Then, translate the point according to the robot's current field position
                     updatedPoint.add(currentRobotPose.getPoint());
                     
-                    // Finally, rotate the original's goal heading by the robot's current heading -90
+                    // Finally, rotate the original's goal heading by the robot's current heading
                     double updatedHeading = originalPoint.pose.getHeading().getDegrees() 
-                            + currentRobotPose.getHeading().getDegrees() 
-                            - BasePoseSubsystem.FACING_AWAY_FROM_DRIVERS;
+                            + currentRobotPose.getHeading().getDegrees();
                     
                     FieldPose updatedPose = new FieldPose(updatedPoint, Rotation2d.fromDegrees(updatedHeading));
                     pointsToVisit.add(new RabbitPoint(

--- a/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
@@ -33,8 +33,8 @@ public abstract class BasePoseSubsystem extends BaseSubsystem {
     private double headingOffset;
     
     // These are two common robot starting positions - kept here as convenient shorthand.
-    public static final double FACING_AWAY_FROM_DRIVERS = 90;
-    public static final double FACING_TOWARDS_DRIVERS = -90;
+    public static final double FACING_AWAY_FROM_DRIVERS = 0;
+    public static final double FACING_TOWARDS_DRIVERS = -180;
     public static final double INCHES_IN_A_METER = 39.3701;
     
     private final DoubleProperty currentPitch;
@@ -88,7 +88,7 @@ public abstract class BasePoseSubsystem extends BaseSubsystem {
     }
     
     private double getCompassHeading(Rotation2d standardHeading) {
-        return Rotation2d.fromDegrees(currentHeading.getDegrees() - 90).getDegrees();
+        return Rotation2d.fromDegrees(currentHeading.getDegrees()).getDegrees();
     }
     
     private void updateCurrentHeading() {

--- a/src/test/java/xbot/common/subsystems/drive/PurePursuitCommandTest.java
+++ b/src/test/java/xbot/common/subsystems/drive/PurePursuitCommandTest.java
@@ -33,7 +33,9 @@ public class PurePursuitCommandTest extends BaseCommonLibTest {
         pose.setDriveTalons(drive.leftTank, drive.rightTank);
         
         timer.advanceTimeInSecondsBy(10);
+
         pose.periodic();
+        pose.setCurrentHeading(90);
         
         drive.getPositionalPid().setMaxOutput(1);
         drive.getPositionalPid().setMinOutput(-1);
@@ -83,6 +85,7 @@ public class PurePursuitCommandTest extends BaseCommonLibTest {
     
     @Test
     public void testSimpleRelative() {
+        pose.setCurrentHeading(0);
         command.addPoint(new FieldPose(new XYPair(0, 10), Rotation2d.fromDegrees(90)));
         command.addPoint(new FieldPose(new XYPair(10, 10), Rotation2d.fromDegrees(90)));
         
@@ -95,18 +98,19 @@ public class PurePursuitCommandTest extends BaseCommonLibTest {
     
     @Test
     public void testComplexRelative() {
-        command.addPoint(new FieldPose(new XYPair(0, 10), Rotation2d.fromDegrees(90)));
+        pose.setCurrentHeading(0);
+        command.addPoint(new FieldPose(new XYPair(10, 0), Rotation2d.fromDegrees(0)));
         command.addPoint(new FieldPose(new XYPair(10, 10), Rotation2d.fromDegrees(90)));
         
         // rotate the robot
-        pose.setCurrentHeading(180);
+        pose.setCurrentHeading(90);
         pose.setDriveEncoderDistances(10, 10);
         
         command.setMode(PointLoadingMode.Relative);
         command.initialize();
         
-        verifyPose(command.getPlannedPointsToVisit().get(0), -20, 0, 180);
-        verifyPose(command.getPlannedPointsToVisit().get(1), -20, 10, 180); 
+        verifyPose(command.getPlannedPointsToVisit().get(0), 0, 20, 90);
+        verifyPose(command.getPlannedPointsToVisit().get(1), -10, 20, 180);
     }
     
     //@SuppressWarnings("serial")

--- a/src/test/java/xbot/common/subsystems/pose/PoseSubsystemTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/PoseSubsystemTest.java
@@ -17,23 +17,23 @@ public class PoseSubsystemTest extends BasePoseTest {
     
     @Test
     public void testInitialHeading() {
-        // IMU initially starts at 0, robot starts at 90.
+        // IMU initially starts at 0, robot starts at 0.
         verifyRobotHeading(BasePoseSubsystem.FACING_AWAY_FROM_DRIVERS);
     }
     
     @Test
     public void testGyroRotate() {
         changeMockGyroHeading(45);
-        verifyRobotHeading(135);
+        verifyRobotHeading(BasePoseSubsystem.FACING_AWAY_FROM_DRIVERS + 45);
         
         changeMockGyroHeading(-45);
-        verifyRobotHeading(90);
+        verifyRobotHeading(BasePoseSubsystem.FACING_AWAY_FROM_DRIVERS);
     }
     
     @Test
     public void testCalibrate() {
         changeMockGyroHeading(45);
-        verifyRobotHeading(135);
+        verifyRobotHeading(BasePoseSubsystem.FACING_AWAY_FROM_DRIVERS+45);
 
         pose.setCurrentHeading(90);
         verifyRobotHeading(90);
@@ -42,7 +42,7 @@ public class PoseSubsystemTest extends BasePoseTest {
     @Test
     public void testCalibrateAndMove() {
         changeMockGyroHeading(45);
-        verifyRobotHeading(135);
+        verifyRobotHeading(BasePoseSubsystem.FACING_AWAY_FROM_DRIVERS+45);
         
         pose.setCurrentHeading(90);
         verifyRobotHeading(90);
@@ -53,6 +53,8 @@ public class PoseSubsystemTest extends BasePoseTest {
     
     @Test
     public void testCrossBounds () {
+        pose.setCurrentHeading(90);
+
         changeMockGyroHeading(180);
         verifyRobotHeading(-90);
         

--- a/src/test/java/xbot/common/subsystems/pose/commands/ResetDistanceCommandTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/commands/ResetDistanceCommandTest.java
@@ -22,7 +22,7 @@ public class ResetDistanceCommandTest extends BasePoseTest {
         
         pose.setDriveEncoderDistances(100, 100);
         verifyRobotOrientedDistance(100);
-        verifyAbsoluteDistance(0, 100);
+        verifyAbsoluteDistance(100, 0);
         
         reset.isFinished();
         reset.initialize();
@@ -39,7 +39,7 @@ public class ResetDistanceCommandTest extends BasePoseTest {
         
         pose.setDriveEncoderDistances(100, 100);
         verifyRobotOrientedDistance(100);
-        verifyAbsoluteDistance(0, 100);
+        verifyAbsoluteDistance(100, 0);
         
         reset.isFinished();
         reset.initialize();
@@ -59,7 +59,7 @@ public class ResetDistanceCommandTest extends BasePoseTest {
         
         pose.setDriveEncoderDistances(100, 100);
         verifyRobotOrientedDistance(100);
-        verifyAbsoluteDistance(0, 100);
+        verifyAbsoluteDistance(100, 0);
         
         reset.isFinished();
         reset.initialize();
@@ -67,7 +67,7 @@ public class ResetDistanceCommandTest extends BasePoseTest {
         
         pose.setDriveEncoderDistances(200, 200);
         verifyRobotOrientedDistance(100);
-        verifyAbsoluteDistance(0, 100);
+        verifyAbsoluteDistance(100, 0);
         
         reset.isFinished();
         reset.initialize();


### PR DESCRIPTION
Use FRC Coordinate System (x is "down the field", y is "across the driver station").

The most significant change for us is that 0 degrees is the default, and that robot-oriented driving forward is +X motion