### PR TITLE
Support absolute encoders attached to SparkMax objects

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -8,12 +8,14 @@ import com.revrobotics.CANSparkBase.SoftLimitDirection;
 import com.revrobotics.CANSparkLowLevel;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.REVLibError;
+import com.revrobotics.SparkAbsoluteEncoder;
 import com.revrobotics.SparkPIDController.ArbFFUnits;
 
 import org.apache.logging.log4j.LogManager;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.io_inputs.XCANSparkMaxInputs;
 import xbot.common.controls.io_inputs.XCANSparkMaxInputsAutoLogged;
+import xbot.common.controls.sensors.XSparkAbsoluteEncoder;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.DevicePolice.DeviceType;
 import xbot.common.injection.electrical_contract.DeviceInfo;
@@ -789,6 +791,8 @@ public abstract class XCANSparkMax {
                 clearFaults();
             }
     }
+
+    public abstract XSparkAbsoluteEncoder getAbsoluteEncoder(String nameWithPrefix, boolean inverted);
 
     // Methods for integrating with AdvantageKit
     protected abstract void updateInputs(XCANSparkMaxInputs inputs);

--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -797,7 +797,7 @@ public abstract class XCANSparkMax {
      * rather than creating it via a factory as we do with other objects.
      * @param nameWithPrefix Name of the encoder, with the prefix already applied.
      * @param inverted Whether the encoder is inverted.
-     * @return
+     * @return The absolute encoder attached to this SparkMax.
      */
     public abstract XSparkAbsoluteEncoder getAbsoluteEncoder(String nameWithPrefix, boolean inverted);
 

--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -792,6 +792,13 @@ public abstract class XCANSparkMax {
             }
     }
 
+    /**
+     * If an absolute encoder is attached directly to the SparkMax, we need to retrieve it from the SparkMax object
+     * rather than creating it via a factory as we do with other objects.
+     * @param nameWithPrefix Name of the encoder, with the prefix already applied.
+     * @param inverted Whether the encoder is inverted.
+     * @return
+     */
     public abstract XSparkAbsoluteEncoder getAbsoluteEncoder(String nameWithPrefix, boolean inverted);
 
     // Methods for integrating with AdvantageKit

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
@@ -25,7 +25,9 @@ import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.actuators.XCANSparkMaxPIDProperties;
 import xbot.common.controls.io_inputs.XCANSparkMaxInputs;
 import xbot.common.controls.sensors.XEncoder;
+import xbot.common.controls.sensors.XSparkAbsoluteEncoder;
 import xbot.common.controls.sensors.mock_adapters.MockEncoder;
