### PR TITLE
Fix missing swerve periodic

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -330,6 +330,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
     public void periodic() {
         if (contract.isDriveReady()) {
             setupStatusFramesAsNeeded();
+            motorController.periodic();
         }
 
         org.littletonrobotics.junction.Logger.getInstance().recordOutput(


### PR DESCRIPTION
# Why are we doing this?
Swerve steering wasn't rotating the wheels
# Whats changing?
Call `periodic()` on the motor controller to send the PID values
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
