### PR TITLE
Add new version checking that won't crash the robot

### DIFF
--- a/src/main/java/org/photonvision/PhotonCameraExtended.java
+++ b/src/main/java/org/photonvision/PhotonCameraExtended.java
@@ -39,7 +39,8 @@ public class PhotonCameraExtended extends PhotonCamera {
         if (!versionString.isEmpty() && !PhotonVersion.versionMatches(versionString)) {
             // Error on a verified version mismatch
             // But stay silent otherwise
-            log.error("PhotonVision version mismatch. Expected: " + PhotonVersion.versionString + " Actual: " + versionString + ". Unexpected behavior may occur.");
+            log.error("PhotonVision version mismatch. Expected: " + PhotonVersion.versionString + " Actual: "
+                    + versionString + ". Unexpected behavior may occur.");
             return false;
         }
         return true;

--- a/src/main/java/org/photonvision/PhotonCameraExtended.java
+++ b/src/main/java/org/photonvision/PhotonCameraExtended.java
@@ -1,16 +1,21 @@
 package org.photonvision;
 
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.DriverStation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.photonvision.targeting.PhotonPipelineResult;
 import xbot.common.controls.io_inputs.PhotonCameraExtendedInputsAutoLogged;
 
 public class PhotonCameraExtended extends PhotonCamera {
 
     PhotonCameraExtendedInputsAutoLogged io;
+    Logger log = LogManager.getLogger(this.getClass());
 
     public PhotonCameraExtended(NetworkTableInstance instance, String cameraName) {
         super(instance, cameraName);
         io = new PhotonCameraExtendedInputsAutoLogged();
+
     }
 
     public PhotonCameraExtended(String cameraName) {
@@ -26,6 +31,18 @@ public class PhotonCameraExtended extends PhotonCamera {
 
     public double[] getDistCoeffsRaw() {
         return io.distCoeffs;
+    }
+
+    public boolean doesLibraryVersionMatchCoprocessorVersion() {
+        // Check for version. Warn if the versions aren't aligned.
+        String versionString = versionEntry.get("");
+        if (!versionString.isEmpty() && !PhotonVersion.versionMatches(versionString)) {
+            // Error on a verified version mismatch
+            // But stay silent otherwise
+            log.error("PhotonVision version mismatch. Expected: " + PhotonVersion.versionString + " Actual: " + versionString + ". Unexpected behavior may occur.");
+            return false;
+        }
+        return true;
     }
 
     public void refreshDataFrame() {


### PR DESCRIPTION
# Why are we doing this?
We disabled version checking in a previous commit to avoid a guaranteed crash when the PhotonLib version doesn't match the PhotonLib coprocessor version; but that also exposes us to extra risk that some other crash will happen inside the library. Instead, we will just do a quick check to see if there is a version mismatch, and if so choose not to call any PhotonVision functions.
# Whats changing?
Adds a safe version check and uses that check to disable one or more cameras.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
