### PR TITLE
Added limit switch states to MockCANSparkMax

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
@@ -670,14 +670,24 @@ public class MockCANSparkMax extends XCANSparkMax implements ISimulatableMotor, 
     public void setReverseLimitSwitch(Type switchType, boolean enabled) {
     }
 
+    public boolean forwardLimitSwitchState;
+    public void setForwardLimitSwitchStateForTesting(boolean pressed) {
+        forwardLimitSwitchState = pressed;
+    }
+
+    public boolean reverseLimitSwitchState;
+    public void setReverseLimitSwitchStateForTesting(boolean pressed) {
+        reverseLimitSwitchState = pressed;
+    }
+
     @Override
     public boolean getForwardLimitSwitchPressed(Type switchType) {
-        return false;
+        return forwardLimitSwitchState;
     }
 
     @Override
     public boolean getReverseLimitSwitchPressed(Type switchType) {
-        return false;
+        return reverseLimitSwitchState;
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?
To allow tests regarding limit switches being pressed

# Whats changing?
Added limit switch states

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
