### PR TITLE
Generic Maintainer System and DutyCycleEncoder

### DIFF
--- a/src/main/java/xbot/common/command/BaseMaintainerCommand.java
+++ b/src/main/java/xbot/common/command/BaseMaintainerCommand.java
@@ -9,7 +9,7 @@ import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.properties.StringProperty;
 
-public abstract class BaseMaintainerCommand extends BaseCommand {
+public abstract class BaseMaintainerCommand<T> extends BaseCommand {
 
     BaseSetpointSubsystem subsystemToMaintan;
 
@@ -53,7 +53,7 @@ public abstract class BaseMaintainerCommand extends BaseCommand {
      * at its goal.
      */
     protected void maintain() {
-        double humanInput = getHumanInput();
+        double humanInput = getHumanInputMagnitude();
         HumanVsMachineMode mode = decider.getRecommendedMode(humanInput);
         currentModeProp.set(mode.toString());
 
@@ -80,10 +80,8 @@ public abstract class BaseMaintainerCommand extends BaseCommand {
         }
     }
 
-    protected void coastAction() {
-        // Typically do nothing.
-        subsystemToMaintan.setPower(0);
-    }
+    // Typically do nothing.
+    protected abstract void coastAction();
 
     protected void humanControlAction() {
         // Typically simply assign human input
@@ -150,14 +148,18 @@ public abstract class BaseMaintainerCommand extends BaseCommand {
      * computation.
      */
     protected boolean getErrorWithinTolerance() {
-        if (Math.abs(subsystemToMaintan.getCurrentValue() - subsystemToMaintan.getTargetValue()) < errorToleranceProp
+        if (Math.abs(getErrorMagnitude()) < errorToleranceProp
                 .get()) {
             return true;
         }
         return false;
     }
 
-    protected abstract double getHumanInput();
+    protected abstract double getErrorMagnitude();
+
+    protected abstract T getHumanInput();
+
+    protected abstract double getHumanInputMagnitude();
 
     @Override
     public String getPrefix() {

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -64,7 +64,13 @@ public abstract class BaseRobot extends TimedRobot {
 
     protected RobotSession robotSession;
 
-    public BaseRobot() {                
+    public BaseRobot() {
+        // The IterativeRobot uses the period below to trigger some timeouts. We find these to be more annoying
+        // than helpful, so we set the period (typically 0.02) to something dramatically larger (10 seconds).
+        super(10);
+        // However, we want to make sure that we actually do call the loopFunc quickly and periodically at
+        // 50hz, so we make this call to addPeriodic.
+        addPeriodic(super::loopFunc, 0.02);
         brownoutLatch = new Latch(false, EdgeType.Both, edge -> {
             if(edge == EdgeType.RisingEdge) {
                 log.warn("Entering brownout");
@@ -75,7 +81,18 @@ public abstract class BaseRobot extends TimedRobot {
         });
         
     }
-    
+
+    @Override
+    protected void loopFunc() {
+        // Do nothing. This is part of some shenanigans to avoid loop overrun notifications.
+    }
+
+    @Override
+    public double getPeriod() {
+        // In case anything was depending on reading the period, we use the typical 50hz value.
+        return 0.02;
+    }
+
     /**
      * Override if you need a different module
      */
@@ -122,7 +139,11 @@ public abstract class BaseRobot extends TimedRobot {
         this.initializeSystems();
         log.info("========== SYSTEMS INITIALIZED ==========");
         SmartDashboard.putData(CommandScheduler.getInstance());
-        
+
+        if (this.isReal()) {
+            // We're just so tired of seeing these in logs. We may re-enable this at competition time.
+            DriverStation.silenceJoystickConnectionWarning(true);
+        }
         PropertyFactory pf = injectorComponent.propertyFactory();
         pf.setTopLevelPrefix();
         frequencyReportInterval = pf.createPersistentProperty("Robot loop frequency report interval", 20);
@@ -173,6 +194,8 @@ public abstract class BaseRobot extends TimedRobot {
         // Get the property manager and get all properties from the robot disk
         propertyManager = injectorComponent.propertyManager();
         xScheduler = injectorComponent.scheduler();
+        // All this does is set the timeout period for the scheduler - the actual loop still runs at 50hz.
+        CommandScheduler.getInstance().setPeriod(0.05);
         autonomousCommandSelector = injectorComponent.autonomousCommandSelector();
     }
 

--- a/src/main/java/xbot/common/command/BaseSetpointSubsystem.java
+++ b/src/main/java/xbot/common/command/BaseSetpointSubsystem.java
@@ -3,7 +3,7 @@ package xbot.common.command;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import xbot.common.controls.sensors.XTimer;
 
-public abstract class BaseSetpointSubsystem extends BaseSubsystem implements SupportsSetpointLock {
+public abstract class BaseSetpointSubsystem<T> extends BaseSubsystem implements SupportsSetpointLock {
 
     private Subsystem setpointLock;
     private double lastUpdateTimeFromMaintainer;
@@ -30,13 +30,13 @@ public abstract class BaseSetpointSubsystem extends BaseSubsystem implements Sup
         this.atGoal = atGoal;
     }
 
-    public abstract double getCurrentValue();
+    public abstract T getCurrentValue();
 
-    public abstract double getTargetValue();
+    public abstract T getTargetValue();
 
-    public abstract void setTargetValue(double value);
+    public abstract void setTargetValue(T value);
 
-    public abstract void setPower(double power);
+    public abstract void setPower(T power);
 
     public abstract boolean isCalibrated();
 }

--- a/src/main/java/xbot/common/controls/sensors/XDutyCycleEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XDutyCycleEncoder.java
@@ -1,19 +1,44 @@
 package xbot.common.controls.sensors;
 
 import edu.wpi.first.math.geometry.Rotation2d;
+import xbot.common.controls.XBaseIO;
+import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.math.ContiguousDouble;
 import xbot.common.math.WrappedRotation2d;
 
-public abstract class XDutyCycleEncoder {
+public abstract class XDutyCycleEncoder implements XBaseIO {
+
+    protected int channel;
 
     public interface XDutyCycleEncoderFactory {
-        XDutyCycleEncoder create(DeviceInfo deviceInfo, String owningSystemPrefix);
+        XDutyCycleEncoder create(DeviceInfo deviceInfo);
+    }
+
+    public XDutyCycleEncoder(DeviceInfo info, DevicePolice police) {
+        this.channel = info.channel;
+        police.registerDevice(DevicePolice.DeviceType.DigitalIO, channel, this);
     }
 
     protected abstract double getAbsoluteRawPosition();
 
+    /**
+     * Typically not recommended - use {@link #getWrappedPosition()} instead.
+     * @return the absolute position of the encoder in degrees from (0, 360)
+     */
     public Rotation2d getAbsolutePosition() {
         return new Rotation2d(getAbsoluteRawPosition()*2*Math.PI);
+    }
+
+    /**
+     * @return the absolute position of the encoder in degrees from (-180, 180)
+     */
+    public WrappedRotation2d getWrappedPosition() {
+        return WrappedRotation2d.fromRotation2d(getAbsolutePosition());
+    }
+
+    @Override
+    public int getChannel() {
+        return channel;
     }
 }

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockDutyCycleEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockDutyCycleEncoder.java
@@ -1,0 +1,39 @@
+package xbot.common.controls.sensors.mock_adapters;
+
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+import edu.wpi.first.wpilibj.MockAnalogInput;
+import xbot.common.controls.sensors.XAnalogInput;
+import xbot.common.controls.sensors.XDutyCycleEncoder;
+import xbot.common.injection.DevicePolice;
+import xbot.common.injection.electrical_contract.DeviceInfo;
+
+public class MockDutyCycleEncoder extends XDutyCycleEncoder {
+
+    private double rawPosition;
+
+    @AssistedFactory
+    public abstract static class MockDutyCycleEncoderFactory implements XDutyCycleEncoder.XDutyCycleEncoderFactory {
+        public abstract MockDutyCycleEncoder create(@Assisted("info") DeviceInfo info);
+    }
+
+    @AssistedInject
+    public MockDutyCycleEncoder(@Assisted("info") DeviceInfo info, DevicePolice police) {
+        super(info, police);
+    }
+
+    @Override
+    protected double getAbsoluteRawPosition() {
+        return rawPosition;
+    }
+
+    public void setRawPosition(double rawPosition) {
+        this.rawPosition = rawPosition;
+    }
+
+    @Override
+    public int getChannel() {
+        return channel;
+    }
+}

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/DutyCycleEncoderWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/DutyCycleEncoderWpiAdapter.java
@@ -1,0 +1,31 @@
+package xbot.common.controls.sensors.wpi_adapters;
+
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+import edu.wpi.first.wpilibj.DutyCycleEncoder;
+import xbot.common.controls.sensors.XDutyCycleEncoder;
+import xbot.common.controls.sensors.mock_adapters.MockDutyCycleEncoder;
+import xbot.common.injection.DevicePolice;
+import xbot.common.injection.electrical_contract.DeviceInfo;
+
+public class DutyCycleEncoderWpiAdapter extends XDutyCycleEncoder {
+
+    DutyCycleEncoder internalEncoder;
+
+    @AssistedFactory
+    public abstract static class DutyCycleEncoderWpiAdapterFactory implements XDutyCycleEncoder.XDutyCycleEncoderFactory {
+        public abstract MockDutyCycleEncoder create(@Assisted("info") DeviceInfo info);
+    }
+
+    @AssistedInject
+    public DutyCycleEncoderWpiAdapter(@Assisted("info") DeviceInfo info, DevicePolice police) {
+        super(info, police);
+        internalEncoder = new DutyCycleEncoder(info.channel);
+    }
+
+    @Override
+    protected double getAbsoluteRawPosition() {
+        return internalEncoder.getAbsolutePosition();
+    }
+}

--- a/src/main/java/xbot/common/injection/components/BaseComponent.java
+++ b/src/main/java/xbot/common/injection/components/BaseComponent.java
@@ -15,6 +15,7 @@ import xbot.common.controls.actuators.XRelay.XRelayFactory;
 import xbot.common.controls.actuators.XServo.XServoFactory;
 import xbot.common.controls.actuators.XSolenoid.XSolenoidFactory;
 import xbot.common.controls.actuators.XSpeedController.XSpeedControllerFactory;
+import xbot.common.controls.sensors.XDutyCycleEncoder;
 import xbot.common.controls.sensors.XSettableTimerImpl;
 import xbot.common.controls.sensors.XTimerImpl;
 import xbot.common.controls.sensors.XAS5600.XAS5600Factory;
@@ -178,4 +179,6 @@ public abstract class BaseComponent {
     public abstract BaseDriveSubsystem driveSubsystem();
     
     public abstract BasePoseSubsystem poseSubsystem();
+
+    public abstract XDutyCycleEncoder.XDutyCycleEncoderFactory dutyCycleEncoderFactory();
 }

--- a/src/main/java/xbot/common/injection/modules/MockDevicesModule.java
+++ b/src/main/java/xbot/common/injection/modules/MockDevicesModule.java
@@ -1,7 +1,5 @@
 package xbot.common.injection.modules;
 
-import javax.inject.Singleton;
-
 import dagger.Binds;
 import dagger.Module;
 import edu.wpi.first.wpilibj.MockAnalogInput.MockAnalogInputFactory;
@@ -34,16 +32,20 @@ import xbot.common.controls.sensors.XAnalogDistanceSensor.XAnalogDistanceSensorF
 import xbot.common.controls.sensors.XAnalogInput.XAnalogInputFactory;
 import xbot.common.controls.sensors.XCANCoder.XCANCoderFactory;
 import xbot.common.controls.sensors.XDigitalInput.XDigitalInputFactory;
+import xbot.common.controls.sensors.XDutyCycleEncoder;
 import xbot.common.controls.sensors.XEncoder.XEncoderFactory;
 import xbot.common.controls.sensors.XGyro.XGyroFactory;
 import xbot.common.controls.sensors.XLidarLite.XLidarLiteFactory;
 import xbot.common.controls.sensors.XPowerDistributionPanel.XPowerDistributionPanelFactory;
 import xbot.common.controls.sensors.mock_adapters.MockAbsoluteEncoder.MockAbsoluteEncoderFactory;
 import xbot.common.controls.sensors.mock_adapters.MockCANCoder.MockCANCoderFactory;
+import xbot.common.controls.sensors.mock_adapters.MockDutyCycleEncoder;
 import xbot.common.controls.sensors.mock_adapters.MockEncoder.MockEncoderFactory;
 import xbot.common.controls.sensors.mock_adapters.MockGyro.MockGyroFactory;
 import xbot.common.networking.MockZeromqListener.MockZeromqListenerFactory;
 import xbot.common.networking.XZeromqListener.XZeromqListenerFactory;
+
+import javax.inject.Singleton;
 
 @Module
 public abstract class MockDevicesModule {
@@ -126,4 +128,8 @@ public abstract class MockDevicesModule {
     @Binds
     @Singleton
     public abstract XZeromqListenerFactory getZeromqListenerFactory(MockZeromqListenerFactory impl);
+
+    @Binds
+    @Singleton
+    public abstract XDutyCycleEncoder.XDutyCycleEncoderFactory getDutyCycleEncoderFactory(MockDutyCycleEncoder.MockDutyCycleEncoderFactory impl);
 }

--- a/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
+++ b/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
@@ -30,6 +30,7 @@ import xbot.common.controls.sensors.XAnalogDistanceSensor.XAnalogDistanceSensorF
 import xbot.common.controls.sensors.XAnalogInput.XAnalogInputFactory;
 import xbot.common.controls.sensors.XCANCoder.XCANCoderFactory;
 import xbot.common.controls.sensors.XDigitalInput.XDigitalInputFactory;
+import xbot.common.controls.sensors.XDutyCycleEncoder;
 import xbot.common.controls.sensors.XEncoder.XEncoderFactory;
 import xbot.common.controls.sensors.XGyro.XGyroFactory;
 import xbot.common.controls.sensors.XLidarLite.XLidarLiteFactory;
@@ -37,6 +38,7 @@ import xbot.common.controls.sensors.XPowerDistributionPanel.XPowerDistributionPa
 import xbot.common.controls.sensors.wpi_adapters.AnalogInputWPIAdapater.AnalogInputWPIAdapaterFactory;
 import xbot.common.controls.sensors.wpi_adapters.CANCoderAdapter.CANCoderAdapterFactory;
 import xbot.common.controls.sensors.wpi_adapters.DigitalInputWPIAdapter.DigitalInputWPIAdapterFactory;
+import xbot.common.controls.sensors.wpi_adapters.DutyCycleEncoderWpiAdapter;
 import xbot.common.controls.sensors.wpi_adapters.EncoderWPIAdapter.EncoderWPIAdapterFactory;
 import xbot.common.controls.sensors.wpi_adapters.InertialMeasurementUnitAdapter.InertialMeasurementUnitAdapterFactory;
 import xbot.common.controls.sensors.wpi_adapters.LidarLiteWpiAdapter.LidarLiteWpiAdapterFactory;
@@ -125,4 +127,8 @@ public abstract class RealDevicesModule {
     @Binds
     @Singleton
     public abstract XZeromqListenerFactory getZeromqListenerFactory(ZeromqListenerFactory impl);
+
+    @Binds
+    @Singleton
+    public abstract XDutyCycleEncoder.XDutyCycleEncoderFactory getDutyCycleEncoderFactory(DutyCycleEncoderWpiAdapter.DutyCycleEncoderWpiAdapterFactory impl);
 }

--- a/src/test/java/xbot/common/command/MockSetpointSubsystem.java
+++ b/src/test/java/xbot/common/command/MockSetpointSubsystem.java
@@ -4,32 +4,32 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class MockSetpointSubsystem extends BaseSetpointSubsystem {
+public class MockSetpointSubsystem extends BaseSetpointSubsystem<Double> {
 
     @Inject
     public MockSetpointSubsystem() {}
 
     @Override
-    public double getCurrentValue() {
-        return 0;
+    public Double getCurrentValue() {
+        return 0.0;
     }
 
     @Override
-    public double getTargetValue() {
-        return 0;
+    public Double getTargetValue() {
+        return 0.0;
     }
 
     @Override
-    public void setPower(double power) {
+    public void setTargetValue(Double value) {
+
+    }
+
+    @Override
+    public void setPower(Double power) {
     }
 
     @Override
     public boolean isCalibrated() {
         return false;
     }
-
-    @Override
-    public void setTargetValue(double value) {
-    }
-
 }

--- a/src/test/java/xbot/common/controls/sensors/DutyCycleEncoderTest.java
+++ b/src/test/java/xbot/common/controls/sensors/DutyCycleEncoderTest.java
@@ -1,0 +1,29 @@
+package xbot.common.controls.sensors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import xbot.common.controls.sensors.mock_adapters.MockDutyCycleEncoder;
+import xbot.common.injection.BaseCommonLibTest;
+import xbot.common.injection.BaseWPITest;
+import xbot.common.injection.electrical_contract.DeviceInfo;
+import static org.junit.Assert.assertEquals;
+
+public class DutyCycleEncoderTest extends BaseCommonLibTest {
+
+    @Test
+    public void simpleScaling() {
+        MockDutyCycleEncoder encoder = (MockDutyCycleEncoder)this.getInjectorComponent().dutyCycleEncoderFactory().create(new DeviceInfo(0, false));
+
+        encoder.setRawPosition(0);
+        assertEquals(0, encoder.getAbsolutePosition().getDegrees(), 0.001);
+        assertEquals(0, encoder.getWrappedPosition().getDegrees(), 0.001);
+
+        encoder.setRawPosition(0.499999999999999999);
+        assertEquals(180, encoder.getAbsolutePosition().getDegrees(), 0.001);
+        assertEquals(180, encoder.getWrappedPosition().getDegrees(), 0.001);
+
+        encoder.setRawPosition(1.00000000001);
+        assertEquals(360, encoder.getAbsolutePosition().getDegrees(), 0.001);
+        assertEquals(0, encoder.getWrappedPosition().getDegrees(), 0.001);
+    }
+}


### PR DESCRIPTION
- Modify the Maintainer/Setpoint classes to be generics
- Add DutyCycleEncoder (since we have some through-bore encoders that will need this for absolute positioning)