### PR TITLE
Silence warnings about deprecated CANCoder class

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANTalon.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANTalon.java
@@ -25,7 +25,6 @@ import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.StickyFaults;
 import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.can.BaseTalon;
-import com.ctre.phoenix.sensors.CANCoder;
 import com.ctre.phoenix.sensors.SensorVelocityMeasPeriod;
 
 import org.apache.logging.log4j.LogManager;
@@ -835,7 +834,8 @@ public class MockCANTalon extends XCANTalon implements ISimulatableSensor, ISimu
     }
 
     @Override
-    public ErrorCode configRemoteFeedbackFilter(CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
+    @SuppressWarnings("removal")
+    public ErrorCode configRemoteFeedbackFilter(com.ctre.phoenix.sensors.CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
         return null;
     }
 

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANVictorSPX.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANVictorSPX.java
@@ -23,7 +23,6 @@ import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.StickyFaults;
 import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.can.BaseTalon;
-import com.ctre.phoenix.sensors.CANCoder;
 import com.ctre.phoenix.sensors.SensorVelocityMeasPeriod;
 
 import dagger.assisted.Assisted;
@@ -577,7 +576,8 @@ public class MockCANVictorSPX extends XCANVictorSPX {
     }
 
     @Override
-    public ErrorCode configRemoteFeedbackFilter(CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
+    @SuppressWarnings("removal")
+    public ErrorCode configRemoteFeedbackFilter(com.ctre.phoenix.sensors.CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
         return null;
     }
 

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonWPIAdapter.java
@@ -25,7 +25,6 @@ import com.ctre.phoenix.motorcontrol.StickyFaults;
 import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.can.BaseTalon;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
-import com.ctre.phoenix.sensors.CANCoder;
 import com.ctre.phoenix.sensors.SensorVelocityMeasPeriod;
 
 import dagger.assisted.Assisted;
@@ -523,7 +522,8 @@ public class CANTalonWPIAdapter extends XCANTalon {
     }
 
     @Override
-    public ErrorCode configRemoteFeedbackFilter(CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
+    @SuppressWarnings("removal")
+    public ErrorCode configRemoteFeedbackFilter(com.ctre.phoenix.sensors.CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
         return null;
     }
 

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANVictorSPXWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANVictorSPXWpiAdapter.java
@@ -30,7 +30,6 @@ import com.ctre.phoenix.motorcontrol.can.SlotConfiguration;
 import com.ctre.phoenix.motorcontrol.can.VictorSPX;
 import com.ctre.phoenix.motorcontrol.can.VictorSPXConfiguration;
 import com.ctre.phoenix.motorcontrol.can.VictorSPXPIDSetConfiguration;
-import com.ctre.phoenix.sensors.CANCoder;
 import com.ctre.phoenix.sensors.SensorVelocityMeasPeriod;
 
 import dagger.assisted.Assisted;
@@ -917,7 +916,8 @@ public class CANVictorSPXWpiAdapter extends XCANVictorSPX {
     }
 
     @Override
-    public ErrorCode configRemoteFeedbackFilter(CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
+    @SuppressWarnings("removal")
+    public ErrorCode configRemoteFeedbackFilter(com.ctre.phoenix.sensors.CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
         return null;
     }
 

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/VictorAppearingAsTalonWPIAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/VictorAppearingAsTalonWPIAdapter.java
@@ -23,7 +23,6 @@ import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.StickyFaults;
 import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.can.BaseTalon;
-import com.ctre.phoenix.sensors.CANCoder;
 import com.ctre.phoenix.sensors.SensorVelocityMeasPeriod;
 
 import dagger.assisted.Assisted;
@@ -667,7 +666,8 @@ public class VictorAppearingAsTalonWPIAdapter extends XCANTalon {
     }
 
     @Override
-    public ErrorCode configRemoteFeedbackFilter(CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
+    @SuppressWarnings("removal")
+    public ErrorCode configRemoteFeedbackFilter(com.ctre.phoenix.sensors.CANCoder canCoderRef, int remoteOrdinal, int timeoutMs) {
         return null;
     }
 


### PR DESCRIPTION
# Why are we doing this?
Warnings during build show up as red text and are confusing to students.

# Whats changing?
Deprecation warnings are silenced.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
