### PR TITLE
Add DigitalInput to suite of Akit devices

### DIFF
--- a/src/main/java/edu/wpi/first/wpilibj/MockDigitalInput.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockDigitalInput.java
@@ -6,8 +6,10 @@ import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 
+import xbot.common.controls.io_inputs.XDigitalInputs;
 import xbot.common.controls.sensors.XDigitalInput;
 import xbot.common.injection.DevicePolice;
+import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.simulation.ISimulatableSensor;
 
 public class MockDigitalInput extends XDigitalInput implements ISimulatableSensor {
@@ -18,13 +20,13 @@ public class MockDigitalInput extends XDigitalInput implements ISimulatableSenso
     @AssistedFactory
     public abstract static class MockDigitalInputFactory implements XDigitalInputFactory
     {
-        public abstract MockDigitalInput create(@Assisted("channel") int channel);
+        public abstract MockDigitalInput create(@Assisted("info")DeviceInfo info);
     }
 
     @AssistedInject
-    public MockDigitalInput(@Assisted("channel") int channel, DevicePolice police) {
-        super(police, channel);
-        this.channel = channel;
+    public MockDigitalInput(@Assisted("info") DeviceInfo info, DevicePolice police) {
+        super(police, info);
+        this.channel = info.channel;
     }
 
     public void setValue(boolean value) {
@@ -37,8 +39,9 @@ public class MockDigitalInput extends XDigitalInput implements ISimulatableSenso
         value = !value;
     }
 
-    public boolean getRaw() {
-        return value;
+    @Override
+    public void updateInputs(XDigitalInputs inputs) {
+        inputs.signal = value;
     }
 
     public int getChannel() {

--- a/src/main/java/xbot/common/controls/io_inputs/XDigitalInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/XDigitalInputs.java
@@ -1,0 +1,8 @@
+package xbot.common.controls.io_inputs;
+
+import org.littletonrobotics.junction.AutoLog;
+
+@AutoLog
+public class XDigitalInputs {
+    public boolean signal;
+}

--- a/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
+++ b/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
@@ -1,23 +1,30 @@
 package xbot.common.controls.sensors;
 
+import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.XBaseIO;
+import xbot.common.controls.io_inputs.XDigitalInputs;
+import xbot.common.controls.io_inputs.XDigitalInputsAutoLogged;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.DevicePolice.DeviceType;
+import xbot.common.injection.electrical_contract.DeviceInfo;
 
 public abstract class XDigitalInput implements XBaseIO {
 
     boolean inverted;
+    XDigitalInputsAutoLogged inputs;
+    DeviceInfo info;
     
     public interface XDigitalInputFactory {
-        XDigitalInput create(int channel);
+        XDigitalInput create(DeviceInfo info);
     }
 
-    public XDigitalInput(DevicePolice police, int channel) {
-        police.registerDevice(DeviceType.DigitalIO, channel, this);
+    public XDigitalInput(DevicePolice police, DeviceInfo info) {
+        police.registerDevice(DeviceType.DigitalIO, info.channel, this);
+        inputs = new XDigitalInputsAutoLogged();
     }
     
     public boolean get() {
-        return getRaw() ^ inverted;
+        return inputs.signal ^ inverted;
     }
     
     public void setInverted(boolean inverted) {
@@ -27,6 +34,11 @@ public abstract class XDigitalInput implements XBaseIO {
     public boolean getInverted() {
         return inverted;
     }
-    
-    protected abstract boolean getRaw();
+
+    public abstract void updateInputs(XDigitalInputs inputs);
+
+    public void refreshDataFrame() {
+        updateInputs(inputs);
+        Logger.getInstance().processInputs(info.name+"/DigitalInput", inputs);
+    }
 }

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/DigitalInputWPIAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/DigitalInputWPIAdapter.java
@@ -5,8 +5,10 @@ import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 
 import edu.wpi.first.wpilibj.DigitalInput;
+import xbot.common.controls.io_inputs.XDigitalInputs;
 import xbot.common.controls.sensors.XDigitalInput;
 import xbot.common.injection.DevicePolice;
+import xbot.common.injection.electrical_contract.DeviceInfo;
 
 public class DigitalInputWPIAdapter extends XDigitalInput {
 
@@ -15,28 +17,24 @@ public class DigitalInputWPIAdapter extends XDigitalInput {
     @AssistedFactory
     public abstract static class DigitalInputWPIAdapterFactory implements XDigitalInputFactory
     {
-        public abstract DigitalInputWPIAdapter create(@Assisted("channel") int channel);
+        public abstract DigitalInputWPIAdapter create(@Assisted("info")DeviceInfo info);
     }
 
     /**
      * Create an instance of a Digital Input class. Creates a digital input given a channel.
      *
-     * @param channel
+     * @param info
      *            the DIO channel for the digital input 0-9 are on-board, 10-25 are on the MXP
      */
     @AssistedInject
-    public DigitalInputWPIAdapter(@Assisted("channel") int channel, DevicePolice police) {
-        super(police, channel);
-        adapter = new DigitalInput(channel);
+    public DigitalInputWPIAdapter(@Assisted("info") DeviceInfo info, DevicePolice police) {
+        super(police, info);
+        adapter = new DigitalInput(info.channel);
     }
 
-    /**
-     * Get the value from a digital input channel. Retrieve the value of a single digital input channel from the FPGA.
-     *
-     * @return the status of the digital input
-     */
-    protected boolean getRaw() {
-        return adapter.get();
+    @Override
+    public void updateInputs(XDigitalInputs inputs) {
+        inputs.signal = adapter.get();
     }
 
     /**

--- a/src/test/java/xbot/common/injection/factories/TestAllFactoryClasses.java
+++ b/src/test/java/xbot/common/injection/factories/TestAllFactoryClasses.java
@@ -22,7 +22,7 @@ public class TestAllFactoryClasses extends BaseCommonLibTest {
         getInjectorComponent().pidPropertyManagerFactory().create("pid", 0, 0, 0, 0);
         getInjectorComponent().powerDistributionPanelFactory().create();
         getInjectorComponent().encoderFactory().create("foo", 1, 2, 1);
-        getInjectorComponent().digitalInputFactory().create(5);
+        getInjectorComponent().digitalInputFactory().create(new DeviceInfo("foo", 5));
         getInjectorComponent().analogInputFactory().create(1);
         getInjectorComponent().xboxControllerFactory().create(2);
         getInjectorComponent().solenoidFactory().create(1);


### PR DESCRIPTION
# Why are we doing this?
DigitalInput was not in the AdvantageKit system, so its inputs wouldn't be automatically logged.
# Whats changing?
DigitalInput now will log values to disc or reload them during replay.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
