### PR TITLE
Move the swerve default command map to SCL

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDefaultCommandMap.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDefaultCommandMap.java
@@ -1,0 +1,47 @@
+package xbot.common.subsystems.drive.swerve;
+
+import xbot.common.injection.swerve.FrontLeftDrive;
+import xbot.common.injection.swerve.FrontRightDrive;
+import xbot.common.injection.swerve.RearLeftDrive;
+import xbot.common.injection.swerve.RearRightDrive;
+import xbot.common.injection.swerve.SwerveComponent;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Sets up the default commands for the swerve subsystems
+ */
+@Singleton
+public final class SwerveDefaultCommandMap {
+    @Inject
+    public SwerveDefaultCommandMap() {}
+
+    @Inject
+    public void setupFrontLeftSubsystems(
+            @FrontLeftDrive SwerveComponent swerveComponent) {
+        swerveComponent.swerveDriveSubsystem().setDefaultCommand(swerveComponent.swerveDriveMaintainerCommand());
+        swerveComponent.swerveSteeringSubsystem().setDefaultCommand(swerveComponent.swerveSteeringMaintainerCommand());
+    }
+
+    @Inject
+    public void setupFrontRightSubsystems(
+            @FrontRightDrive SwerveComponent swerveComponent) {
+        swerveComponent.swerveDriveSubsystem().setDefaultCommand(swerveComponent.swerveDriveMaintainerCommand());
+        swerveComponent.swerveSteeringSubsystem().setDefaultCommand(swerveComponent.swerveSteeringMaintainerCommand());
+    }
+
+    @Inject
+    public void setupRearLeftSubsystems(
+            @RearLeftDrive SwerveComponent swerveComponent) {
+        swerveComponent.swerveDriveSubsystem().setDefaultCommand(swerveComponent.swerveDriveMaintainerCommand());
+        swerveComponent.swerveSteeringSubsystem().setDefaultCommand(swerveComponent.swerveSteeringMaintainerCommand());
+    }
+
+    @Inject
+    public void setupRearRightSubsystems(
+            @RearRightDrive SwerveComponent swerveComponent) {
+        swerveComponent.swerveDriveSubsystem().setDefaultCommand(swerveComponent.swerveDriveMaintainerCommand());
+        swerveComponent.swerveSteeringSubsystem().setDefaultCommand(swerveComponent.swerveSteeringMaintainerCommand());
+    }
+}


### PR DESCRIPTION
# Why are we doing this?
This is code common to all swerve bots.

# Whats changing?
Move swerve injectors to common lib from robot code.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