+import xbot.common.controls.sensors.mock_adapters.MockSparkAbsoluteEncoder;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.properties.PropertyFactory;
@@ -681,6 +683,11 @@ public class MockCANSparkMax extends XCANSparkMax implements ISimulatableMotor, 
     @Override
     public REVLibError setPeriodicFramePeriod(CANSparkLowLevel.PeriodicFrame frame, int periodMs) {
         return REVLibError.kOk;
+    }
+
+    @Override
+    public XSparkAbsoluteEncoder getAbsoluteEncoder(String nameWithPrefix, boolean inverted) {
+        return new MockSparkAbsoluteEncoder(nameWithPrefix, inverted);
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -11,6 +11,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.MotorFeedbackSensor;
 import com.revrobotics.REVLibError;
 import com.revrobotics.RelativeEncoder;
+import com.revrobotics.SparkAbsoluteEncoder;
 import com.revrobotics.SparkAnalogSensor;
 import com.revrobotics.SparkAnalogSensor.Mode;
 import com.revrobotics.SparkLimitSwitch;
@@ -24,6 +25,8 @@ import dagger.assisted.AssistedInject;
 import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.actuators.XCANSparkMaxPIDProperties;
 import xbot.common.controls.io_inputs.XCANSparkMaxInputs;
+import xbot.common.controls.sensors.XSparkAbsoluteEncoder;
+import xbot.common.controls.sensors.wpi_adapters.SparkAbsoluteEncoderAdapter;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.properties.PropertyFactory;
@@ -599,6 +602,12 @@ public class CANSparkMaxWpiAdapter extends XCANSparkMax {
     @Override
     public boolean getReverseLimitSwitchPressed(com.revrobotics.SparkLimitSwitch.Type switchType) {
         return internalSpark.getReverseLimitSwitch(switchType).isPressed();
+    }
+
+    @Override
+    public XSparkAbsoluteEncoder getAbsoluteEncoder(String nameWithPrefix, boolean inverted) {
+        return new SparkAbsoluteEncoderAdapter(nameWithPrefix,
+                internalSpark.getAbsoluteEncoder(SparkAbsoluteEncoder.Type.kDutyCycle), inverted);
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/sensors/XSparkAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XSparkAbsoluteEncoder.java
@@ -1,0 +1,32 @@
+package xbot.common.controls.sensors;
+
+import org.littletonrobotics.junction.Logger;
+import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
+import xbot.common.controls.io_inputs.XAbsoluteEncoderInputsAutoLogged;
+
+public abstract class XSparkAbsoluteEncoder {
+
+    protected XAbsoluteEncoderInputsAutoLogged inputs;
+    boolean inverted;
+
+    String nameWithPrefix;
+
+    public XSparkAbsoluteEncoder(String nameWithPrefix, boolean inverted) {
+        inputs = new XAbsoluteEncoderInputsAutoLogged();
+        this.nameWithPrefix = nameWithPrefix;
+        this.inverted = inverted;
+    }
+
+    public double getPosition() {
+        return getUnderlyingPosition() * (inverted ? -1 : 1);
+    }
+
+    public abstract double getUnderlyingPosition();
+
+    public abstract void updateInputs(XAbsoluteEncoderInputs inputs);
+
+    public void refreshDataFrame() {
+        updateInputs(inputs);
+        Logger.getInstance().processInputs(nameWithPrefix, inputs);
+    }
+}

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockSparkAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockSparkAbsoluteEncoder.java
@@ -1,0 +1,25 @@
+package xbot.common.controls.sensors.mock_adapters;
+
+import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
+import xbot.common.controls.sensors.XSparkAbsoluteEncoder;
+
+public class MockSparkAbsoluteEncoder extends XSparkAbsoluteEncoder {
+
+    public MockSparkAbsoluteEncoder(String nameWithPrefix, boolean inverted) {
+        super(nameWithPrefix, inverted);
+    }
+
+    public void setMockPosition(double position) {
+        inputs.position = position;
+    }
+
+    @Override
+    public double getUnderlyingPosition() {
+        return inputs.position;
+    }
+
+    @Override
+    public void updateInputs(XAbsoluteEncoderInputs inputs) {
+        // Nothing needed here for mock.
+    }
+}

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/SparkAbsoluteEncoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/SparkAbsoluteEncoderAdapter.java
@@ -1,0 +1,28 @@
+package xbot.common.controls.sensors.wpi_adapters;
+
+import com.revrobotics.SparkAbsoluteEncoder;
+import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
+import xbot.common.controls.sensors.XSparkAbsoluteEncoder;
+
+public class SparkAbsoluteEncoderAdapter extends XSparkAbsoluteEncoder {
+
+    SparkAbsoluteEncoder realEncoder;
+
+    public SparkAbsoluteEncoderAdapter(String nameWithPrefix, SparkAbsoluteEncoder realEncoder, boolean inverted) {
+        super(nameWithPrefix, inverted);
+        this.realEncoder = realEncoder;
+    }
+
+    @Override
+    public double getUnderlyingPosition() {
+        return inputs.position;
+    }
+
+    @Override
+    public void updateInputs(XAbsoluteEncoderInputs inputs) {
+        inputs.position = realEncoder.getPosition();
+        inputs.absolutePosition = inputs.position;
+        inputs.velocity = realEncoder.getVelocity();
+        inputs.deviceHealth = "NotChecked";
+    }
+}


### PR DESCRIPTION
# Why are we doing this?
Current plans for the robot involve attaching a through-bore encoder to the Arm assembly, and plugging that directly into a nearby SparkMax rather than the RIO.

# What's changing?
XCANSparkMax objects can be asked for a XSparkAbsoluteEncoder object, which in turn must be refreshed like any other base sensor.

# Questions/notes for reviewers
I put this together to unblock a student working in the area, but there's probably some way to either join this closer to the existing XAbsoluteEncoder or more strongly separate them.

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
