### PR TITLE
Properties now logged by AKIT

### DIFF
--- a/src/main/java/xbot/common/command/BaseMaintainerCommand.java
+++ b/src/main/java/xbot/common/command/BaseMaintainerCommand.java
@@ -45,7 +45,7 @@ public abstract class BaseMaintainerCommand<T> extends BaseCommand {
         pf.setPrefix(this);
         pf.setDefaultLevel(Property.PropertyLevel.Debug);
         errorToleranceProp = pf.createPersistentProperty("Error Tolerance", defaultErrorTolerance);
-        errorTimeStableWindowProp = pf.createEphemeralProperty("Error Time Stable Window", defaultTimeStableWindow);
+        errorTimeStableWindowProp = pf.createPersistentProperty("Error Time Stable Window", defaultTimeStableWindow);
 
         timeStableValidator = new TimeStableValidator(() -> errorTimeStableWindowProp.get());
         decider = humanVsMachineDeciderFactory.create(this.getPrefix());

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -177,8 +177,8 @@ public abstract class BaseRobot extends LoggedRobot {
     @Override
     public void disabledInit() {
         updateLoggingContext();
+        propertyManager.refreshDataFrame();
         log.info("Disabled init (" + getMatchContextString() + ")");
-        propertyManager.saveOutAllProperties();
     }
 
     public void disabledPeriodic() {
@@ -248,6 +248,12 @@ public abstract class BaseRobot extends LoggedRobot {
         Logger.getInstance().recordOutput("OutsidePeriodicMs", outsidePeriodicEnd - outsidePeriodicStart);
         // Get a fresh data frame from all top-level components (typically large subsystems or shared sensors)
         double dataFrameStart = getPerformanceTimestampInMs();
+
+        // Refresh the properties ahead of all other systems, since some may want to immediately
+        // use the relevant values.
+        propertyManager.refreshDataFrame();
+
+        // Then, refresh any Subsystem or other components that implement DataFrameRefreshable.
         for (DataFrameRefreshable refreshable : dataFrameRefreshables) {
             refreshable.refreshDataFrame();
         }

--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -59,7 +59,7 @@ public abstract class XCANSparkMax {
         }
 
         public XCANSparkMax createWithoutProperties(DeviceInfo deviceInfo, String owningSystemPrefix, String name) {
-            return create(deviceInfo, owningSystemPrefix, name, null);
+            return create(deviceInfo, owningSystemPrefix, name, null, null);
         }
     }
 

--- a/src/main/java/xbot/common/controls/actuators/XCANTalon.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANTalon.java
@@ -64,18 +64,6 @@ public abstract class XCANTalon implements IMotorControllerEnhanced {
         policeTicket = police.registerDevice(DeviceType.CAN, deviceId, this);
     }
 
-
-
-    public void createTelemetryProperties(String callingSystemPrefix, String deviceName) {
-        // Creates nice prefixes for the SmartDashboard.
-        propMan.setPrefix(callingSystemPrefix + "/" + deviceName);
-        currentProperty = propMan.createEphemeralProperty("current", 0);
-        outVoltageProperty = propMan.createEphemeralProperty("voltage", 0);
-        temperatureProperty = propMan.createEphemeralProperty("temperature", 0);
-        positionProperty = propMan.createEphemeralProperty("position", 0);
-        velocityProperty = propMan.createEphemeralProperty("velocity", 0);
-    }
-
     public void updateTelemetryProperties() {
         if(currentProperty == null
                 || outVoltageProperty == null
@@ -356,7 +344,6 @@ public abstract class XCANTalon implements IMotorControllerEnhanced {
         this.setInverted(masterInverted);
         this.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, 0, 0);
         this.setSensorPhase(sensorPhase);
-        this.createTelemetryProperties(prefix, masterName);
 
         this.setNeutralMode(NeutralMode.Coast);
         this.configForwardLimitSwitchSource(LimitSwitchSource.Deactivated, LimitSwitchNormal.Disabled, 0);

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockAbsoluteEncoder.java
@@ -21,9 +21,9 @@ import xbot.common.simulation.ISimulatableSensor;
 public class MockAbsoluteEncoder extends XAbsoluteEncoder implements ISimulatableSensor {
 
     private final int deviceId;
-    private final BooleanProperty inverted;
-    private final DoubleProperty simulationScale;
-    private final DoubleProperty positionOffset;
+    private boolean inverted;
+    private double simulationScale;
+    private double positionOffset;
 
     private double velocity;
     private WrappedRotation2d absolutePosition;
@@ -45,10 +45,6 @@ public class MockAbsoluteEncoder extends XAbsoluteEncoder implements ISimulatabl
         this.deviceId = deviceInfo.channel;
         this.velocity = 0;
         this.absolutePosition = new WrappedRotation2d(0);
-        this.positionOffset = pf.createEphemeralProperty("PositionOffset", 0);
-        this.inverted = pf.createEphemeralProperty("Inverted", deviceInfo.inverted);
-        this.simulationScale = pf.createEphemeralProperty("SimulationScale", deviceInfo.simulationScalingValue);
-
         police.registerDevice(DeviceType.CAN, deviceInfo.channel, this);
     }
     
@@ -58,35 +54,35 @@ public class MockAbsoluteEncoder extends XAbsoluteEncoder implements ISimulatabl
     }
 
     public double getPosition_internal() {
-        return WrappedRotation2d.fromDegrees(this.absolutePosition.getDegrees() + this.positionOffset.get()).getDegrees() * (inverted.get() ? -1 : 1);
+        return WrappedRotation2d.fromDegrees(this.absolutePosition.getDegrees() + this.positionOffset).getDegrees() * (inverted ? -1 : 1);
     }
 
     public double getAbsolutePosition_internal() {
-        return this.absolutePosition.getDegrees() * (inverted.get() ? -1 : 1);
+        return this.absolutePosition.getDegrees() * (inverted ? -1 : 1);
     }
 
     public double getVelocity_internal() {
-        return this.velocity * (inverted.get() ? -1 : 1);
+        return this.velocity * (inverted ? -1 : 1);
     }
 
     @Override
     public void setPosition(double newPosition) {
-        this.positionOffset.set(WrappedRotation2d.fromDegrees(newPosition).minus(this.absolutePosition).getDegrees());
+        this.positionOffset = (WrappedRotation2d.fromDegrees(newPosition).minus(this.absolutePosition).getDegrees());
     }
     
 
     public double getPositionOffset() {
-        return this.positionOffset.get();
+        return this.positionOffset;
     }
 
     public void setAbsolutePosition(double position) {
-        this.absolutePosition = WrappedRotation2d.fromDegrees(position * (inverted.get() ? -1 : 1));
+        this.absolutePosition = WrappedRotation2d.fromDegrees(position * (inverted ? -1 : 1));
     }
 
     @Override
     public void ingestSimulationData(JSONObject payload) {
         setAbsolutePosition(
-            payload.getBigDecimal("EncoderTicks").doubleValue() * this.simulationScale.get()
+            payload.getBigDecimal("EncoderTicks").doubleValue() * this.simulationScale
         );
     }
 

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockCANCoder.java
@@ -24,9 +24,9 @@ import xbot.common.simulation.ISimulatableSensor;
 public class MockCANCoder extends XCANCoder implements ISimulatableSensor {
 
     private final int deviceId;
-    private final BooleanProperty inverted;
-    private final DoubleProperty simulationScale;
-    private final DoubleProperty positionOffset;
+    private boolean inverted;
+    private double simulationScale;
+    private double positionOffset;
 
     private double velocity;
     private WrappedRotation2d absolutePosition;
@@ -49,9 +49,9 @@ public class MockCANCoder extends XCANCoder implements ISimulatableSensor {
         this.velocity = 0;
         this.absolutePosition = new WrappedRotation2d(0);
         pf.setDefaultLevel(Property.PropertyLevel.Debug);
-        this.positionOffset = pf.createEphemeralProperty("PositionOffset", 0);
-        this.inverted = pf.createEphemeralProperty("Inverted", deviceInfo.inverted);
-        this.simulationScale = pf.createEphemeralProperty("SimulationScale", deviceInfo.simulationScalingValue);
+        this.positionOffset = 0;
+        this.inverted = deviceInfo.inverted;
+        this.simulationScale = deviceInfo.simulationScalingValue;
 
         police.registerDevice(DeviceType.CAN, deviceInfo.channel, this);
     }
@@ -62,35 +62,35 @@ public class MockCANCoder extends XCANCoder implements ISimulatableSensor {
     }
 
     public double getPosition_internal() {
-        return WrappedRotation2d.fromDegrees(this.absolutePosition.getDegrees() + this.positionOffset.get()).getDegrees() * (inverted.get() ? -1 : 1);
+        return WrappedRotation2d.fromDegrees(this.absolutePosition.getDegrees() + this.positionOffset).getDegrees() * (inverted ? -1 : 1);
     }
 
     public double getAbsolutePosition_internal() {
-        return this.absolutePosition.getDegrees() * (inverted.get() ? -1 : 1);
+        return this.absolutePosition.getDegrees() * (inverted ? -1 : 1);
     }
 
     public double getVelocity_internal() {
-        return this.velocity * (inverted.get() ? -1 : 1);
+        return this.velocity * (inverted ? -1 : 1);
     }
 
     @Override
     public void setPosition(double newPosition) {
-        this.positionOffset.set(WrappedRotation2d.fromDegrees(newPosition).minus(this.absolutePosition).getDegrees());
+        this.positionOffset = (WrappedRotation2d.fromDegrees(newPosition).minus(this.absolutePosition).getDegrees());
     }
     
 
     public double getPositionOffset() {
-        return this.positionOffset.get();
+        return this.positionOffset;
     }
 
     public void setAbsolutePosition(double position) {
-        this.absolutePosition = WrappedRotation2d.fromDegrees(position * (inverted.get() ? -1 : 1));
+        this.absolutePosition = WrappedRotation2d.fromDegrees(position * (inverted ? -1 : 1));
     }
 
     @Override
     public void ingestSimulationData(JSONObject payload) {
         setAbsolutePosition(
-            payload.getBigDecimal("EncoderTicks").doubleValue() * this.simulationScale.get()
+            payload.getBigDecimal("EncoderTicks").doubleValue() * this.simulationScale
         );
     }
 

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
@@ -29,8 +29,8 @@ public class CANCoderAdapter extends XCANCoder {
     private final int deviceId;
     private final CANcoder cancoder;
 
-    private final DoubleProperty magnetOffset;
-    private final BooleanProperty inverted;
+    private double magnetOffset;
+    private boolean inverted;
 
     @AssistedFactory
     public abstract static class CANCoderAdapterFactory implements XCANCoderFactory {
@@ -46,13 +46,13 @@ public class CANCoderAdapter extends XCANCoder {
         super(deviceInfo);
         pf.setPrefix(owningSystemPrefix);
 
-        this.inverted = pf.createEphemeralProperty("Inverted", deviceInfo.inverted);
-        this.magnetOffset = pf.createEphemeralProperty("Magnet offset", 0.0);
+        this.inverted = deviceInfo.inverted;
+        this.magnetOffset = 0.0;
         
         this.cancoder = new CANcoder(deviceInfo.channel, "rio");
 
         var currentConfig = getCurrentConfiguration();
-        currentConfig.MagnetSensor.SensorDirection = this.inverted.get()
+        currentConfig.MagnetSensor.SensorDirection = this.inverted
                 ? SensorDirectionValue.Clockwise_Positive : SensorDirectionValue.CounterClockwise_Positive;
         applyConfiguration(currentConfig);
 
@@ -104,8 +104,8 @@ public class CANCoderAdapter extends XCANCoder {
         // Note that the "refresh" is a blocking call.
         cancoder.getConfigurator().refresh(currentConfigs);
 
-        this.magnetOffset.set(currentConfigs.MagnetSensor.MagnetOffset);
-        return this.magnetOffset.get();
+        this.magnetOffset = currentConfigs.MagnetSensor.MagnetOffset;
+        return this.magnetOffset;
     }
 
     /**
@@ -123,7 +123,7 @@ public class CANCoderAdapter extends XCANCoder {
             log.error("Failed to set magnet offset for device " + this.getDeviceId() + ". Error code: " + status.value);
             return false;
         } else {
-            this.magnetOffset.set(offsetInDegrees);
+            this.magnetOffset = offsetInDegrees;
             return true;
         }
     }

--- a/src/main/java/xbot/common/logic/WatchdogTimer.java
+++ b/src/main/java/xbot/common/logic/WatchdogTimer.java
@@ -10,8 +10,8 @@ public class WatchdogTimer {
     private double lastKick = Double.NEGATIVE_INFINITY;
     private Latch latch;
     
-    private BooleanProperty isUpProp;
-    private DoubleProperty timeSinceKickProp;
+    private boolean isUp;
+    private double timeSinceKick;
     
     private final double timeout;
     private Runnable onUp = null;
@@ -21,22 +21,9 @@ public class WatchdogTimer {
         this.timeout = timeout;
         latch = new Latch(false, EdgeType.Both, this::handleLatchUpdate);
     }
-    
-    public WatchdogTimer(double timeout, String name, PropertyFactory propMan) {
-        this(timeout);
-        propMan.setPrefix(name);
-        this.isUpProp = propMan.createEphemeralProperty("Is up?", false);
-        this.timeSinceKickProp = propMan.createEphemeralProperty("Time since kick", Double.POSITIVE_INFINITY);
-    }
 
     public WatchdogTimer(double timeout, Runnable onUp, Runnable onDown) {
         this(timeout);
-        this.onUp = onUp;
-        this.onDown = onDown;
-    }
-    
-    public WatchdogTimer(double timeout, Runnable onUp, Runnable onDown, String name, PropertyFactory propMan) {
-        this(timeout, name, propMan);
         this.onUp = onUp;
         this.onDown = onDown;
     }
@@ -56,13 +43,8 @@ public class WatchdogTimer {
     
     public void check() {
         double now = XTimer.getFPGATimestamp();
-        double timeSinceKick = now - lastKick;
-        boolean isUp = Double.isFinite(timeSinceKick) && timeSinceKick <= timeout;
-        
+        timeSinceKick = now - lastKick;
+        isUp = Double.isFinite(timeSinceKick) && timeSinceKick <= timeout;
         latch.setValue(isUp);
-        if (this.isUpProp != null && this.timeSinceKickProp != null) {
-            isUpProp.set(isUp);
-            timeSinceKickProp.set(timeSinceKick);
-        }
     }
 }

--- a/src/main/java/xbot/common/properties/PreferenceStorage.java
+++ b/src/main/java/xbot/common/properties/PreferenceStorage.java
@@ -23,7 +23,8 @@ public class PreferenceStorage implements PermanentStorage {
     boolean fastMode = false;
     
     @Inject
-    public PreferenceStorage() {}
+    public PreferenceStorage() {
+    }
 
     @Override
     public void setDouble(String key, double value) {

--- a/src/main/java/xbot/common/properties/Property.java
+++ b/src/main/java/xbot/common/properties/Property.java
@@ -48,10 +48,11 @@ public abstract class Property implements DataFrameRefreshable {
 
     /**
      * Creates a new property.
-     * @param key The property key.
-     *            This should be unique unless you really know what you're doing.
+     * @param prefix The property prefix.
+     *               This should be unique unless you really know what you're doing.
+     * @param suffix The property suffix.
+     *               This should be unique unless you really know what you're doing.
      * @param manager The property manager.
-     * @param persistenceType The persistence type.
      * @param level The property level.
      */
     public Property(String prefix, String suffix, XPropertyManager manager, PropertyLevel level) {
@@ -77,10 +78,11 @@ public abstract class Property implements DataFrameRefreshable {
 
     /**
      * Creates a new property.
+     * @param prefix The property prefix.
+     *            This should be unique unless you really know what you're doing.
      * @param key The property key.
      *            This should be unique unless you really know what you're doing.
      * @param manager The property manager.
-     * @param persistenceType The persistence type.
      */
     public Property(String prefix, String key, XPropertyManager manager) {
         this(prefix, key, manager, PropertyLevel.Important);

--- a/src/main/java/xbot/common/properties/Property.java
+++ b/src/main/java/xbot/common/properties/Property.java
@@ -6,6 +6,7 @@ package xbot.common.properties;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import xbot.common.advantage.DataFrameRefreshable;
 
 /**
  * There are many values on the robot that we want to configure on the fly as
@@ -15,14 +16,18 @@ import org.apache.logging.log4j.Logger;
  * 
  * @author Alex
  */
-public abstract class Property {
+public abstract class Property implements DataFrameRefreshable {
     /**
      * The key for the property.
      */
     public final String key;
 
-    protected final PermanentStorage permanentStore;
-    protected final ITableProxy randomAccessStore;
+    public final String prefix;
+
+    public final String suffix;
+
+    public final PropertyLevel level;
+    protected final ITableProxy activeStore;
     
     /** 
      * Enum to determine property persistence
@@ -38,10 +43,8 @@ public abstract class Property {
         Important,
         Debug
     }
-    
-    public final PropertyPersistenceType persistenceType;
 
-    protected static Logger log;
+    protected Logger log = LogManager.getLogger(this.getClass());
 
     /**
      * Creates a new property.
@@ -51,20 +54,25 @@ public abstract class Property {
      * @param persistenceType The persistence type.
      * @param level The property level.
      */
-    public Property(String key, XPropertyManager manager, PropertyPersistenceType persistenceType, PropertyLevel level) {
-        this.key = sanitizeKey(key);
+    public Property(String prefix, String suffix, XPropertyManager manager, PropertyLevel level) {
+        this.prefix = prefix;
+        this.suffix = suffix;
+        this.key = sanitizeFullKey(prefix + suffix);
+        this.level = level;
+
         log = LogManager.getLogger(this.getClass().getSimpleName() + " (\"" + this.key + "\")");
-        
-        this.permanentStore = manager.permanentStore;
 
         if(level == PropertyLevel.Debug){
-            this.randomAccessStore = manager.inMemoryRandomAccessStore;
+            this.activeStore = manager.inMemoryRandomAccessStore;
         } else {
-            this.randomAccessStore = manager.randomAccessStore;
+            this.activeStore = manager.permanentStore;
         }
 
-        this.persistenceType = persistenceType;
         manager.registerProperty(this);
+    }
+
+    public PropertyLevel getLevel() {
+        return level;
     }
 
     /**
@@ -74,21 +82,11 @@ public abstract class Property {
      * @param manager The property manager.
      * @param persistenceType The persistence type.
      */
-    public Property(String key, XPropertyManager manager, PropertyPersistenceType persistenceType) {
-        this(key, manager, persistenceType, PropertyLevel.Important);
+    public Property(String prefix, String key, XPropertyManager manager) {
+        this(prefix, key, manager, PropertyLevel.Important);
     }
 
-    /**
-     * Creates a new persistent property.
-     * @param key The property key.
-     *            This should be unique unless you really know what you're doing.
-     * @param manager The property manager.
-     */
-    public Property(String key, XPropertyManager manager) {
-        this(key, manager, PropertyPersistenceType.Persistent);
-    } 
-
-    private String sanitizeKey(String key) {
+    private String sanitizeFullKey(String key) {
         String sanitizedKey = key;
         sanitizedKey = sanitizedKey.replace(",", "");
         sanitizedKey = sanitizedKey.replace("\n", "");
@@ -99,18 +97,6 @@ public abstract class Property {
         }
         return sanitizedKey;
     }
-
-    /**
-     * Save the property permanently. This shouldn't happen very often (I/O is
-     * expensive).
-     */
-    public abstract void save();
-
-    /**
-     * Load the property from storage. This shouldn't happen very often (I/O is
-     * expensive).
-     */
-    public abstract void load();
 
     /**
      * Checks if the property's current value matches the default.

--- a/src/main/java/xbot/common/properties/PropertyFactory.java
+++ b/src/main/java/xbot/common/properties/PropertyFactory.java
@@ -75,29 +75,21 @@ public class PropertyFactory {
         return this.prefix;
     }
 
-    /**
-     * Creates a property key.
-     * @param key The key to append to the prefix.
-     * @return The full property key.
-     */
-    public String createFullKey(String key) {
-        String fullKey = null;
+    public String getCleanPrefix() {
+        String cleanPrefix = null;
         if(this.prefix == null || this.prefix.isEmpty()) {
-            fullKey = key;
+            cleanPrefix = "/";
         }
         else if (prefix.charAt(prefix.length() -1) == '/')
         {
             // If somebody already put a slash as a trailing character, then we don't have much to do.
-            fullKey = this.getPrefix() + key;
+            cleanPrefix = prefix;
         } else {
-            fullKey = this.getPrefix() + "/" + key;
+            cleanPrefix = this.getPrefix() + "/";
         }
-        // We've seen issues with badly assembled keys where slashes are getting doubled up
-        String cleanedKey = fullKey.replaceAll("/+", "/");
-        if (fullKey.equals(cleanedKey)) {
-            //log.warn("Property key '" + fullKey + "' had double slashes that were stripped out. Please fix the key logic to not create double slashes.");
-        }
-        return cleanedKey;
+
+        cleanPrefix = cleanPrefix.replaceAll("/+", "/");
+        return cleanPrefix;
     }
 
     private void checkPrefixSet() {
@@ -118,141 +110,72 @@ public class PropertyFactory {
     }
 
     /**
-     * Method for creating a boolean ephemeral property.
-     * @param key The key for the property.
+     * Method for creating a double persistent property.
+     * @param suffix The suffix for the property.
      * @param defaultValue The default value for the property.
      * @return The property.
      */
-    public BooleanProperty createEphemeralProperty(String key, boolean defaultValue) {
+    public BooleanProperty createPersistentProperty(String suffix, boolean defaultValue) {
         checkPrefixSet();
-        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, defaultLevel);
-    }
-
-    /**
-     * Method for creating a boolean ephemeral property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @param level The property level.
-     * @return The property.
-     */
-    public BooleanProperty createEphemeralProperty(String key, boolean defaultValue, PropertyLevel level) {
-        checkPrefixSet();
-        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, level);
-    }
-
-    /**
-     * Method for creating a string ephemeral property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @param level The property level.
-     * @return The property.
-     */
-    public StringProperty createEphemeralProperty(String key, String defaultValue, PropertyLevel level) {
-        checkPrefixSet();
-        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, level);
-    }
-
-    /**
-     * Method for creating a string ephemeral property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @return The property.
-     */
-    public StringProperty createEphemeralProperty(String key, String defaultValue) {
-        checkPrefixSet();
-        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, defaultLevel);
-    }
-
-    /**
-     * Method for creating a double ephemeral property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @return The property.
-     */
-    public DoubleProperty createEphemeralProperty(String key, double defaultValue) {
-        checkPrefixSet();
-        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, defaultLevel);
-    }
-
-    /**
-     * Method for creating a double ephemeral property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @param level The property level.
-     * @return The property.
-     */
-    public DoubleProperty createEphemeralProperty(String key, double defaultValue, PropertyLevel level) {
-        checkPrefixSet();
-        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Ephemeral, this.propertyManager, level);
+        return new BooleanProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, defaultLevel);
     }
 
     /**
      * Method for creating a double persistent property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @return The property.
-     */
-    public BooleanProperty createPersistentProperty(String key, boolean defaultValue) {
-        checkPrefixSet();
-        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, defaultLevel);
-    }
-
-    /**
-     * Method for creating a double persistent property.
-     * @param key The key for the property.
+     * @param suffix The suffix for the property.
      * @param defaultValue The default value for the property.
      * @param level The property level.
      * @return The property.
      */
-    public BooleanProperty createPersistentProperty(String key, boolean defaultValue, PropertyLevel level) {
+    public BooleanProperty createPersistentProperty(String suffix, boolean defaultValue, PropertyLevel level) {
         checkPrefixSet();
-        return new BooleanProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, level);
+        return new BooleanProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, level);
     }
 
     /**
      * Method for creating a double persistent property.
-     * @param key The key for the property.
+     * @param suffix The suffix for the property.
      * @param defaultValue The default value for the property.
      * @return The property.
      */
-    public StringProperty createPersistentProperty(String key, String defaultValue) {
+    public StringProperty createPersistentProperty(String suffix, String defaultValue) {
         checkPrefixSet();
-        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, defaultLevel);
+        return new StringProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, defaultLevel);
     }
 
     /**
      * Method for creating a double persistent property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @param level The property level.
-     * @return The property.
-     */
-    public StringProperty createPersistentProperty(String key, String defaultValue, PropertyLevel level) {
-        checkPrefixSet();
-        return new StringProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, level);
-    }
-
-    /**
-     * Method for creating a double persistent property.
-     * @param key The key for the property.
-     * @param defaultValue The default value for the property.
-     * @return The property.
-     */
-    public DoubleProperty createPersistentProperty(String key, double defaultValue) {
-        checkPrefixSet();
-        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, defaultLevel);
-    }
-
-    /**
-     * Method for creating a double persistent property.
-     * @param key The key for the property.
+     * @param suffix The suffix for the property.
      * @param defaultValue The default value for the property.
      * @param level The property level.
      * @return The property.
      */
-    public DoubleProperty createPersistentProperty(String key, double defaultValue, PropertyLevel level) {
+    public StringProperty createPersistentProperty(String suffix, String defaultValue, PropertyLevel level) {
         checkPrefixSet();
-        return new DoubleProperty(this.createFullKey(key), defaultValue, PropertyPersistenceType.Persistent, this.propertyManager, level);
+        return new StringProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, level);
+    }
+
+    /**
+     * Method for creating a double persistent property.
+     * @param suffix The suffix for the property.
+     * @param defaultValue The default value for the property.
+     * @return The property.
+     */
+    public DoubleProperty createPersistentProperty(String suffix, double defaultValue) {
+        checkPrefixSet();
+        return new DoubleProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, defaultLevel);
+    }
+
+    /**
+     * Method for creating a double persistent property.
+     * @param suffix The suffix for the property.
+     * @param defaultValue The default value for the property.
+     * @param level The property level.
+     * @return The property.
+     */
+    public DoubleProperty createPersistentProperty(String suffix, double defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new DoubleProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, level);
     }
 
 

--- a/src/main/java/xbot/common/properties/XPropertyManager.java
+++ b/src/main/java/xbot/common/properties/XPropertyManager.java
@@ -42,9 +42,13 @@ public class XPropertyManager implements DataFrameRefreshable {
         properties.add(property);
     }
 
+    /**
+     * Must be called every robot loop, and should be done before any properties are accessed in order to
+     * make the robot as responsive as possible.
+     */
     @Override
     public void refreshDataFrame() {
-        // Only refresh persistent/configuration properties. Ephemeral properties are of output type.
+        // Only refresh persistent/configuration properties.
         for (Property property : properties) {
             if (property.level == Property.PropertyLevel.Important) {
                 property.refreshDataFrame();

--- a/src/main/java/xbot/common/properties/XPropertyManager.java
+++ b/src/main/java/xbot/common/properties/XPropertyManager.java
@@ -8,6 +8,7 @@ import javax.inject.Singleton;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import xbot.common.advantage.DataFrameRefreshable;
 
 /**
  * The PropertyManager keeps track of all properties in CoreCode. All properties are implicitly added into its storage.
@@ -17,24 +18,20 @@ import org.apache.logging.log4j.Logger;
  * @author Alex
  */
 @Singleton
-public class XPropertyManager {
+public class XPropertyManager implements DataFrameRefreshable {
     public static final String IN_MEMORY_STORE_NAME = "InMemoryStore";
     private static final Logger log = LogManager.getLogger(XPropertyManager.class);
 
     public final ArrayList<Property> properties;
     public final PermanentStorage permanentStore;
-    public final ITableProxy randomAccessStore;
     public final ITableProxy inMemoryRandomAccessStore;
 
     @Inject
     public XPropertyManager(
-        PermanentStorage permanentStore, 
-        ITableProxy randomAccessStore, 
-        @Named(IN_MEMORY_STORE_NAME) ITableProxy inMemoryRandomAccessStore
+        PermanentStorage permanentStore
     ) {
         this.properties = new ArrayList<>();
         this.permanentStore = permanentStore;
-        this.randomAccessStore = randomAccessStore;
         this.inMemoryRandomAccessStore = new TableProxy();
     }
 
@@ -45,48 +42,12 @@ public class XPropertyManager {
         properties.add(property);
     }
 
-    /**
-     * Loads all properties from storage into the PermanentStore's table.
-     */
-    public void loadPropertiesFromStorage() {
-        // We need to somehow get the random store and force load everything in that.
-        int escape = 0;
+    @Override
+    public void refreshDataFrame() {
+        // Only refresh persistent/configuration properties. Ephemeral properties are of output type.
         for (Property property : properties) {
-            property.load();
-
-            escape++;
-            if (escape > 2000) {
-                log.warn("Exceeded maximum property count when loading properties.");
-                break;
-            }
-        }
-    }
-
-    /**
-     * Save all properties into permanent storage.
-     */
-    public void saveOutAllProperties() {
-
-        // We should clear the permanent storage before we save, otherwise we can have
-        // "orphaned" values that are loaded/saved indefinitely, even if there's nothing in the
-        // code that uses them.
-
-        if (properties.isEmpty()) {
-            log.error("No properties to save! Skipping save phase.");
-            return;
-        }
-
-        log.info("{} properties to save.", properties.size());
-
-        int escape = 0;
-
-        for (Property property : properties) {
-            property.save();
-
-            escape++;
-            if (escape > 2000) {
-                log.warn("Exceeded maximum property count when saving properties.");
-                break;
+            if (property.level == Property.PropertyLevel.Important) {
+                property.refreshDataFrame();
             }
         }
     }

--- a/src/main/java/xbot/common/properties/package-info.java
+++ b/src/main/java/xbot/common/properties/package-info.java
@@ -15,6 +15,10 @@
  * duplication, however, this automatic logging also lets the robot perform an accurate "replay mode" if any
  * configuration values were changed at runtime.
  *<p>
+ * Properties can be created with Important or Debug levels. Important properties are persisted to robot storage;
+ * Debug properties are kept entirely in memory, meaning they effectively "load from default" every time the robot
+ * boots.
+ *<p>
  * This package used to have a separate Ephemeral property; that's been deprecated. If you want to publish an
  * interesting value to the human operators (as well as log it to disc), use AdvantageKit's logger,
  * as in the following example:

--- a/src/main/java/xbot/common/properties/package-info.java
+++ b/src/main/java/xbot/common/properties/package-info.java
@@ -2,22 +2,23 @@
  * The property system. This allows sending values to Smart Dashboard and
  * configuring software at runtime or reporting values back to the drivers'
  * station.
- *
+ *<p>
  * In general, any property on the robot is for one specific purpose: Configuration. These values are written
  * infrequently, but often read constantly. Typical use cases would be for PID constants, subsystem limits,
  * thresholds, durations, and similar scenarios.
- *
+ *<p>
  * Properties load their values from a file on the robot (managed by WPI's Preferences system), and simultaneously
- * publish those values to the SmartDashboard in the "Preferences" table. Here, they can be modified by drivers/
- * programmers at runtime, and changes are immediately reflected in the robot's behavior.
- *
+ * publish those values to the SmartDashboard in the "Preferences" table. Here, they can be modified by
+ * drivers/programmers at runtime, and changes are immediately reflected in the robot's behavior.
+ *<p>
  * The value of the properties in every robot "tick" is also persisted to AdvantageKit. Mostly this is just
  * duplication, however, this automatic logging also lets the robot perform an accurate "replay mode" if any
  * configuration values were changed at runtime.
- *
+ *<p>
  * This package used to have a separate Ephemeral property; that's been deprecated. If you want to publish an
- * interesting value to the human operators, use AdvantageKit's logger, as in the following example:
- *
+ * interesting value to the human operators (as well as log it to disc), use AdvantageKit's logger,
+ * as in the following example:
+ *<p>
  * <pre>org.littletonrobotics.junction.Logger.recordOutput("DriveSubsystem/MaximumForwardSpeed", maxForwardSpeed);</pre>
  * or, for most commands/subsystems,
  * <pre>org.littletonrobotics.junction.Logger.recordOutput(this.getPrefix() + "/MaximumForwardSpeed", maxForwardSpeed);</pre>

--- a/src/main/java/xbot/common/properties/package-info.java
+++ b/src/main/java/xbot/common/properties/package-info.java
@@ -2,5 +2,24 @@
  * The property system. This allows sending values to Smart Dashboard and
  * configuring software at runtime or reporting values back to the drivers'
  * station.
+ *
+ * In general, any property on the robot is for one specific purpose: Configuration. These values are written
+ * infrequently, but often read constantly. Typical use cases would be for PID constants, subsystem limits,
+ * thresholds, durations, and similar scenarios.
+ *
+ * Properties load their values from a file on the robot (managed by WPI's Preferences system), and simultaneously
+ * publish those values to the SmartDashboard in the "Preferences" table. Here, they can be modified by drivers/
+ * programmers at runtime, and changes are immediately reflected in the robot's behavior.
+ *
+ * The value of the properties in every robot "tick" is also persisted to AdvantageKit. Mostly this is just
+ * duplication, however, this automatic logging also lets the robot perform an accurate "replay mode" if any
+ * configuration values were changed at runtime.
+ *
+ * This package used to have a separate Ephemeral property; that's been deprecated. If you want to publish an
+ * interesting value to the human operators, use AdvantageKit's logger, as in the following example:
+ *
+ * <pre>org.littletonrobotics.junction.Logger.recordOutput("DriveSubsystem/MaximumForwardSpeed", maxForwardSpeed);</pre>
+ * or, for most commands/subsystems,
+ * <pre>org.littletonrobotics.junction.Logger.recordOutput(this.getPrefix() + "/MaximumForwardSpeed", maxForwardSpeed);</pre>
  */
 package xbot.common.properties;

--- a/src/main/java/xbot/common/simulation/ExampleSensorData.json
+++ b/src/main/java/xbot/common/simulation/ExampleSensorData.json
@@ -1,28 +1,28 @@
 {
-	"Sensors": [
-		{
-			"ID": "DigitalIO3",
-			"Payload": {
-				"EncoderTicks": 123
-			}
-		},
+    "Sensors": [
+        {
+            "ID": "DigitalIO3",
+            "Payload": {
+                "EncoderTicks": 123
+            }
+        },
         {
             "ID": "Analog5",
-			"Payload": {
+            "Payload": {
                 "Voltage": 2.45784
             }
-		},
-		{
+        },
+        {
             "ID": "Analog6",
-			"Payload": {
+            "Payload": {
                 "Distance": 129.323
             }
-		},
-		{
-			"ID": "CAN12",
-			"Payload": {
-				"EncoderTicks": 224
-			}
-		}
-	]
+        },
+        {
+            "ID": "CAN12",
+            "Payload": {
+                "EncoderTicks": 224
+            }
+        }
+    ]
 }

--- a/src/main/java/xbot/common/simulation/WebotsClient.java
+++ b/src/main/java/xbot/common/simulation/WebotsClient.java
@@ -16,10 +16,13 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import edu.wpi.first.wpilibj.util.Color;
+import org.littletonrobotics.junction.Logger;
 import xbot.common.math.FieldPose;
 import xbot.common.math.XYPair;
 import xbot.common.properties.BooleanProperty;
@@ -30,9 +33,9 @@ import xbot.common.subsystems.pose.BasePoseSubsystem;
 
 @Singleton
 public class WebotsClient {
-    final DoubleProperty simulatorPoseX;
-    final DoubleProperty simulatorPoseY;
-    final DoubleProperty simulatorPoseYaw;
+    double simulatorPoseX;
+    double simulatorPoseY;
+    double simulatorPoseYaw;
     final StringProperty simulatorRobotTemplate;
     final BooleanProperty enableProxy;
     final DoubleProperty proxyPort;
@@ -47,9 +50,6 @@ public class WebotsClient {
     @Inject
     public WebotsClient(PropertyFactory propertyFactory) {
         propertyFactory.setPrefix("Webots");
-        simulatorPoseX = propertyFactory.createEphemeralProperty("Simulator Pose X", 0);
-        simulatorPoseY = propertyFactory.createEphemeralProperty("Simulator Pose Y", 0);
-        simulatorPoseYaw = propertyFactory.createEphemeralProperty("Simulator Pose Yaw", 0);
         simulatorRobotTemplate = propertyFactory.createPersistentProperty("Robot Template", "RobotTemplate2022");
         enableProxy = propertyFactory.createPersistentProperty("Enable Proxy", false);
         proxyPort = propertyFactory.createPersistentProperty("Proxy Port", 8888);
@@ -116,9 +116,12 @@ public class WebotsClient {
             positionArray.getDouble(1)*BasePoseSubsystem.INCHES_IN_A_METER, 
             worldPose.getDouble("Yaw"));
         FieldPose calibratedPose = truePose.getFieldPoseOffsetBy(fieldOffset);
-        simulatorPoseX.set(calibratedPose.getPoint().x);
-        simulatorPoseY.set(calibratedPose.getPoint().y);
-        simulatorPoseYaw.set(calibratedPose.getHeading().getDegrees());
+        simulatorPoseX = calibratedPose.getPoint().x;
+        simulatorPoseY = calibratedPose.getPoint().y;
+        simulatorPoseYaw = calibratedPose.getHeading().getDegrees();
+
+        Pose2d simulatorPose = new Pose2d(simulatorPoseX, simulatorPoseY, Rotation2d.fromDegrees(simulatorPoseYaw));
+        Logger.recordOutput("Webots/SimulatorPose", simulatorPose);
     }
 
     public void resetPosition() {

--- a/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
+++ b/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
@@ -17,9 +17,6 @@ import xbot.common.properties.StringProperty;
 @Singleton
 public class AutonomousCommandSelector extends BaseSubsystem {
     private static Logger log = LogManager.getLogger(AutonomousCommandSelector.class);
-
-    public final StringProperty currentAutonomousCommandName;
-    public final StringProperty currentAutonomousState;
     Supplier<Command> commandSupplier;
 
     Command currentAutonomousCommand;
@@ -27,9 +24,7 @@ public class AutonomousCommandSelector extends BaseSubsystem {
     @Inject
     public AutonomousCommandSelector(PropertyFactory propFactory) {
         propFactory.setTopLevelPrefix();
-        currentAutonomousCommandName = propFactory.createEphemeralProperty("Current autonomous command name",
-                "No command set");
-        currentAutonomousState = propFactory.createEphemeralProperty("Auto Program State", "Not set");
+        setAutonomousState("Not set");
     }
 
     public Command getCurrentAutonomousCommand() {
@@ -41,8 +36,9 @@ public class AutonomousCommandSelector extends BaseSubsystem {
 
     public void setCurrentAutonomousCommand(Command currentAutonomousCommand) {
         log.info("Setting CurrentAutonomousCommand to " + currentAutonomousCommand);
-        this.currentAutonomousCommandName
-                .set(currentAutonomousCommand == null ? "No command set" : currentAutonomousCommand.getName());
+        org.littletonrobotics.junction.Logger.recordOutput(
+                this.getPrefix() + "Current autonomous command name",
+                currentAutonomousCommand == null ? "No command set" : currentAutonomousCommand.getName());
 
         this.currentAutonomousCommand = currentAutonomousCommand;
         commandSupplier = null;
@@ -54,7 +50,7 @@ public class AutonomousCommandSelector extends BaseSubsystem {
     }
 
     public void setAutonomousState(String state) {
-        currentAutonomousState.set(state);
+        org.littletonrobotics.junction.Logger.recordOutput(this.getPrefix() + "Auto Program State", state);
     }
 
 }

--- a/src/main/java/xbot/common/subsystems/compressor/CompressorSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/compressor/CompressorSubsystem.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import org.littletonrobotics.junction.Logger;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.command.NamedRunCommand;
 import xbot.common.controls.actuators.XCompressor;
@@ -17,7 +18,6 @@ import xbot.common.properties.PropertyFactory;
 @Singleton
 public class CompressorSubsystem extends BaseSubsystem {
     protected final XCompressor compressor;
-    protected final BooleanProperty isEnabledProperty;
 
     /**
      * Create a new CompressorSubsystem.
@@ -28,7 +28,6 @@ public class CompressorSubsystem extends BaseSubsystem {
     public CompressorSubsystem(XCompressorFactory compressorFactory, PropertyFactory pf) {
         pf.setPrefix("CompressorSubsystem");
         this.compressor = compressorFactory.create();
-        this.isEnabledProperty = pf.createEphemeralProperty("Compressor Enabled", compressor.isEnabled());
         this.register();
     }
 
@@ -81,6 +80,6 @@ public class CompressorSubsystem extends BaseSubsystem {
     @Override
     public void periodic() {
         super.periodic();
-        isEnabledProperty.set(compressor.isEnabled());
+        Logger.recordOutput(getPrefix() + "Compressor Enabled", this.compressor.isEnabled());
     }
 }

--- a/src/test/java/xbot/common/controls/actuators/MockCANTalonTest.java
+++ b/src/test/java/xbot/common/controls/actuators/MockCANTalonTest.java
@@ -13,15 +13,21 @@ import xbot.common.injection.BaseCommonLibTest;
 import xbot.common.injection.electrical_contract.CANTalonInfo;
 
 public class MockCANTalonTest extends BaseCommonLibTest {
-    
-    @Test
-    public void testSpeedControl() {
-        XCANTalon talon = getInjectorComponent().canTalonFactory().create(new CANTalonInfo(1));
-       
+
+    XCANTalon talon;
+    @Override
+    public void setUp() {
+        super.setUp();
+
+        talon = getInjectorComponent().canTalonFactory().create(new CANTalonInfo(1));
         talon.config_kP(0, 0.5, 0);
-        
         talon.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, 0, 0);
 
+        getPropertyManager().refreshDataFrame();
+    }
+
+    @Test
+    public void testSpeedControl() {
         talon.set(ControlMode.Velocity, 1);
         assertTrue("Should be going forward", talon.getMotorOutputPercent() > 0);
         ((MockCANTalon)talon).setRate(2);
@@ -31,12 +37,6 @@ public class MockCANTalonTest extends BaseCommonLibTest {
 
     @Test
     public void testPositionControl() {
-        XCANTalon talon = getInjectorComponent().canTalonFactory().create(new CANTalonInfo(1));
-       
-        talon.config_kP(0, 0.5, 0);
-        
-        talon.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, 0, 0);
-
         talon.set(ControlMode.Position, 1);
         assertTrue("Should be going forward", talon.getMotorOutputPercent() > 0);
         ((MockCANTalon)talon).setPosition(2);
@@ -46,11 +46,11 @@ public class MockCANTalonTest extends BaseCommonLibTest {
     
     @Test
     public void internalEncoderTest() {
-    	MockCANTalon motor = (MockCANTalon)getInjectorComponent().canTalonFactory().create(new CANTalonInfo(1));
-    	motor.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, 0, 0);
-    	motor.setPosition(100);
+        MockCANTalon mockTalon = (MockCANTalon)talon;
+
+        mockTalon.setPosition(100);
     	
-    	assertEquals(100, motor.getPosition(), 0.001);
-    	assertEquals(100, motor.getSelectedSensorPosition(0), 0.001);
+    	assertEquals(100, mockTalon.getPosition(), 0.001);
+    	assertEquals(100, mockTalon.getSelectedSensorPosition(0), 0.001);
     }
 }

--- a/src/test/java/xbot/common/injection/BaseCommonLibTest.java
+++ b/src/test/java/xbot/common/injection/BaseCommonLibTest.java
@@ -2,11 +2,17 @@ package xbot.common.injection;
 
 import xbot.common.injection.components.CommonLibTestComponent;
 import xbot.common.injection.components.DaggerCommonLibTestComponent;
+import xbot.common.properties.PropertyFactory;
+import xbot.common.properties.XPropertyManager;
 
 public class BaseCommonLibTest extends BaseWPITest {
 
     protected CommonLibTestComponent getInjectorComponent() {
         return (CommonLibTestComponent)super.getInjectorComponent();
+    }
+
+    protected XPropertyManager getPropertyManager() {
+        return getInjectorComponent().propertyManager();
     }
 
     @Override

--- a/src/test/java/xbot/common/properties/PropertyFactoryTest.java
+++ b/src/test/java/xbot/common/properties/PropertyFactoryTest.java
@@ -11,9 +11,11 @@ public class PropertyFactoryTest extends BaseCommonLibTest {
     @Test
     public void testNoDoubleSlashes() {
         PropertyFactory factory = getInjectorComponent().propertyFactory();
-        assertEquals(-1, factory.createFullKey("my//mykey").indexOf("//"));
+        factory.setPrefix("my//myPrefixWithDoubleSlashes");
 
-        factory.setPrefix("prefix");
-        assertEquals(-1, factory.createFullKey("/mykey").indexOf("//"));
+        assertEquals(-1, factory.getCleanPrefix().indexOf("//"));
+
+        factory.setPrefix("simplePrefixWithNoSlashes");
+        assertEquals(-1, factory.getCleanPrefix().indexOf("//"));
     } 
 }

--- a/src/test/java/xbot/common/properties/PropertyTest.java
+++ b/src/test/java/xbot/common/properties/PropertyTest.java
@@ -24,9 +24,9 @@ public class PropertyTest extends BaseCommonLibTest {
 
     @Test
     public void testDefaultValue() {
-        DoubleProperty dbl = propertyFactory.createEphemeralProperty("speed", 1.0);
-        BooleanProperty bool = propertyFactory.createEphemeralProperty("isTrue", true);
-        StringProperty str = propertyFactory.createEphemeralProperty("string", "teststring");
+        DoubleProperty dbl = propertyFactory.createPersistentProperty("speed", 1.0);
+        BooleanProperty bool = propertyFactory.createPersistentProperty("isTrue", true);
+        StringProperty str = propertyFactory.createPersistentProperty("string", "teststring");
 
         assertEquals(1.0, dbl.get(), 0.001);
         assertTrue(bool.get());
@@ -35,9 +35,9 @@ public class PropertyTest extends BaseCommonLibTest {
 
     @Test
     public void testChangingValue() {
-        DoubleProperty dbl = propertyFactory.createEphemeralProperty("speed", 1.0);
-        BooleanProperty bool = propertyFactory.createEphemeralProperty("isTrue", true);
-        StringProperty str = propertyFactory.createEphemeralProperty("string", "teststring");
+        DoubleProperty dbl = propertyFactory.createPersistentProperty("speed", 1.0);
+        BooleanProperty bool = propertyFactory.createPersistentProperty("isTrue", true);
+        StringProperty str = propertyFactory.createPersistentProperty("string", "teststring");
 
         dbl.set(0.5);
         bool.set(false);
@@ -46,102 +46,15 @@ public class PropertyTest extends BaseCommonLibTest {
         assertEquals(0.5, dbl.get(), 0.001);
         assertFalse(bool.get());
         assertEquals("test2", str.get());
-    }
-
-    @Test
-    public void testSavingValue() {
-        DoubleProperty dbl = propertyFactory.createPersistentProperty("speed", 0.5);
-        BooleanProperty bool = propertyFactory.createPersistentProperty("isTrue", false);
-        StringProperty str = propertyFactory.createPersistentProperty("string", "test2");
-
-        assertNull(propertyManager.permanentStore.getDouble("speed"));
-        assertNull(propertyManager.permanentStore.getBoolean("isTrue"));
-        assertNull(propertyManager.permanentStore.getString("string"));
-
-        assertEquals(0.5, dbl.get(), 0.001);
-        assertFalse(bool.get());
-        assertEquals("test2", str.get());
-
-        propertyManager.saveOutAllProperties();
-
-        // default values should exist in permanent store
-        assertEquals(0.5, propertyManager.permanentStore.getDouble("speed"), 0.001);
-        assertFalse(propertyManager.permanentStore.getBoolean("isTrue"));
-        assertEquals("test2", propertyManager.permanentStore.getString("string"));
-
-        dbl.set(1.0);
-        bool.set(true);
-        str.set("new");
-        
-        propertyManager.saveOutAllProperties();
-
-        // non-defaults should save
-        assertEquals(1.0, propertyManager.permanentStore.getDouble("speed"), 0.001);
-        assertTrue(propertyManager.permanentStore.getBoolean("isTrue"));
-        assertEquals("new", propertyManager.permanentStore.getString("string"));
-
-        dbl.set(0.5);
-        bool.set(false);
-        str.set("test2");
-
-        propertyManager.saveOutAllProperties();
-
-        // default values should be still be in permanent store
-        assertEquals(0.5, propertyManager.permanentStore.getDouble("speed"), 0.001);
-        assertFalse(propertyManager.permanentStore.getBoolean("isTrue"));
-        assertEquals("test2", propertyManager.permanentStore.getString("string"));
-
-        // note that we still need to save default values, because we don't want
-        // to lose them if a different robot program is loaded that doesn't have
-        // the same set of properties
     }
 
     @Test
     public void testBadPropertyName() {
-        DoubleProperty dbl = propertyFactory.createEphemeralProperty("commas are bad ,", 0.5);
-        assertEquals("commas are bad ", dbl.key);
+        DoubleProperty dbl = propertyFactory.createPersistentProperty("commas are bad ,", 0.5);
+        assertEquals("/commas are bad ", dbl.key);
 
-        DoubleProperty dbl2 = propertyFactory.createEphemeralProperty("new lines are bad too\n", 0.5);
-        assertEquals("new lines are bad too", dbl2.key);
+        DoubleProperty dbl2 = propertyFactory.createPersistentProperty("new lines are bad too\n", 0.5);
+        assertEquals("/new lines are bad too", dbl2.key);
 
-    }
-
-    @Test
-    public void testLoadingValue() {
-        propertyManager.permanentStore.setDouble("speed", 0.5);
-        propertyManager.permanentStore.setBoolean("isTrue", true);
-        propertyManager.permanentStore.setString("string", "teststring");
-
-        propertyManager.loadPropertiesFromStorage();
-
-        DoubleProperty dbl = propertyFactory.createPersistentProperty("speed", 1.0);
-        BooleanProperty bool = propertyFactory.createPersistentProperty("isTrue", false);
-        StringProperty str = propertyFactory.createPersistentProperty("string", "blahblah");
-
-        assertEquals(0.5, dbl.get(), 0.001);
-        assertTrue(bool.get());
-        assertEquals("teststring", str.get());
-    }
-
-    @Test
-    public void testLoadingValueAfterCreation() {
-
-        propertyFactory.createPersistentProperty("speed", 0.5);
-        propertyFactory.createPersistentProperty("isTrue", true);
-        propertyFactory.createPersistentProperty("string", "teststring");
-
-        propertyManager.saveOutAllProperties();
-
-        DoubleProperty dbl = propertyFactory.createPersistentProperty("speed", 1.0);
-        BooleanProperty bool = propertyFactory.createPersistentProperty("isTrue", false);
-        StringProperty str = propertyFactory.createPersistentProperty("string", "blahblah");
-
-        propertyManager.loadPropertiesFromStorage();
-
-        // Values should not change because the old properties should be loaded
-        // rather than the new defaults.
-        assertEquals(0.5, dbl.get(), 0.001);
-        assertTrue(bool.get());
-        assertEquals("teststring", str.get());
     }
 }

--- a/src/test/java/xbot/common/subsystems/compressor/CompressorSubsystemTest.java
+++ b/src/test/java/xbot/common/subsystems/compressor/CompressorSubsystemTest.java
@@ -51,10 +51,10 @@ public class CompressorSubsystemTest extends BaseCommonLibTest  {
     public void testPeriodic() {
         compressorSubsystem.enable();
         compressorSubsystem.periodic();
-        assertTrue(compressorSubsystem.isEnabledProperty.get());
+        assertTrue(compressorSubsystem.isEnabled());
 
         compressorSubsystem.disable();
         compressorSubsystem.periodic();
-        assertFalse(compressorSubsystem.isEnabledProperty.get());
+        assertFalse(compressorSubsystem.isEnabled());
     }
 }


### PR DESCRIPTION
# Why are we doing this?
* We should add configuration properties to AKIT, so it can 100% replay the match from the logged data. However, this would cause them to show up in 3 places - Preferences, SmartDashboard, and AKIT. That's a little excessive
* The Preferences system already handles using a network table for random access, so our save/load mechanism was no longer relevant - it can be retired.
# Whats changing?
* Ephemeral properties are gone - replaced by calls to the AKIT logger.
* Double/String/BooleanProperties now log and hydrate from AKIT like other systems
* The PropertyManager refreshes all properties at the top of each cycle.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
