### PR TITLE
Move some vision to SCL, improve AdvantageKit Integration

### DIFF
--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -94,7 +94,7 @@ public abstract class BaseRobot extends LoggedRobot {
 
         Logger.getInstance().recordMetadata("ProjectName", "XbotProject"); // Set a metadata value
         if (isReal() || forceWebots) {
-            Logger.addDataReceiver(new WPILOGWriter("/home/lvuser/")); // Log to a USB stick ("/U/logs")
+            Logger.addDataReceiver(new WPILOGWriter("/U/logs")); // Log to a USB stick ("/U/logs")
             Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
             new PowerDistribution(1, PowerDistribution.ModuleType.kRev); // Enables power distribution logging
         } else {

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -94,14 +94,14 @@ public abstract class BaseRobot extends LoggedRobot {
 
         Logger.getInstance().recordMetadata("ProjectName", "XbotProject"); // Set a metadata value
         if (isReal() || forceWebots) {
-            Logger.getInstance().addDataReceiver(new WPILOGWriter("/media/sda1/")); // Log to a USB stick
-            Logger.getInstance().addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
+            Logger.addDataReceiver(new WPILOGWriter("/home/lvuser/")); // Log to a USB stick ("/U/logs")
+            Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
             new PowerDistribution(1, PowerDistribution.ModuleType.kRev); // Enables power distribution logging
         } else {
             setUseTiming(false); // Run as fast as possible
             String logPath = LogFileUtil.findReplayLog(); // Pull the replay log from AdvantageScope (or prompt the user)
-            Logger.getInstance().setReplaySource(new WPILOGReader(logPath)); // Read replay log
-            Logger.getInstance().addDataReceiver(new WPILOGWriter(LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
+            Logger.setReplaySource(new WPILOGReader(logPath)); // Read replay log
+            Logger.addDataReceiver(new WPILOGWriter(LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
         }
 
         Logger.getInstance().start(); // Start logging! No more data receivers, replay sources, or metadata values may be added.

--- a/src/main/java/xbot/common/controls/io_inputs/XPhotonCameraInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/XPhotonCameraInputs.java
@@ -1,0 +1,11 @@
+package xbot.common.controls.io_inputs;
+
+import org.littletonrobotics.junction.AutoLog;
+import org.photonvision.targeting.PhotonPipelineResult;
+
+@AutoLog
+public class XPhotonCameraInputs {
+    public double pipelineResult;
+    public double[] cameraMatrix;
+    public double[] distCoeffs;
+}

--- a/src/main/java/xbot/common/controls/sensors/XCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XCANCoder.java
@@ -26,8 +26,8 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
 
     /**
      * Updates how often we get data about the CANCoder position.
-     * @param frequencyInHz
-     * @return
+     * @param frequencyInHz How many times per second we want to get data.
+     * @return The status code returned from the underlying object.
      */
     public abstract StatusCode setUpdateFrequencyForPosition(double frequencyInHz);
 
@@ -35,7 +35,7 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
      * Stops all signals that are not explicitly set.
      * For example, if you haven't called setUpdateFrequencyForPosition, this will stop that signal!
      * Useful for reducing CAN bus traffic for data we're not reading.
-     * @return
+     * @return The status code returned from the underlying object.
      */
     public abstract StatusCode stopAllUnsetSignals();
 

--- a/src/main/java/xbot/common/controls/sensors/XCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XCANCoder.java
@@ -5,6 +5,7 @@ import com.ctre.phoenix.sensors.CANCoderFaults;
 import com.ctre.phoenix.sensors.CANCoderStatusFrame;
 import com.ctre.phoenix.sensors.CANCoderStickyFaults;
 
+import com.ctre.phoenix6.StatusCode;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.io_inputs.XCANCoderInputs;
 import xbot.common.controls.io_inputs.XCANCoderInputsAutoLogged;
@@ -23,15 +24,22 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
         inputs = new XCANCoderInputsAutoLogged();
     }
 
-    public abstract ErrorCode setStatusFramePeriod(CANCoderStatusFrame frame, int periodMs);
+    /**
+     * Updates how often we get data about the CANCoder position.
+     * @param frequencyInHz
+     * @return
+     */
+    public abstract StatusCode setUpdateFrequencyForPosition(double frequencyInHz);
 
-    public abstract int getStatusFramePeriod(CANCoderStatusFrame frame);
+    /**
+     * Stops all signals that are not explicitly set.
+     * For example, if you haven't called setUpdateFrequencyForPosition, this will stop that signal!
+     * Useful for reducing CAN bus traffic for data we're not reading.
+     * @return
+     */
+    public abstract StatusCode stopAllUnsetSignals();
 
-    public abstract ErrorCode getFaults(CANCoderFaults toFill);
-
-    public abstract ErrorCode getStickyFaults(CANCoderStickyFaults toFill);
-
-    public abstract ErrorCode clearStickyFaults();
+    public abstract StatusCode clearStickyFaults();
 
     public boolean hasResetOccurred() {
         return inputs.hasResetOccurred;

--- a/src/main/java/xbot/common/controls/sensors/XPhotonCamera.java
+++ b/src/main/java/xbot/common/controls/sensors/XPhotonCamera.java
@@ -1,0 +1,59 @@
+package xbot.common.controls.sensors;
+
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.Num;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
+import org.littletonrobotics.junction.Logger;
+import org.photonvision.targeting.PhotonPipelineResult;
+import xbot.common.controls.io_inputs.XGyroIoInputs;
+import xbot.common.controls.io_inputs.XPhotonCameraInputs;
+import xbot.common.controls.io_inputs.XPhotonCameraInputsAutoLogged;
+
+import java.util.Optional;
+
+public abstract class XPhotonCamera {
+
+    protected XPhotonCameraInputsAutoLogged io;
+    protected String cameraName;
+
+    public interface XPhotonCameraFactory {
+        XPhotonCamera create(String cameraName);
+    }
+
+    protected XPhotonCamera(String cameraName)
+    {
+        this.cameraName = cameraName;
+        io = new XPhotonCameraInputsAutoLogged();
+    }
+
+    public PhotonPipelineResult getLatestResult() {
+        // TODO: once PhotonVision has proper protobuf support for PhotonPipelineResult, replace this
+        // with a call to the IO layer.
+        return null;
+    }
+
+    public Optional<Matrix<N3, N3>> getCameraMatrix() {
+        var cameraMatrix = io.cameraMatrix;
+        if (cameraMatrix != null && cameraMatrix.length == 9) {
+            return Optional.of(MatBuilder.fill(Nat.N3(), Nat.N3(), cameraMatrix));
+        } else return Optional.empty();
+    }
+
+    public Optional<Matrix<N5, N1>> getDistCoeffs() {
+        var distCoeffs = io.distCoeffs;
+        if (distCoeffs != null && distCoeffs.length == 5) {
+            return Optional.of(MatBuilder.fill(Nat.N5(), Nat.N1(), distCoeffs));
+        } else return Optional.empty();
+    }
+
+    protected abstract void updateInputs(XPhotonCameraInputs inputs);
+
+    public void refreshDataFrame() {
+        updateInputs(io);
+        Logger.processInputs("PhotonCamera" + cameraName, io);
+    }
+}

--- a/src/main/java/xbot/common/controls/sensors/XPhotonCamera.java
+++ b/src/main/java/xbot/common/controls/sensors/XPhotonCamera.java
@@ -40,14 +40,18 @@ public abstract class XPhotonCamera {
         var cameraMatrix = io.cameraMatrix;
         if (cameraMatrix != null && cameraMatrix.length == 9) {
             return Optional.of(MatBuilder.fill(Nat.N3(), Nat.N3(), cameraMatrix));
-        } else return Optional.empty();
+        } else {
+            return Optional.empty();
+        }
     }
 
     public Optional<Matrix<N5, N1>> getDistCoeffs() {
         var distCoeffs = io.distCoeffs;
         if (distCoeffs != null && distCoeffs.length == 5) {
             return Optional.of(MatBuilder.fill(Nat.N5(), Nat.N1(), distCoeffs));
-        } else return Optional.empty();
+        } else {
+            return Optional.empty();
+        }
     }
 
     protected abstract void updateInputs(XPhotonCameraInputs inputs);

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockCANCoder.java
@@ -1,10 +1,6 @@
 package xbot.common.controls.sensors.mock_adapters;
 
-import com.ctre.phoenix.ErrorCode;
-import com.ctre.phoenix.sensors.CANCoderFaults;
-import com.ctre.phoenix.sensors.CANCoderStatusFrame;
-import com.ctre.phoenix.sensors.CANCoderStickyFaults;
-
+import com.ctre.phoenix6.StatusCode;
 import org.json.JSONObject;
 
 import dagger.assisted.Assisted;
@@ -103,30 +99,19 @@ public class MockCANCoder extends XCANCoder implements ISimulatableSensor {
     }
 
 
-
     @Override
-    public ErrorCode setStatusFramePeriod(CANCoderStatusFrame frame, int periodMs) {
-        return ErrorCode.OK;
+    public StatusCode setUpdateFrequencyForPosition(double frequencyInHz) {
+        return StatusCode.OK;
     }
 
     @Override
-    public int getStatusFramePeriod(CANCoderStatusFrame frame) {
-        return 20;
+    public StatusCode stopAllUnsetSignals() {
+        return StatusCode.OK;
     }
 
     @Override
-    public ErrorCode getFaults(CANCoderFaults toFill) {
-        return ErrorCode.OK;
-    }
-
-    @Override
-    public ErrorCode getStickyFaults(CANCoderStickyFaults toFill) {
-        return ErrorCode.OK;
-    }
-
-    @Override
-    public ErrorCode clearStickyFaults() {
-        return ErrorCode.OK;
+    public StatusCode clearStickyFaults() {
+        return StatusCode.OK;
     }
     
     public boolean hasResetOccurred_internal() {

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockPhotonCamera.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockPhotonCamera.java
@@ -1,0 +1,28 @@
+package xbot.common.controls.sensors.mock_adapters;
+
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+import org.photonvision.targeting.PhotonPipelineResult;
+import xbot.common.controls.io_inputs.XPhotonCameraInputs;
+import xbot.common.controls.sensors.XPhotonCamera;
+
+public class MockPhotonCamera extends XPhotonCamera {
+
+    @AssistedFactory
+    public abstract static class MockPhotonCameraFactory implements XPhotonCameraFactory {
+        public abstract MockPhotonCamera create(String cameraName);
+    }
+
+    @AssistedInject
+    public MockPhotonCamera(@Assisted String cameraName) {
+        super(cameraName);
+    }
+
+    @Override
+    protected void updateInputs(XPhotonCameraInputs inputs) {
+        inputs.pipelineResult = 0;
+        inputs.cameraMatrix = new double[9];
+        inputs.distCoeffs = new double[5];
+    }
+}

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
@@ -83,9 +83,9 @@ public class CANCoderAdapter extends XCANCoder {
     public DeviceHealth getHealth_internal() {
         // Needs to be tested on the actual robot with devices unplugged to see if this is a valid approach
         if (this.cancoder.getVersionMajor().getValueAsDouble() > 0) {
-            return DeviceHealth.Unhealthy;
+            return DeviceHealth.Healthy;
         }
-        return DeviceHealth.Healthy;
+        return DeviceHealth.Unhealthy;
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
@@ -52,8 +52,8 @@ public class CANCoderAdapter extends XCANCoder {
         this.cancoder = new CANcoder(deviceInfo.channel, "rio");
 
         var currentConfig = getCurrentConfiguration();
-        currentConfig.MagnetSensor.SensorDirection = this.inverted.get() ?
-                SensorDirectionValue.Clockwise_Positive : SensorDirectionValue.CounterClockwise_Positive;
+        currentConfig.MagnetSensor.SensorDirection = this.inverted.get()
+                ? SensorDirectionValue.Clockwise_Positive : SensorDirectionValue.CounterClockwise_Positive;
         applyConfiguration(currentConfig);
 
         this.getMagnetOffset();

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
@@ -1,12 +1,9 @@
 package xbot.common.controls.sensors.wpi_adapters;
 
-import com.ctre.phoenix.ErrorCode;
-import com.ctre.phoenix.sensors.CANCoder;
-import com.ctre.phoenix.sensors.CANCoderFaults;
-import com.ctre.phoenix.sensors.CANCoderStatusFrame;
-import com.ctre.phoenix.sensors.CANCoderStickyFaults;
-import com.ctre.phoenix.sensors.WPI_CANCoder;
-
+import com.ctre.phoenix6.StatusCode;
+import com.ctre.phoenix6.configs.CANcoderConfiguration;
+import com.ctre.phoenix6.hardware.CANcoder;
+import com.ctre.phoenix6.signals.SensorDirectionValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -30,7 +27,7 @@ public class CANCoderAdapter extends XCANCoder {
     private static final Logger log = LogManager.getLogger(CANCoderAdapter.class);
 
     private final int deviceId;
-    private final CANCoder cancoder;
+    private final CANcoder cancoder;
 
     private final DoubleProperty magnetOffset;
     private final BooleanProperty inverted;
@@ -52,8 +49,13 @@ public class CANCoderAdapter extends XCANCoder {
         this.inverted = pf.createEphemeralProperty("Inverted", deviceInfo.inverted);
         this.magnetOffset = pf.createEphemeralProperty("Magnet offset", 0.0);
         
-        this.cancoder = new WPI_CANCoder(deviceInfo.channel, "rio");
-        this.cancoder.configSensorDirection(this.inverted.get());
+        this.cancoder = new CANcoder(deviceInfo.channel, "rio");
+
+        var currentConfig = getCurrentConfiguration();
+        currentConfig.MagnetSensor.SensorDirection = this.inverted.get() ?
+                SensorDirectionValue.Clockwise_Positive : SensorDirectionValue.CounterClockwise_Positive;
+        applyConfiguration(currentConfig);
+
         this.getMagnetOffset();
         
         this.deviceId = deviceInfo.channel;
@@ -67,19 +69,20 @@ public class CANCoderAdapter extends XCANCoder {
     }
 
     public double getPosition_internal() {
-        return this.cancoder.getPosition();
+        return this.cancoder.getPosition().getValueAsDouble();
     }
 
     public double getAbsolutePosition_internal() {
-        return this.cancoder.getAbsolutePosition();
+        return this.cancoder.getAbsolutePosition().getValueAsDouble();
     }
 
     public double getVelocity_internal() {
-        return this.cancoder.getVelocity();
+        return this.cancoder.getVelocity().getValueAsDouble();
     }
 
     public DeviceHealth getHealth_internal() {
-        if (this.cancoder.getFirmwareVersion() == -1) {
+        // Needs to be tested on the actual robot with devices unplugged to see if this is a valid approach
+        if (this.cancoder.getVersionMajor().getValueAsDouble() > 0) {
             return DeviceHealth.Unhealthy;
         }
         return DeviceHealth.Healthy;
@@ -91,11 +94,17 @@ public class CANCoderAdapter extends XCANCoder {
     }
 
     /**
-     * Gets the magnet offset configured on the encoder device.
+     * Gets the magnet offset configured on the encoder device. Blocking call.
      * @return The magnet offset in degrees
      */
     public double getMagnetOffset() {
-        this.magnetOffset.set(this.cancoder.configGetMagnetOffset());
+
+        // With Phoenix6, getting configuration is now a multi-step process.
+        var currentConfigs = new CANcoderConfiguration();
+        // Note that the "refresh" is a blocking call.
+        cancoder.getConfigurator().refresh(currentConfigs);
+
+        this.magnetOffset.set(currentConfigs.MagnetSensor.MagnetOffset);
         return this.magnetOffset.get();
     }
 
@@ -105,9 +114,13 @@ public class CANCoderAdapter extends XCANCoder {
      * @return True on success.
      */
     public boolean setMagnetOffset(double offsetInDegrees) {
-        ErrorCode errorCode = this.cancoder.configMagnetOffset(offsetInDegrees);
-        if (errorCode.value != 0) {
-            log.error("Failed to set magnet offset for device " + this.getDeviceId() + ". Error code: " + errorCode.value);
+
+        var currentConfigs = getCurrentConfiguration();
+        currentConfigs.MagnetSensor.MagnetOffset = offsetInDegrees;
+        var status = applyConfiguration(currentConfigs);
+
+        if (status.isError()) {
+            log.error("Failed to set magnet offset for device " + this.getDeviceId() + ". Error code: " + status.value);
             return false;
         } else {
             this.magnetOffset.set(offsetInDegrees);
@@ -115,33 +128,31 @@ public class CANCoderAdapter extends XCANCoder {
         }
     }
 
-    @Override
-    public ErrorCode setStatusFramePeriod(CANCoderStatusFrame frame, int periodMs) {
-        return this.cancoder.setStatusFramePeriod(frame, periodMs);
+    public StatusCode setUpdateFrequencyForPosition(double frequencyInHz) {
+        return this.cancoder.getPosition().setUpdateFrequency(frequencyInHz);
+    }
+
+    public StatusCode stopAllUnsetSignals() {
+        return this.cancoder.optimizeBusUtilization();
     }
 
     @Override
-    public int getStatusFramePeriod(CANCoderStatusFrame frame) {
-        return this.cancoder.getStatusFramePeriod(frame);
-    }
-
-    @Override
-    public ErrorCode getFaults(CANCoderFaults toFill) {
-        return this.cancoder.getFaults(toFill);
-    }
-
-    @Override
-    public ErrorCode getStickyFaults(CANCoderStickyFaults toFill) {
-        return this.cancoder.getStickyFaults(toFill);
-    }
-
-    @Override
-    public ErrorCode clearStickyFaults() {
+    public StatusCode clearStickyFaults() {
         return this.cancoder.clearStickyFaults();
     }
 
     public boolean hasResetOccurred_internal() {
         return this.cancoder.hasResetOccurred();
+    }
+
+    private CANcoderConfiguration getCurrentConfiguration() {
+        var currentConfig = new CANcoderConfiguration();
+        this.cancoder.getConfigurator().refresh(currentConfig);
+        return currentConfig;
+    }
+
+    private StatusCode applyConfiguration(CANcoderConfiguration toApply) {
+        return this.cancoder.getConfigurator().apply(toApply);
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/PhotonCameraAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/PhotonCameraAdapter.java
@@ -1,0 +1,42 @@
+package xbot.common.controls.sensors.wpi_adapters;
+
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N2;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
+import org.photonvision.PhotonCamera;
+import org.photonvision.targeting.PhotonPipelineResult;
+import xbot.common.controls.io_inputs.XPhotonCameraInputs;
+import xbot.common.controls.sensors.XPhotonCamera;
+import xbot.common.vision.XbotPhotonCameraFork;
+
+import java.util.Optional;
+
+public class PhotonCameraAdapter extends XPhotonCamera {
+
+    XbotPhotonCameraFork camera;
+
+    @AssistedFactory
+    public abstract static class PhotonCameraAdapterFactory implements XPhotonCameraFactory {
+        public abstract PhotonCameraAdapter create(String cameraName);
+    }
+
+    @AssistedInject
+    public PhotonCameraAdapter(@Assisted String cameraName) {
+        super(cameraName);
+        camera = new XbotPhotonCameraFork(cameraName);
+    }
+
+    @Override
+    protected void updateInputs(XPhotonCameraInputs inputs) {
+        inputs.pipelineResult = camera.getLatestResult().getTimestampSeconds();
+        inputs.cameraMatrix = camera.getCameraMatrixRaw();
+        inputs.distCoeffs = camera.getDistCoeffsRaw();
+    }
+}

--- a/src/main/java/xbot/common/injection/modules/MockDevicesModule.java
+++ b/src/main/java/xbot/common/injection/modules/MockDevicesModule.java
@@ -36,12 +36,14 @@ import xbot.common.controls.sensors.XDutyCycleEncoder;
 import xbot.common.controls.sensors.XEncoder.XEncoderFactory;
 import xbot.common.controls.sensors.XGyro.XGyroFactory;
 import xbot.common.controls.sensors.XLidarLite.XLidarLiteFactory;
+import xbot.common.controls.sensors.XPhotonCamera;
 import xbot.common.controls.sensors.XPowerDistributionPanel.XPowerDistributionPanelFactory;
 import xbot.common.controls.sensors.mock_adapters.MockAbsoluteEncoder.MockAbsoluteEncoderFactory;
 import xbot.common.controls.sensors.mock_adapters.MockCANCoder.MockCANCoderFactory;
 import xbot.common.controls.sensors.mock_adapters.MockDutyCycleEncoder;
 import xbot.common.controls.sensors.mock_adapters.MockEncoder.MockEncoderFactory;
 import xbot.common.controls.sensors.mock_adapters.MockGyro.MockGyroFactory;
+import xbot.common.controls.sensors.mock_adapters.MockPhotonCamera;
 import xbot.common.networking.MockZeromqListener.MockZeromqListenerFactory;
 import xbot.common.networking.XZeromqListener.XZeromqListenerFactory;
 
@@ -135,4 +137,8 @@ public abstract class MockDevicesModule {
     @Binds
     @Singleton
     public abstract XDutyCycleEncoder.XDutyCycleEncoderFactory getDutyCycleEncoderFactory(MockDutyCycleEncoder.MockDutyCycleEncoderFactory impl);
+
+    @Binds
+    @Singleton
+    public abstract XPhotonCamera.XPhotonCameraFactory getPhotonCameraFactory(MockPhotonCamera.MockPhotonCameraFactory impl);
 }

--- a/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
+++ b/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
@@ -138,5 +138,6 @@ public abstract class RealDevicesModule {
 
     @Binds
     @Singleton
-    public abstract XPhotonCamera.XPhotonCameraFactory getPhotonCameraFactory(xbot.common.controls.sensors.wpi_adapters.PhotonCameraAdapter.PhotonCameraAdapterFactory impl);
+    public abstract XPhotonCamera.XPhotonCameraFactory
+        getPhotonCameraFactory(xbot.common.controls.sensors.wpi_adapters.PhotonCameraAdapter.PhotonCameraAdapterFactory impl);
 }

--- a/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
+++ b/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
@@ -34,6 +34,7 @@ import xbot.common.controls.sensors.XDutyCycleEncoder;
 import xbot.common.controls.sensors.XEncoder.XEncoderFactory;
 import xbot.common.controls.sensors.XGyro.XGyroFactory;
 import xbot.common.controls.sensors.XLidarLite.XLidarLiteFactory;
+import xbot.common.controls.sensors.XPhotonCamera;
 import xbot.common.controls.sensors.XPowerDistributionPanel.XPowerDistributionPanelFactory;
 import xbot.common.controls.sensors.wpi_adapters.AnalogInputWPIAdapater.AnalogInputWPIAdapaterFactory;
 import xbot.common.controls.sensors.wpi_adapters.CANCoderAdapter.CANCoderAdapterFactory;
@@ -134,4 +135,8 @@ public abstract class RealDevicesModule {
     @Binds
     @Singleton
     public abstract XDutyCycleEncoder.XDutyCycleEncoderFactory getDutyCycleEncoderFactory(DutyCycleEncoderWpiAdapter.DutyCycleEncoderWpiAdapterFactory impl);
+
+    @Binds
+    @Singleton
+    public abstract XPhotonCamera.XPhotonCameraFactory getPhotonCameraFactory(xbot.common.controls.sensors.wpi_adapters.PhotonCameraAdapter.PhotonCameraAdapterFactory impl);
 }

--- a/src/main/java/xbot/common/math/XYPair.java
+++ b/src/main/java/xbot/common/math/XYPair.java
@@ -2,12 +2,16 @@ package xbot.common.math;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.struct.Translation2dStruct;
+import edu.wpi.first.util.struct.StructSerializable;
+
+import java.sql.Struct;
 
 /**
  * Pair of X and Y coordinates. Can be used for points, vectors, or anything
  * else that requires a coordinate pair.
  */
-public class XYPair {
+public class XYPair implements StructSerializable {
     public static final XYPair ZERO = new XYPair(0, 0);
 
     public double x;
@@ -181,4 +185,7 @@ public class XYPair {
     public Translation2d toTranslation2d() {
         return new Translation2d(x, y);
     }
+
+    /** Translation2d struct for serialization. */
+    public static final XYPairStruct struct = new XYPairStruct();
 }

--- a/src/main/java/xbot/common/math/XYPairStruct.java
+++ b/src/main/java/xbot/common/math/XYPairStruct.java
@@ -1,0 +1,44 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package xbot.common.math;
+
+import edu.wpi.first.util.struct.Struct;
+
+import java.nio.ByteBuffer;
+
+public class XYPairStruct implements Struct<XYPair> {
+    @Override
+    public Class<XYPair> getTypeClass() {
+        return XYPair.class;
+    }
+
+    @Override
+    public String getTypeString() {
+        return "struct:Translation2d";
+    }
+
+    @Override
+    public int getSize() {
+        return kSizeDouble * 2;
+    }
+
+    @Override
+    public String getSchema() {
+        return "double x;double y";
+    }
+
+    @Override
+    public XYPair unpack(ByteBuffer bb) {
+        double x = bb.getDouble();
+        double y = bb.getDouble();
+        return new XYPair(x, y);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, XYPair value) {
+        bb.putDouble(value.x);
+        bb.putDouble(value.y);
+    }
+}

--- a/src/main/java/xbot/common/math/XYPairStruct.java
+++ b/src/main/java/xbot/common/math/XYPairStruct.java
@@ -1,7 +1,3 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
-
 package xbot.common.math;
 
 import edu.wpi.first.util.struct.Struct;

--- a/src/main/java/xbot/common/vision/XbotPhotonCameraFork.java
+++ b/src/main/java/xbot/common/vision/XbotPhotonCameraFork.java
@@ -1,0 +1,452 @@
+package xbot.common.vision;
+/*
+ * MIT License
+ *
+ * Copyright (c) PhotonVision
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.numbers.*;
+import edu.wpi.first.networktables.BooleanPublisher;
+import edu.wpi.first.networktables.BooleanSubscriber;
+import edu.wpi.first.networktables.DoubleArrayPublisher;
+import edu.wpi.first.networktables.DoubleArraySubscriber;
+import edu.wpi.first.networktables.DoublePublisher;
+import edu.wpi.first.networktables.IntegerEntry;
+import edu.wpi.first.networktables.IntegerPublisher;
+import edu.wpi.first.networktables.IntegerSubscriber;
+import edu.wpi.first.networktables.MultiSubscriber;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+import edu.wpi.first.networktables.RawSubscriber;
+import edu.wpi.first.networktables.StringPublisher;
+import edu.wpi.first.networktables.StringSubscriber;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import java.util.Optional;
+import java.util.Set;
+
+import org.photonvision.PhotonVersion;
+import org.photonvision.common.dataflow.structures.Packet;
+import org.photonvision.common.hardware.VisionLEDMode;
+import org.photonvision.targeting.PhotonPipelineResult;
+
+/** Represents a camera that is connected to PhotonVision. */
+public class XbotPhotonCameraFork implements AutoCloseable {
+    public static final String kTableName = "photonvision";
+
+    private final NetworkTable cameraTable;
+    RawSubscriber rawBytesEntry;
+    BooleanPublisher driverModePublisher;
+    BooleanSubscriber driverModeSubscriber;
+    DoublePublisher latencyMillisEntry;
+    BooleanPublisher hasTargetEntry;
+    DoublePublisher targetPitchEntry;
+    DoublePublisher targetYawEntry;
+    DoublePublisher targetAreaEntry;
+    DoubleArrayPublisher targetPoseEntry;
+    DoublePublisher targetSkewEntry;
+    StringSubscriber versionEntry;
+    IntegerEntry inputSaveImgEntry, outputSaveImgEntry;
+    IntegerPublisher pipelineIndexRequest, ledModeRequest;
+    IntegerSubscriber pipelineIndexState, ledModeState;
+    IntegerSubscriber heartbeatEntry;
+    private DoubleArraySubscriber cameraIntrinsicsSubscriber;
+    private DoubleArraySubscriber cameraDistortionSubscriber;
+    private StringPublisher atflPublisher;
+
+    @Override
+    public void close() {
+        rawBytesEntry.close();
+        driverModePublisher.close();
+        driverModeSubscriber.close();
+        latencyMillisEntry.close();
+        hasTargetEntry.close();
+        targetPitchEntry.close();
+        targetYawEntry.close();
+        targetAreaEntry.close();
+        targetPoseEntry.close();
+        targetSkewEntry.close();
+        versionEntry.close();
+        inputSaveImgEntry.close();
+        outputSaveImgEntry.close();
+        pipelineIndexRequest.close();
+        pipelineIndexState.close();
+        ledModeRequest.close();
+        ledModeState.close();
+        pipelineIndexRequest.close();
+        cameraIntrinsicsSubscriber.close();
+        cameraDistortionSubscriber.close();
+        atflPublisher.close();
+    }
+
+    private final String path;
+    private final String name;
+
+    private static boolean VERSION_CHECK_ENABLED = true;
+    private static long VERSION_CHECK_INTERVAL = 5;
+    private double lastVersionCheckTime = 0;
+
+    private long prevHeartbeatValue = -1;
+    private double prevHeartbeatChangeTime = 0;
+    private static final double HEARBEAT_DEBOUNCE_SEC = 0.5;
+
+    public static void setVersionCheckEnabled(boolean enabled) {
+        VERSION_CHECK_ENABLED = enabled;
+    }
+
+    Packet packet = new Packet(1);
+
+    private static AprilTagFieldLayout lastSetTagLayout =
+            AprilTagFields.kDefaultField.loadAprilTagLayoutField();
+
+    // Existing is enough to make this multisubscriber do its thing
+    private final MultiSubscriber m_topicNameSubscriber;
+
+    /**
+     * Constructs a PhotonCamera from a root table.
+     *
+     * @param instance The NetworkTableInstance to pull data from. This can be a custom instance in
+     *     simulation, but should *usually* be the default NTInstance from
+     *     NetworkTableInstance::getDefault
+     * @param cameraName The name of the camera, as seen in the UI.
+     */
+    public XbotPhotonCameraFork(NetworkTableInstance instance, String cameraName) {
+        name = cameraName;
+        var photonvision_root_table = instance.getTable(kTableName);
+        this.cameraTable = photonvision_root_table.getSubTable(cameraName);
+        path = cameraTable.getPath();
+        rawBytesEntry =
+                cameraTable
+                        .getRawTopic("rawBytes")
+                        .subscribe(
+                                "rawBytes", new byte[] {}, PubSubOption.periodic(0.01), PubSubOption.sendAll(true));
+        driverModePublisher = cameraTable.getBooleanTopic("driverModeRequest").publish();
+        driverModeSubscriber = cameraTable.getBooleanTopic("driverMode").subscribe(false);
+        inputSaveImgEntry = cameraTable.getIntegerTopic("inputSaveImgCmd").getEntry(0);
+        outputSaveImgEntry = cameraTable.getIntegerTopic("outputSaveImgCmd").getEntry(0);
+        pipelineIndexRequest = cameraTable.getIntegerTopic("pipelineIndexRequest").publish();
+        pipelineIndexState = cameraTable.getIntegerTopic("pipelineIndexState").subscribe(0);
+        heartbeatEntry = cameraTable.getIntegerTopic("heartbeat").subscribe(-1);
+        cameraIntrinsicsSubscriber =
+                cameraTable.getDoubleArrayTopic("cameraIntrinsics").subscribe(null);
+        cameraDistortionSubscriber =
+                cameraTable.getDoubleArrayTopic("cameraDistortion").subscribe(null);
+
+        ledModeRequest = photonvision_root_table.getIntegerTopic("ledModeRequest").publish();
+        ledModeState = photonvision_root_table.getIntegerTopic("ledModeState").subscribe(-1);
+        versionEntry = photonvision_root_table.getStringTopic("version").subscribe("");
+
+        atflPublisher = photonvision_root_table.getStringTopic("apriltag_field_layout").publish();
+        // Save the layout locally on Rio; on reboot, should be pushed out to NT clients
+        atflPublisher.getTopic().setPersistent(true);
+
+        m_topicNameSubscriber =
+                new MultiSubscriber(
+                        instance, new String[] {"/photonvision/"}, PubSubOption.topicsOnly(true));
+    }
+
+    /**
+     * Constructs a PhotonCamera from the name of the camera.
+     *
+     * @param cameraName The nickname of the camera (found in the PhotonVision UI).
+     */
+    public XbotPhotonCameraFork(String cameraName) {
+        this(NetworkTableInstance.getDefault(), cameraName);
+    }
+
+    /**
+     * Returns the latest pipeline result.
+     *
+     * @return The latest pipeline result.
+     */
+    public PhotonPipelineResult getLatestResult() {
+        verifyVersion();
+
+        // Clear the packet.
+        packet.clear();
+
+        // Create latest result.
+        var ret = new PhotonPipelineResult();
+
+        // Populate packet and create result.
+        packet.setData(rawBytesEntry.get(new byte[] {}));
+
+        if (packet.getSize() < 1) return ret;
+        ret.createFromPacket(packet);
+
+        // Set the timestamp of the result.
+        // getLatestChange returns in microseconds, so we divide by 1e6 to convert to seconds.
+        ret.setTimestampSeconds((rawBytesEntry.getLastChange() / 1e6) - ret.getLatencyMillis() / 1e3);
+
+        // Return result.
+        return ret;
+    }
+
+    /**
+     * Returns whether the camera is in driver mode.
+     *
+     * @return Whether the camera is in driver mode.
+     */
+    public boolean getDriverMode() {
+        return driverModeSubscriber.get();
+    }
+
+    /**
+     * Toggles driver mode.
+     *
+     * @param driverMode Whether to set driver mode.
+     */
+    public void setDriverMode(boolean driverMode) {
+        driverModePublisher.set(driverMode);
+    }
+
+    /**
+     * Request the camera to save a new image file from the input camera stream with overlays. Images
+     * take up space in the filesystem of the PhotonCamera. Calling it frequently will fill up disk
+     * space and eventually cause the system to stop working. Clear out images in
+     * /opt/photonvision/photonvision_config/imgSaves frequently to prevent issues.
+     */
+    public void takeInputSnapshot() {
+        inputSaveImgEntry.set(inputSaveImgEntry.get() + 1);
+    }
+
+    /**
+     * Request the camera to save a new image file from the output stream with overlays. Images take
+     * up space in the filesystem of the PhotonCamera. Calling it frequently will fill up disk space
+     * and eventually cause the system to stop working. Clear out images in
+     * /opt/photonvision/photonvision_config/imgSaves frequently to prevent issues.
+     */
+    public void takeOutputSnapshot() {
+        outputSaveImgEntry.set(outputSaveImgEntry.get() + 1);
+    }
+
+    /**
+     * Returns the active pipeline index.
+     *
+     * @return The active pipeline index.
+     */
+    public int getPipelineIndex() {
+        return (int) pipelineIndexState.get(0);
+    }
+
+    /**
+     * Allows the user to select the active pipeline index.
+     *
+     * @param index The active pipeline index.
+     */
+    public void setPipelineIndex(int index) {
+        pipelineIndexRequest.set(index);
+    }
+
+    /**
+     * Returns the current LED mode.
+     *
+     * @return The current LED mode.
+     */
+    public VisionLEDMode getLEDMode() {
+        int value = (int) ledModeState.get(-1);
+        switch (value) {
+            case 0:
+                return VisionLEDMode.kOff;
+            case 1:
+                return VisionLEDMode.kOn;
+            case 2:
+                return VisionLEDMode.kBlink;
+            case -1:
+            default:
+                return VisionLEDMode.kDefault;
+        }
+    }
+
+    /**
+     * Sets the LED mode.
+     *
+     * @param led The mode to set to.
+     */
+    public void setLED(VisionLEDMode led) {
+        ledModeRequest.set(led.value);
+    }
+
+    /**
+     * Returns whether the latest target result has targets.
+     *
+     * <p>This method is deprecated; {@link PhotonPipelineResult#hasTargets()} should be used instead.
+     *
+     * @deprecated This method should be replaced with {@link PhotonPipelineResult#hasTargets()}
+     * @return Whether the latest target result has targets.
+     */
+    @Deprecated
+    public boolean hasTargets() {
+        return getLatestResult().hasTargets();
+    }
+
+    /**
+     * Returns the name of the camera. This will return the same value that was given to the
+     * constructor as cameraName.
+     *
+     * @return The name of the camera.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns whether the camera is connected and actively returning new data. Connection status is
+     * debounced.
+     *
+     * @return True if the camera is actively sending frame data, false otherwise.
+     */
+    public boolean isConnected() {
+        var curHeartbeat = heartbeatEntry.get();
+        var now = Timer.getFPGATimestamp();
+
+        if (curHeartbeat != prevHeartbeatValue) {
+            // New heartbeat value from the coprocessor
+            prevHeartbeatChangeTime = now;
+            prevHeartbeatValue = curHeartbeat;
+        }
+
+        return (now - prevHeartbeatChangeTime) < HEARBEAT_DEBOUNCE_SEC;
+    }
+
+    // TODO: Implement ATFL subscribing in backend
+    // /**
+    //  * Get the last set {@link AprilTagFieldLayout}. The tag layout is shared between all
+    // PhotonVision
+    //  * coprocessors on the same NT instance-- this method returns the most recent layout set. If no
+    //  * layout has been set by the user, this is equal to {@link AprilTagFields#kDefaultField}.
+    //  *
+    //  * @return The last set layout
+    //  */
+    // public AprilTagFieldLayout getAprilTagFieldLayout() {
+    //     return lastSetTagLayout;
+    // }
+
+    // /**
+    //  * Set the {@link AprilTagFieldLayout} used by all PhotonVision coprocessors that are (or might
+    //  * later) connect to this robot. The topic is marked as persistent, so even if you only call
+    // this
+    //  * once ever, it will be saved on the RoboRIO and pushed out to all NT clients when code
+    // reboots.
+    //  * PhotonVision will also store a copy of this layout locally on the coprocessor, but
+    // subscribes
+    //  * to this topic and the local copy will be updated when this function is called.
+    //  *
+    //  * @param layout The layout to use for *all* PhotonVision cameras
+    //  * @return Success of serializing the JSON. This does *not* mean that all PhotonVision clients
+    //  *     have updated their internal layouts.
+    //  */
+    // public boolean setAprilTagFieldLayout(AprilTagFieldLayout layout) {
+    //     try {
+    //         var layout_json = new ObjectMapper().writeValueAsString(layout);
+    //         atflPublisher.set(layout_json);
+    //         lastSetTagLayout = layout;
+    //         return true;
+    //     } catch (JsonProcessingException e) {
+    //         MathSharedStore.reportError("Error setting ATFL in " + this.getName(),
+    // e.getStackTrace());
+    //     }
+    //     return false;
+    // }
+
+    public Optional<Matrix<N3, N3>> getCameraMatrix() {
+        var cameraMatrix = cameraIntrinsicsSubscriber.get();
+        if (cameraMatrix != null && cameraMatrix.length == 9) {
+            return Optional.of(MatBuilder.fill(Nat.N3(), Nat.N3(), cameraMatrix));
+        } else return Optional.empty();
+    }
+
+    public Optional<Matrix<N5, N1>> getDistCoeffs() {
+        var distCoeffs = cameraDistortionSubscriber.get();
+        if (distCoeffs != null && distCoeffs.length == 5) {
+            return Optional.of(MatBuilder.fill(Nat.N5(), Nat.N1(), distCoeffs));
+        } else return Optional.empty();
+    }
+
+    public double[] getCameraMatrixRaw() {
+        return cameraIntrinsicsSubscriber.get();
+    }
+
+    public double[] getDistCoeffsRaw() {
+        return cameraDistortionSubscriber.get();
+    }
+
+    /**
+     * Gets the NetworkTable representing this camera's subtable. You probably don't ever need to call
+     * this.
+     */
+    public final NetworkTable getCameraTable() {
+        return cameraTable;
+    }
+
+    private void verifyVersion() {
+        if (!VERSION_CHECK_ENABLED) return;
+
+        if ((Timer.getFPGATimestamp() - lastVersionCheckTime) < VERSION_CHECK_INTERVAL) return;
+        lastVersionCheckTime = Timer.getFPGATimestamp();
+
+        // Heartbeat entry is assumed to always be present. If it's not present, we
+        // assume that a camera with that name was never connected in the first place.
+        if (!heartbeatEntry.exists()) {
+            Set<String> cameraNames = cameraTable.getInstance().getTable(kTableName).getSubTables();
+            if (cameraNames.isEmpty()) {
+                DriverStation.reportError(
+                        "Could not find any PhotonVision coprocessors on NetworkTables. Double check that PhotonVision is running, and that your camera is connected!",
+                        false);
+            } else {
+                DriverStation.reportError(
+                        "PhotonVision coprocessor at path "
+                                + path
+                                + " not found on NetworkTables. Double check that your camera names match!",
+                        true);
+                DriverStation.reportError(
+                        "Found the following PhotonVision cameras on NetworkTables:\n"
+                                + String.join("\n", cameraNames),
+                        false);
+            }
+        }
+        // Check for connection status. Warn if disconnected.
+        else if (!isConnected()) {
+            DriverStation.reportWarning(
+                    "PhotonVision coprocessor at path " + path + " is not sending new data.", true);
+        }
+
+        // Check for version. Warn if the versions aren't aligned.
+        String versionString = versionEntry.get("");
+        if (!versionString.equals("") && !PhotonVersion.versionMatches(versionString)) {
+            // Error on a verified version mismatch
+            // But stay silent otherwise
+            DriverStation.reportWarning(
+                    "Photon version "
+                            + PhotonVersion.versionString
+                            + " does not match coprocessor version "
+                            + versionString
+                            + "!",
+                    true);
+        }
+    }
+}

--- a/src/main/java/xbot/common/vision/XbotPhotonCameraFork.java
+++ b/src/main/java/xbot/common/vision/XbotPhotonCameraFork.java
@@ -196,7 +196,7 @@ public class XbotPhotonCameraFork implements AutoCloseable {
         packet.setData(rawBytesEntry.get(new byte[] {}));
 
         if (packet.getSize() < 1) return ret;
-        ret.createFromPacket(packet);
+        //ret.createFromPacket(packet);
 
         // Set the timestamp of the result.
         // getLatestChange returns in microseconds, so we divide by 1e6 to convert to seconds.

--- a/src/main/java/xbot/common/vision/XbotPhotonCameraFork.java
+++ b/src/main/java/xbot/common/vision/XbotPhotonCameraFork.java
@@ -23,12 +23,16 @@ package xbot.common.vision;
  * SOFTWARE.
  */
 
+//CHECKSTYLE:OFF
+
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.MatBuilder;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Nat;
-import edu.wpi.first.math.numbers.*;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
 import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.BooleanSubscriber;
 import edu.wpi.first.networktables.DoubleArrayPublisher;
@@ -70,9 +74,12 @@ public class XbotPhotonCameraFork implements AutoCloseable {
     DoubleArrayPublisher targetPoseEntry;
     DoublePublisher targetSkewEntry;
     StringSubscriber versionEntry;
-    IntegerEntry inputSaveImgEntry, outputSaveImgEntry;
-    IntegerPublisher pipelineIndexRequest, ledModeRequest;
-    IntegerSubscriber pipelineIndexState, ledModeState;
+    IntegerEntry inputSaveImgEntry;
+    IntegerEntry outputSaveImgEntry;
+    IntegerPublisher pipelineIndexRequest;
+    IntegerPublisher ledModeRequest;
+    IntegerSubscriber pipelineIndexState;
+    IntegerSubscriber ledModeState;
     IntegerSubscriber heartbeatEntry;
     private DoubleArraySubscriber cameraIntrinsicsSubscriber;
     private DoubleArraySubscriber cameraDistortionSubscriber;
@@ -415,7 +422,8 @@ public class XbotPhotonCameraFork implements AutoCloseable {
             Set<String> cameraNames = cameraTable.getInstance().getTable(kTableName).getSubTables();
             if (cameraNames.isEmpty()) {
                 DriverStation.reportError(
-                        "Could not find any PhotonVision coprocessors on NetworkTables. Double check that PhotonVision is running, and that your camera is connected!",
+                        "Could not find any PhotonVision coprocessors on NetworkTables. " +
+                                "Double check that PhotonVision is running, and that your camera is connected!",
                         false);
             } else {
                 DriverStation.reportError(

--- a/src/main/java/xbot/common/vision/XbotPhotonPoseEstimatorFork.java
+++ b/src/main/java/xbot/common/vision/XbotPhotonPoseEstimatorFork.java
@@ -1,0 +1,751 @@
+package xbot.common.vision;
+/*
+ * MIT License
+ *
+ * Copyright (c) PhotonVision
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Pair;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
+import edu.wpi.first.wpilibj.DriverStation;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+import org.photonvision.estimation.TargetModel;
+import org.photonvision.estimation.VisionEstimation;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+import xbot.common.controls.sensors.XPhotonCamera;
+
+/**
+ * The PhotonPoseEstimator class filters or combines readings from all the AprilTags visible at a
+ * given timestamp on the field to produce a single robot in field pose, using the strategy set
+ * below. Example usage can be found in our apriltagExample example project.
+ */
+public class XbotPhotonPoseEstimatorFork {
+    /** Position estimation strategies that can be used by the {@link org.photonvision.PhotonPoseEstimator} class. */
+    public enum PoseStrategy {
+        /** Choose the Pose with the lowest ambiguity. */
+        LOWEST_AMBIGUITY,
+
+        /** Choose the Pose which is closest to the camera height. */
+        CLOSEST_TO_CAMERA_HEIGHT,
+
+        /** Choose the Pose which is closest to a set Reference position. */
+        CLOSEST_TO_REFERENCE_POSE,
+
+        /** Choose the Pose which is closest to the last pose calculated */
+        CLOSEST_TO_LAST_POSE,
+
+        /** Return the average of the best target poses using ambiguity as weight. */
+        AVERAGE_BEST_TARGETS,
+
+        /**
+         * Use all visible tags to compute a single pose estimate on coprocessor. This option needs to
+         * be enabled on the PhotonVision web UI as well.
+         */
+        MULTI_TAG_PNP_ON_COPROCESSOR,
+
+        /**
+         * Use all visible tags to compute a single pose estimate. This runs on the RoboRIO, and can
+         * take a lot of time.
+         */
+        MULTI_TAG_PNP_ON_RIO
+    }
+
+    private AprilTagFieldLayout fieldTags;
+    private TargetModel tagModel = TargetModel.kAprilTag16h5;
+    private org.photonvision.PhotonPoseEstimator.PoseStrategy primaryStrategy;
+    private org.photonvision.PhotonPoseEstimator.PoseStrategy multiTagFallbackStrategy = org.photonvision.PhotonPoseEstimator.PoseStrategy.LOWEST_AMBIGUITY;
+    private final XPhotonCamera camera;
+    private Transform3d robotToCamera;
+
+    private Pose3d lastPose;
+    private Pose3d referencePose;
+    protected double poseCacheTimestampSeconds = -1;
+    private final Set<Integer> reportedErrors = new HashSet<>();
+
+    /**
+     * Create a new PhotonPoseEstimator.
+     *
+     * @param fieldTags A WPILib {@link AprilTagFieldLayout} linking AprilTag IDs to Pose3d objects
+     *     with respect to the FIRST field using the <a href=
+     *     "https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#field-coordinate-system">Field
+     *     Coordinate System</a>. Note that setting the origin of this layout object will affect the
+     *     results from this class.
+     * @param strategy The strategy it should use to determine the best pose.
+     * @param camera PhotonCamera
+     * @param robotToCamera Transform3d from the center of the robot to the camera mount position (ie,
+     *     robot ➔ camera) in the <a href=
+     *     "https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#robot-coordinate-system">Robot
+     *     Coordinate System</a>.
+     */
+    public XbotPhotonPoseEstimatorFork(
+            AprilTagFieldLayout fieldTags,
+            org.photonvision.PhotonPoseEstimator.PoseStrategy strategy,
+            XPhotonCamera camera,
+            Transform3d robotToCamera) {
+        this.fieldTags = fieldTags;
+        this.primaryStrategy = strategy;
+        this.camera = camera;
+        this.robotToCamera = robotToCamera;
+    }
+
+    public XbotPhotonPoseEstimatorFork(
+            AprilTagFieldLayout fieldTags, org.photonvision.PhotonPoseEstimator.PoseStrategy strategy, Transform3d robotToCamera) {
+        this.fieldTags = fieldTags;
+        this.primaryStrategy = strategy;
+        this.camera = null;
+        this.robotToCamera = robotToCamera;
+    }
+
+    /** Invalidates the pose cache. */
+    private void invalidatePoseCache() {
+        poseCacheTimestampSeconds = -1;
+    }
+
+    private void checkUpdate(Object oldObj, Object newObj) {
+        if (oldObj != newObj && oldObj != null && !oldObj.equals(newObj)) {
+            invalidatePoseCache();
+        }
+    }
+
+    /**
+     * Get the AprilTagFieldLayout being used by the PositionEstimator.
+     *
+     * <p>Note: Setting the origin of this layout will affect the results from this class.
+     *
+     * @return the AprilTagFieldLayout
+     */
+    public AprilTagFieldLayout getFieldTags() {
+        return fieldTags;
+    }
+
+    /**
+     * Set the AprilTagFieldLayout being used by the PositionEstimator.
+     *
+     * <p>Note: Setting the origin of this layout will affect the results from this class.
+     *
+     * @param fieldTags the AprilTagFieldLayout
+     */
+    public void setFieldTags(AprilTagFieldLayout fieldTags) {
+        checkUpdate(this.fieldTags, fieldTags);
+        this.fieldTags = fieldTags;
+    }
+
+    /**
+     * Get the TargetModel representing the tags being detected. This is used for on-rio multitag.
+     *
+     * <p>By default, this is {@link TargetModel#kAprilTag16h5}.
+     */
+    public TargetModel getTagModel() {
+        return tagModel;
+    }
+
+    /**
+     * Set the TargetModel representing the tags being detected. This is used for on-rio multitag.
+     *
+     * @param tagModel E.g. {@link TargetModel#kAprilTag16h5}.
+     */
+    public void setTagModel(TargetModel tagModel) {
+        this.tagModel = tagModel;
+    }
+
+    /**
+     * Get the Position Estimation Strategy being used by the Position Estimator.
+     *
+     * @return the strategy
+     */
+    public org.photonvision.PhotonPoseEstimator.PoseStrategy getPrimaryStrategy() {
+        return primaryStrategy;
+    }
+
+    /**
+     * Set the Position Estimation Strategy used by the Position Estimator.
+     *
+     * @param strategy the strategy to set
+     */
+    public void setPrimaryStrategy(org.photonvision.PhotonPoseEstimator.PoseStrategy strategy) {
+        checkUpdate(this.primaryStrategy, strategy);
+        this.primaryStrategy = strategy;
+    }
+
+    /**
+     * Set the Position Estimation Strategy used in multi-tag mode when only one tag can be seen. Must
+     * NOT be MULTI_TAG_PNP
+     *
+     * @param strategy the strategy to set
+     */
+    public void setMultiTagFallbackStrategy(org.photonvision.PhotonPoseEstimator.PoseStrategy strategy) {
+        checkUpdate(this.multiTagFallbackStrategy, strategy);
+        if (strategy == org.photonvision.PhotonPoseEstimator.PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR
+                || strategy == org.photonvision.PhotonPoseEstimator.PoseStrategy.MULTI_TAG_PNP_ON_RIO) {
+            DriverStation.reportWarning(
+                    "Fallback cannot be set to MULTI_TAG_PNP! Setting to lowest ambiguity", false);
+            strategy = org.photonvision.PhotonPoseEstimator.PoseStrategy.LOWEST_AMBIGUITY;
+        }
+        this.multiTagFallbackStrategy = strategy;
+    }
+
+    /**
+     * Return the reference position that is being used by the estimator.
+     *
+     * @return the referencePose
+     */
+    public Pose3d getReferencePose() {
+        return referencePose;
+    }
+
+    /**
+     * Update the stored reference pose for use when using the <b>CLOSEST_TO_REFERENCE_POSE</b>
+     * strategy.
+     *
+     * @param referencePose the referencePose to set
+     */
+    public void setReferencePose(Pose3d referencePose) {
+        checkUpdate(this.referencePose, referencePose);
+        this.referencePose = referencePose;
+    }
+
+    /**
+     * Update the stored reference pose for use when using the <b>CLOSEST_TO_REFERENCE_POSE</b>
+     * strategy.
+     *
+     * @param referencePose the referencePose to set
+     */
+    public void setReferencePose(Pose2d referencePose) {
+        setReferencePose(new Pose3d(referencePose));
+    }
+
+    /**
+     * Update the stored last pose. Useful for setting the initial estimate when using the
+     * <b>CLOSEST_TO_LAST_POSE</b> strategy.
+     *
+     * @param lastPose the lastPose to set
+     */
+    public void setLastPose(Pose3d lastPose) {
+        this.lastPose = lastPose;
+    }
+
+    /**
+     * Update the stored last pose. Useful for setting the initial estimate when using the
+     * <b>CLOSEST_TO_LAST_POSE</b> strategy.
+     *
+     * @param lastPose the lastPose to set
+     */
+    public void setLastPose(Pose2d lastPose) {
+        setLastPose(new Pose3d(lastPose));
+    }
+
+    /**
+     * @return The current transform from the center of the robot to the camera mount position
+     */
+    public Transform3d getRobotToCameraTransform() {
+        return robotToCamera;
+    }
+
+    /**
+     * Useful for pan and tilt mechanisms and such.
+     *
+     * @param robotToCamera The current transform from the center of the robot to the camera mount
+     *     position
+     */
+    public void setRobotToCameraTransform(Transform3d robotToCamera) {
+        this.robotToCamera = robotToCamera;
+    }
+
+    /**
+     * Poll data from the configured cameras and update the estimated position of the robot. Returns
+     * empty if:
+     *
+     * <ul>
+     *   <li>New data has not been received since the last call to {@code update()}.
+     *   <li>No targets were found from the camera
+     *   <li>There is no camera set
+     * </ul>
+     *
+     * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and targets used to
+     *     create the estimate.
+     */
+    public Optional<EstimatedRobotPose> update() {
+        if (camera == null) {
+            DriverStation.reportError("[PhotonPoseEstimator] Missing camera!", false);
+            return Optional.empty();
+        }
+
+        PhotonPipelineResult cameraResult = camera.getLatestResult();
+
+        return update(cameraResult, camera.getCameraMatrix(), camera.getDistCoeffs());
+    }
+
+    /**
+     * Updates the estimated position of the robot. Returns empty if:
+     *
+     * <ul>
+     *   <li>The timestamp of the provided pipeline result is the same as in the previous call to
+     *       {@code update()}.
+     *   <li>No targets were found in the pipeline results.
+     * </ul>
+     *
+     * @param cameraResult The latest pipeline result from the camera
+     * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and targets used to
+     *     create the estimate.
+     */
+    public Optional<EstimatedRobotPose> update(PhotonPipelineResult cameraResult) {
+        if (camera == null) return update(cameraResult, Optional.empty(), Optional.empty());
+        return update(cameraResult, camera.getCameraMatrix(), camera.getDistCoeffs());
+    }
+
+    /**
+     * Updates the estimated position of the robot. Returns empty if:
+     *
+     * <ul>
+     *   <li>The timestamp of the provided pipeline result is the same as in the previous call to
+     *       {@code update()}.
+     *   <li>No targets were found in the pipeline results.
+     * </ul>
+     *
+     * @param cameraMatrix Camera calibration data that can be used in the case of no assigned
+     *     PhotonCamera.
+     * @param distCoeffs Camera calibration data that can be used in the case of no assigned
+     *     PhotonCamera
+     * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and targets used to
+     *     create the estimate.
+     */
+    public Optional<EstimatedRobotPose> update(
+            PhotonPipelineResult cameraResult,
+            Optional<Matrix<N3, N3>> cameraMatrix,
+            Optional<Matrix<N5, N1>> distCoeffs) {
+        // Time in the past -- give up, since the following if expects times > 0
+        if (cameraResult.getTimestampSeconds() < 0) {
+            return Optional.empty();
+        }
+
+        // If the pose cache timestamp was set, and the result is from the same
+        // timestamp, return an
+        // empty result
+        if (poseCacheTimestampSeconds > 0
+                && Math.abs(poseCacheTimestampSeconds - cameraResult.getTimestampSeconds()) < 1e-6) {
+            return Optional.empty();
+        }
+
+        // Remember the timestamp of the current result used
+        poseCacheTimestampSeconds = cameraResult.getTimestampSeconds();
+
+        // If no targets seen, trivial case -- return empty result
+        if (!cameraResult.hasTargets()) {
+            return Optional.empty();
+        }
+
+        return update(cameraResult, cameraMatrix, distCoeffs, this.primaryStrategy);
+    }
+
+    private Optional<EstimatedRobotPose> update(
+            PhotonPipelineResult cameraResult,
+            Optional<Matrix<N3, N3>> cameraMatrix,
+            Optional<Matrix<N5, N1>> distCoeffs,
+            org.photonvision.PhotonPoseEstimator.PoseStrategy strat) {
+        Optional<EstimatedRobotPose> estimatedPose;
+        switch (strat) {
+            case LOWEST_AMBIGUITY:
+                estimatedPose = lowestAmbiguityStrategy(cameraResult);
+                break;
+            case CLOSEST_TO_CAMERA_HEIGHT:
+                estimatedPose = closestToCameraHeightStrategy(cameraResult);
+                break;
+            case CLOSEST_TO_REFERENCE_POSE:
+                estimatedPose = closestToReferencePoseStrategy(cameraResult, referencePose);
+                break;
+            case CLOSEST_TO_LAST_POSE:
+                setReferencePose(lastPose);
+                estimatedPose = closestToReferencePoseStrategy(cameraResult, referencePose);
+                break;
+            case AVERAGE_BEST_TARGETS:
+                estimatedPose = averageBestTargetsStrategy(cameraResult);
+                break;
+            case MULTI_TAG_PNP_ON_RIO:
+                estimatedPose = multiTagOnRioStrategy(cameraResult, cameraMatrix, distCoeffs);
+                break;
+            case MULTI_TAG_PNP_ON_COPROCESSOR:
+                estimatedPose = multiTagOnCoprocStrategy(cameraResult, cameraMatrix, distCoeffs);
+                break;
+            default:
+                DriverStation.reportError(
+                        "[PhotonPoseEstimator] Unknown Position Estimation Strategy!", false);
+                return Optional.empty();
+        }
+
+        if (estimatedPose.isEmpty()) {
+            lastPose = null;
+        }
+
+        return estimatedPose;
+    }
+
+    private Optional<EstimatedRobotPose> multiTagOnCoprocStrategy(
+            PhotonPipelineResult result,
+            Optional<Matrix<N3, N3>> cameraMatrixOpt,
+            Optional<Matrix<N5, N1>> distCoeffsOpt) {
+        if (result.getMultiTagResult().estimatedPose.isPresent) {
+            var best_tf = result.getMultiTagResult().estimatedPose.best;
+            var best =
+                    new Pose3d()
+                            .plus(best_tf) // field-to-camera
+                            .relativeTo(fieldTags.getOrigin())
+                            .plus(robotToCamera.inverse()); // field-to-robot
+            return Optional.of(
+                    new EstimatedRobotPose(
+                            best,
+                            result.getTimestampSeconds(),
+                            result.getTargets(),
+                            org.photonvision.PhotonPoseEstimator.PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR));
+        } else {
+            return update(result, cameraMatrixOpt, distCoeffsOpt, this.multiTagFallbackStrategy);
+        }
+    }
+
+    private Optional<EstimatedRobotPose> multiTagOnRioStrategy(
+            PhotonPipelineResult result,
+            Optional<Matrix<N3, N3>> cameraMatrixOpt,
+            Optional<Matrix<N5, N1>> distCoeffsOpt) {
+        boolean hasCalibData = cameraMatrixOpt.isPresent() && distCoeffsOpt.isPresent();
+        // cannot run multitagPNP, use fallback strategy
+        if (!hasCalibData || result.getTargets().size() < 2) {
+            return update(result, cameraMatrixOpt, distCoeffsOpt, this.multiTagFallbackStrategy);
+        }
+
+        var pnpResults =
+                VisionEstimation.estimateCamPosePNP(
+                        cameraMatrixOpt.get(), distCoeffsOpt.get(), result.getTargets(), fieldTags, tagModel);
+        // try fallback strategy if solvePNP fails for some reason
+        if (!pnpResults.isPresent)
+            return update(result, cameraMatrixOpt, distCoeffsOpt, this.multiTagFallbackStrategy);
+        var best =
+                new Pose3d()
+                        .plus(pnpResults.best) // field-to-camera
+                        .plus(robotToCamera.inverse()); // field-to-robot
+
+        return Optional.of(
+                new EstimatedRobotPose(
+                        best,
+                        result.getTimestampSeconds(),
+                        result.getTargets(),
+                        org.photonvision.PhotonPoseEstimator.PoseStrategy.MULTI_TAG_PNP_ON_RIO));
+    }
+
+    /**
+     * Return the estimated position of the robot with the lowest position ambiguity from a List of
+     * pipeline results.
+     *
+     * @param result pipeline result
+     * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+     *     estimation.
+     */
+    private Optional<EstimatedRobotPose> lowestAmbiguityStrategy(PhotonPipelineResult result) {
+        PhotonTrackedTarget lowestAmbiguityTarget = null;
+
+        double lowestAmbiguityScore = 10;
+
+        for (PhotonTrackedTarget target : result.targets) {
+            double targetPoseAmbiguity = target.getPoseAmbiguity();
+            // Make sure the target is a Fiducial target.
+            if (targetPoseAmbiguity != -1 && targetPoseAmbiguity < lowestAmbiguityScore) {
+                lowestAmbiguityScore = targetPoseAmbiguity;
+                lowestAmbiguityTarget = target;
+            }
+        }
+
+        // Although there are confirmed to be targets, none of them may be fiducial
+        // targets.
+        if (lowestAmbiguityTarget == null) return Optional.empty();
+
+        int targetFiducialId = lowestAmbiguityTarget.getFiducialId();
+
+        Optional<Pose3d> targetPosition = fieldTags.getTagPose(targetFiducialId);
+
+        if (targetPosition.isEmpty()) {
+            reportFiducialPoseError(targetFiducialId);
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new EstimatedRobotPose(
+                        targetPosition
+                                .get()
+                                .transformBy(lowestAmbiguityTarget.getBestCameraToTarget().inverse())
+                                .transformBy(robotToCamera.inverse()),
+                        result.getTimestampSeconds(),
+                        result.getTargets(),
+                        org.photonvision.PhotonPoseEstimator.PoseStrategy.LOWEST_AMBIGUITY));
+    }
+
+    /**
+     * Return the estimated position of the robot using the target with the lowest delta height
+     * difference between the estimated and actual height of the camera.
+     *
+     * @param result pipeline result
+     * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+     *     estimation.
+     */
+    private Optional<EstimatedRobotPose> closestToCameraHeightStrategy(PhotonPipelineResult result) {
+        double smallestHeightDifference = 10e9;
+        EstimatedRobotPose closestHeightTarget = null;
+
+        for (PhotonTrackedTarget target : result.targets) {
+            int targetFiducialId = target.getFiducialId();
+
+            // Don't report errors for non-fiducial targets. This could also be resolved by
+            // adding -1 to
+            // the initial HashSet.
+            if (targetFiducialId == -1) continue;
+
+            Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
+
+            if (targetPosition.isEmpty()) {
+                reportFiducialPoseError(target.getFiducialId());
+                continue;
+            }
+
+            double alternateTransformDelta =
+                    Math.abs(
+                            robotToCamera.getZ()
+                                    - targetPosition
+                                    .get()
+                                    .transformBy(target.getAlternateCameraToTarget().inverse())
+                                    .getZ());
+            double bestTransformDelta =
+                    Math.abs(
+                            robotToCamera.getZ()
+                                    - targetPosition
+                                    .get()
+                                    .transformBy(target.getBestCameraToTarget().inverse())
+                                    .getZ());
+
+            if (alternateTransformDelta < smallestHeightDifference) {
+                smallestHeightDifference = alternateTransformDelta;
+                closestHeightTarget =
+                        new EstimatedRobotPose(
+                                targetPosition
+                                        .get()
+                                        .transformBy(target.getAlternateCameraToTarget().inverse())
+                                        .transformBy(robotToCamera.inverse()),
+                                result.getTimestampSeconds(),
+                                result.getTargets(),
+                                org.photonvision.PhotonPoseEstimator.PoseStrategy.CLOSEST_TO_CAMERA_HEIGHT);
+            }
+
+            if (bestTransformDelta < smallestHeightDifference) {
+                smallestHeightDifference = bestTransformDelta;
+                closestHeightTarget =
+                        new EstimatedRobotPose(
+                                targetPosition
+                                        .get()
+                                        .transformBy(target.getBestCameraToTarget().inverse())
+                                        .transformBy(robotToCamera.inverse()),
+                                result.getTimestampSeconds(),
+                                result.getTargets(),
+                                org.photonvision.PhotonPoseEstimator.PoseStrategy.CLOSEST_TO_CAMERA_HEIGHT);
+            }
+        }
+
+        // Need to null check here in case none of the provided targets are fiducial.
+        return Optional.ofNullable(closestHeightTarget);
+    }
+
+    /**
+     * Return the estimated position of the robot using the target with the lowest delta in the vector
+     * magnitude between it and the reference pose.
+     *
+     * @param result pipeline result
+     * @param referencePose reference pose to check vector magnitude difference against.
+     * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+     *     estimation.
+     */
+    private Optional<EstimatedRobotPose> closestToReferencePoseStrategy(
+            PhotonPipelineResult result, Pose3d referencePose) {
+        if (referencePose == null) {
+            DriverStation.reportError(
+                    "[PhotonPoseEstimator] Tried to use reference pose strategy without setting the reference!",
+                    false);
+            return Optional.empty();
+        }
+
+        double smallestPoseDelta = 10e9;
+        EstimatedRobotPose lowestDeltaPose = null;
+
+        for (PhotonTrackedTarget target : result.targets) {
+            int targetFiducialId = target.getFiducialId();
+
+            // Don't report errors for non-fiducial targets. This could also be resolved by
+            // adding -1 to
+            // the initial HashSet.
+            if (targetFiducialId == -1) continue;
+
+            Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
+
+            if (targetPosition.isEmpty()) {
+                reportFiducialPoseError(targetFiducialId);
+                continue;
+            }
+
+            Pose3d altTransformPosition =
+                    targetPosition
+                            .get()
+                            .transformBy(target.getAlternateCameraToTarget().inverse())
+                            .transformBy(robotToCamera.inverse());
+            Pose3d bestTransformPosition =
+                    targetPosition
+                            .get()
+                            .transformBy(target.getBestCameraToTarget().inverse())
+                            .transformBy(robotToCamera.inverse());
+
+            double altDifference = Math.abs(calculateDifference(referencePose, altTransformPosition));
+            double bestDifference = Math.abs(calculateDifference(referencePose, bestTransformPosition));
+
+            if (altDifference < smallestPoseDelta) {
+                smallestPoseDelta = altDifference;
+                lowestDeltaPose =
+                        new EstimatedRobotPose(
+                                altTransformPosition,
+                                result.getTimestampSeconds(),
+                                result.getTargets(),
+                                org.photonvision.PhotonPoseEstimator.PoseStrategy.CLOSEST_TO_REFERENCE_POSE);
+            }
+            if (bestDifference < smallestPoseDelta) {
+                smallestPoseDelta = bestDifference;
+                lowestDeltaPose =
+                        new EstimatedRobotPose(
+                                bestTransformPosition,
+                                result.getTimestampSeconds(),
+                                result.getTargets(),
+                                org.photonvision.PhotonPoseEstimator.PoseStrategy.CLOSEST_TO_REFERENCE_POSE);
+            }
+        }
+        return Optional.ofNullable(lowestDeltaPose);
+    }
+
+    /**
+     * Return the average of the best target poses using ambiguity as weight.
+     *
+     * @param result pipeline result
+     * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+     *     estimation.
+     */
+    private Optional<EstimatedRobotPose> averageBestTargetsStrategy(PhotonPipelineResult result) {
+        List<Pair<PhotonTrackedTarget, Pose3d>> estimatedRobotPoses = new ArrayList<>();
+        double totalAmbiguity = 0;
+
+        for (PhotonTrackedTarget target : result.targets) {
+            int targetFiducialId = target.getFiducialId();
+
+            // Don't report errors for non-fiducial targets. This could also be resolved by
+            // adding -1 to
+            // the initial HashSet.
+            if (targetFiducialId == -1) continue;
+
+            Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
+
+            if (targetPosition.isEmpty()) {
+                reportFiducialPoseError(targetFiducialId);
+                continue;
+            }
+
+            double targetPoseAmbiguity = target.getPoseAmbiguity();
+
+            // Pose ambiguity is 0, use that pose
+            if (targetPoseAmbiguity == 0) {
+                return Optional.of(
+                        new EstimatedRobotPose(
+                                targetPosition
+                                        .get()
+                                        .transformBy(target.getBestCameraToTarget().inverse())
+                                        .transformBy(robotToCamera.inverse()),
+                                result.getTimestampSeconds(),
+                                result.getTargets(),
+                                org.photonvision.PhotonPoseEstimator.PoseStrategy.AVERAGE_BEST_TARGETS));
+            }
+
+            totalAmbiguity += 1.0 / target.getPoseAmbiguity();
+
+            estimatedRobotPoses.add(
+                    new Pair<>(
+                            target,
+                            targetPosition
+                                    .get()
+                                    .transformBy(target.getBestCameraToTarget().inverse())
+                                    .transformBy(robotToCamera.inverse())));
+        }
+
+        // Take the average
+
+        Translation3d transform = new Translation3d();
+        Rotation3d rotation = new Rotation3d();
+
+        if (estimatedRobotPoses.isEmpty()) return Optional.empty();
+
+        for (Pair<PhotonTrackedTarget, Pose3d> pair : estimatedRobotPoses) {
+            // Total ambiguity is non-zero confirmed because if it was zero, that pose was
+            // returned.
+            double weight = (1.0 / pair.getFirst().getPoseAmbiguity()) / totalAmbiguity;
+            Pose3d estimatedPose = pair.getSecond();
+            transform = transform.plus(estimatedPose.getTranslation().times(weight));
+            rotation = rotation.plus(estimatedPose.getRotation().times(weight));
+        }
+
+        return Optional.of(
+                new EstimatedRobotPose(
+                        new Pose3d(transform, rotation),
+                        result.getTimestampSeconds(),
+                        result.getTargets(),
+                        org.photonvision.PhotonPoseEstimator.PoseStrategy.AVERAGE_BEST_TARGETS));
+    }
+
+    /**
+     * Difference is defined as the vector magnitude between the two poses
+     *
+     * @return The absolute "difference" (>=0) between two Pose3ds.
+     */
+    private double calculateDifference(Pose3d x, Pose3d y) {
+        return x.getTranslation().getDistance(y.getTranslation());
+    }
+
+    private void reportFiducialPoseError(int fiducialId) {
+        if (!reportedErrors.contains(fiducialId)) {
+            DriverStation.reportError(
+                    "[PhotonPoseEstimator] Tried to get pose of unknown AprilTag: " + fiducialId, false);
+            reportedErrors.add(fiducialId);
+        }
+    }
+}

--- a/src/main/java/xbot/common/vision/XbotPhotonPoseEstimatorFork.java
+++ b/src/main/java/xbot/common/vision/XbotPhotonPoseEstimatorFork.java
@@ -49,6 +49,8 @@ import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
 import xbot.common.controls.sensors.XPhotonCamera;
 
+//CHECKSTYLE:OFF
+
 /**
  * The PhotonPoseEstimator class filters or combines readings from all the AprilTags visible at a
  * given timestamp on the field to produce a single robot in field pose, using the strategy set

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,0 +1,42 @@
+{
+  "fileName": "photonlib.json",
+  "name": "photonlib",
+  "version": "v2024.1.1-beta-3.2",
+  "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
+  "frcYear": "2024",
+  "mavenUrls": [
+    "https://maven.photonvision.org/repository/internal",
+    "https://maven.photonvision.org/repository/snapshots"
+  ],
+  "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/PhotonLib-json/1.0/PhotonLib-json-1.0.json",
+  "jniDependencies": [],
+  "cppDependencies": [
+    {
+      "groupId": "org.photonvision",
+      "artifactId": "PhotonLib-cpp",
+      "version": "v2024.1.1-beta-3.2",
+      "libName": "Photon",
+      "headerClassifier": "headers",
+      "sharedLibrary": true,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "windowsx86-64",
+        "linuxathena",
+        "linuxx86-64",
+        "osxuniversal"
+      ]
+    }
+  ],
+  "javaDependencies": [
+    {
+      "groupId": "org.photonvision",
+      "artifactId": "PhotonLib-java",
+      "version": "v2024.1.1-beta-3.2"
+    },
+    {
+      "groupId": "org.photonvision",
+      "artifactId": "PhotonTargeting-java",
+      "version": "v2024.1.1-beta-3.2"
+    }
+  ]
+}

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,21 +1,36 @@
 {
   "fileName": "photonlib.json",
   "name": "photonlib",
-  "version": "v2024.1.1-beta-3.2",
+  "version": "v2024.1.4",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
   "frcYear": "2024",
   "mavenUrls": [
     "https://maven.photonvision.org/repository/internal",
     "https://maven.photonvision.org/repository/snapshots"
   ],
-  "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/PhotonLib-json/1.0/PhotonLib-json-1.0.json",
+  "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/photonlib-json/1.0/photonlib-json-1.0.json",
   "jniDependencies": [],
   "cppDependencies": [
     {
       "groupId": "org.photonvision",
-      "artifactId": "PhotonLib-cpp",
-      "version": "v2024.1.1-beta-3.2",
-      "libName": "Photon",
+      "artifactId": "photonlib-cpp",
+      "version": "v2024.1.4",
+      "libName": "photonlib",
+      "headerClassifier": "headers",
+      "sharedLibrary": true,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "windowsx86-64",
+        "linuxathena",
+        "linuxx86-64",
+        "osxuniversal"
+      ]
+    },
+    {
+      "groupId": "org.photonvision",
+      "artifactId": "photontargeting-cpp",
+      "version": "v2024.1.4",
+      "libName": "photontargeting",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,
@@ -30,13 +45,13 @@
   "javaDependencies": [
     {
       "groupId": "org.photonvision",
-      "artifactId": "PhotonLib-java",
-      "version": "v2024.1.1-beta-3.2"
+      "artifactId": "photonlib-java",
+      "version": "v2024.1.4"
     },
     {
       "groupId": "org.photonvision",
-      "artifactId": "PhotonTargeting-java",
-      "version": "v2024.1.1-beta-3.2"
+      "artifactId": "photontargeting-java",
+      "version": "v2024.1.4"
     }
   ]
 }


### PR DESCRIPTION
* Use some more modern AKIT conventions (stop Logger instance, use the new "/U/Logs" call to automatically write to a USB drive)
* Make XYPair serializable for AKIT
* Update PhotonVision
* Start writing code for an AKIT-ready camera (PV needs to release v2024.1.5+ so objects can be serialized for Akit)
* Update CANCoder to Phoenix6 so we can use the "auto-zero" button in Phoenix Tuner X