### PR TITLE
Allow setting a default property level per factory

### DIFF
--- a/src/main/java/xbot/common/properties/PropertyFactory.java
+++ b/src/main/java/xbot/common/properties/PropertyFactory.java
@@ -118,7 +118,7 @@ public class PropertyFactory {
      */
     public StringProperty createEphemeralProperty(String key, String defaultValue) {
         checkPrefixSet();
-        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager);
+        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, defaultLevel);
     }
 
     /**
@@ -128,7 +128,7 @@ public class PropertyFactory {
      */
     public DoubleProperty createEphemeralProperty(String key, double defaultValue) {
         checkPrefixSet();
-        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager);
+        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, defaultLevel);
     }
 
     /**
@@ -148,7 +148,7 @@ public class PropertyFactory {
      */
     public BooleanProperty createPersistentProperty(String key, boolean defaultValue) {
         checkPrefixSet();
-        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager);
+        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, defaultLevel);
     }
 
     /**
@@ -168,7 +168,7 @@ public class PropertyFactory {
      */
     public StringProperty createPersistentProperty(String key, String defaultValue) {
         checkPrefixSet();
-        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager);
+        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, defaultLevel);
     }
 
     /**
@@ -188,7 +188,7 @@ public class PropertyFactory {
      */
     public DoubleProperty createPersistentProperty(String key, double defaultValue) {
         checkPrefixSet();
-        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager);
+        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, defaultLevel);
     }
 
     /**

--- a/src/main/java/xbot/common/properties/PropertyFactory.java
+++ b/src/main/java/xbot/common/properties/PropertyFactory.java
@@ -15,6 +15,7 @@ public class PropertyFactory {
     private String prefix = "";
     private RobotAssertionManager assertionManager;
     private boolean prefixSet;
+    private PropertyLevel defaultLevel = PropertyLevel.Important;
 
     @Inject
     PropertyFactory(XPropertyManager propertyManager, RobotAssertionManager assertionManager) {
@@ -76,6 +77,10 @@ public class PropertyFactory {
         }
     }
 
+    public void setDefaultLevel(PropertyLevel level) {
+        this.defaultLevel = level;
+    }
+
     /**
      * Method for creating a boolean ephemeral property
      * 
@@ -83,7 +88,7 @@ public class PropertyFactory {
      */
     public BooleanProperty createEphemeralProperty(String key, boolean defaultValue) {
         checkPrefixSet();
-        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager);
+        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, defaultLevel);
     }
 
     /**


### PR DESCRIPTION
this will allow us to remove properties from the network tables at the factory level, instead of just per property (what we can do today).