### PR TITLE
Fix logging when property values are non-default

### DIFF
--- a/src/main/java/xbot/common/properties/BooleanProperty.java
+++ b/src/main/java/xbot/common/properties/BooleanProperty.java
@@ -74,8 +74,10 @@ public class BooleanProperty extends Property {
     public void load() {
         Boolean value = permanentStore.getBoolean(key);
         if (value != null) {
-            set(value.booleanValue());
-            log.info("Property " + key + " has the non-default value " + value.booleanValue());
+            set(value);
+            if (value != defaultValue) {
+                log.info("Property " + key + " has the non-default value " + value);
+            }
         } else {
             set(defaultValue);
         }

--- a/src/main/java/xbot/common/properties/DoubleProperty.java
+++ b/src/main/java/xbot/common/properties/DoubleProperty.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
  * @author Alex
  */
 public class DoubleProperty extends Property {
-    double defaultValue;
+    private final double defaultValue;
     double lastValue;
 
     public DoubleProperty(String name, double defaultValue, XPropertyManager manager) {
@@ -46,7 +46,7 @@ public class DoubleProperty extends Property {
             return defaultValue;
         }
         
-        return nullableTableValue.doubleValue();
+        return nullableTableValue;
     }
     
     public void set(double value) {
@@ -68,8 +68,10 @@ public class DoubleProperty extends Property {
     public void load() {
         Double value = permanentStore.getDouble(key);
         if(value != null) {
-            log.info("Property " + key + " has the non-default value " + value.doubleValue());
-            randomAccessStore.setDouble(key, value.doubleValue());
+            randomAccessStore.setDouble(key, value);
+            if (value != defaultValue) {
+                log.info("Property " + key + " has the non-default value " + value);
+            }
         } else {
             set(defaultValue);
         }

--- a/src/main/java/xbot/common/properties/StringProperty.java
+++ b/src/main/java/xbot/common/properties/StringProperty.java
@@ -11,7 +11,7 @@ package xbot.common.properties;
  * @author Sterling
  */
 public class StringProperty extends Property {
-    private String defaultValue;
+    private final String defaultValue;
     
     public StringProperty(String name, String defaultValue, XPropertyManager manager) {
         super(name, manager);
@@ -60,7 +60,9 @@ public class StringProperty extends Property {
         String value = permanentStore.getString(key);
         if(value != null) {
             set(value);
-            log.info("Property " + key + " has the non-default value " + value);
+            if (!value.equals(defaultValue)) {
+                log.info("Property " + key + " has the non-default value " + value);
+            }
         } else {
             set(defaultValue);
         }


### PR DESCRIPTION
# Why are we doing this?
Bug introduced when default properties were persisted to storage again.

# Whats changing?
Only log if value is non-default.
Removed unboxing, java does auto-unboxing.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
