### PR TITLE
Don't always flip points

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/SwerveSimpleTrajectoryCommand.java
+++ b/src/main/java/xbot/common/subsystems/drive/SwerveSimpleTrajectoryCommand.java
@@ -20,7 +20,8 @@ public class SwerveSimpleTrajectoryCommand extends BaseCommand {
     public SwerveSimpleTrajectoryLogic logic;
 
     @Inject
-    public SwerveSimpleTrajectoryCommand(BaseSwerveDriveSubsystem drive, BasePoseSubsystem pose, PropertyFactory pf, HeadingModuleFactory headingModuleFactory) {
+    public SwerveSimpleTrajectoryCommand(BaseSwerveDriveSubsystem drive, BasePoseSubsystem pose, PropertyFactory pf,
+                                         HeadingModuleFactory headingModuleFactory) {
         this.drive = drive;
         this.pose = pose;
         headingModule = headingModuleFactory.create(drive.getRotateToHeadingPid());
@@ -38,7 +39,8 @@ public class SwerveSimpleTrajectoryCommand extends BaseCommand {
 
     @Override
     public void execute() {
-        Twist2d powers = logic.calculatePowers(pose.getCurrentPose2d(), drive.getPositionalPid(), headingModule, drive.getMaxTargetSpeedMetersPerSecond());
+        Twist2d powers = logic.calculatePowers(pose.getCurrentPose2d(), drive.getPositionalPid(),
+                headingModule, drive.getMaxTargetSpeedMetersPerSecond());
 
         aKitLog.record("Powers", powers);
 

--- a/src/main/java/xbot/common/subsystems/drive/SwerveSimpleTrajectoryCommand.java
+++ b/src/main/java/xbot/common/subsystems/drive/SwerveSimpleTrajectoryCommand.java
@@ -14,13 +14,13 @@ import javax.inject.Inject;
 
 public class SwerveSimpleTrajectoryCommand extends BaseCommand {
 
-    protected BaseDriveSubsystem drive;
+    protected BaseSwerveDriveSubsystem drive;
     protected BasePoseSubsystem pose;
     protected HeadingModule headingModule;
     public SwerveSimpleTrajectoryLogic logic;
 
     @Inject
-    public SwerveSimpleTrajectoryCommand(BaseDriveSubsystem drive, BasePoseSubsystem pose, PropertyFactory pf, HeadingModuleFactory headingModuleFactory) {
+    public SwerveSimpleTrajectoryCommand(BaseSwerveDriveSubsystem drive, BasePoseSubsystem pose, PropertyFactory pf, HeadingModuleFactory headingModuleFactory) {
         this.drive = drive;
         this.pose = pose;
         headingModule = headingModuleFactory.create(drive.getRotateToHeadingPid());
@@ -38,7 +38,7 @@ public class SwerveSimpleTrajectoryCommand extends BaseCommand {
 
     @Override
     public void execute() {
-        Twist2d powers = logic.calculatePowers(pose.getCurrentPose2d(), drive.getPositionalPid(), headingModule);
+        Twist2d powers = logic.calculatePowers(pose.getCurrentPose2d(), drive.getPositionalPid(), headingModule, drive.getMaxTargetSpeedMetersPerSecond());
 
         aKitLog.record("Powers", powers);
 

--- a/src/main/java/xbot/common/trajectory/LowResField.java
+++ b/src/main/java/xbot/common/trajectory/LowResField.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Stack;
 import java.util.TreeMap;
@@ -112,7 +111,7 @@ public class LowResField {
                 Translation2d slidPoint = o.movePointOutsideOfBounds(currentSource);
                 currentSource = slidPoint;
 
-                var specialStartingPoint = XbotSwervePoint.createXbotSwervePoint(
+                var specialStartingPoint = new XbotSwervePoint(
                         slidPoint,
                         targetPoint.getRotation2d(),
                         10);
@@ -129,7 +128,7 @@ public class LowResField {
                 specialFinalPoint = ultimateTarget;
 
                 // For the rest of the logic, consider this "legal" point to be the final point.
-                ultimateTarget = XbotSwervePoint.createXbotSwervePoint(
+                ultimateTarget = new XbotSwervePoint(
                         slidPoint,
                         targetPoint.getRotation2d(),
                         10);
@@ -190,7 +189,7 @@ public class LowResField {
                         var nearestCorner = o.getClosestCornerToPoint(currentSource);
                         nearestCorner = o.getClosestCornerToPoint(currentSource);
                         log.info("Chosen corner:" + nearestCorner.toString());
-                        XbotSwervePoint cornerPoint = XbotSwervePoint.createXbotSwervePoint(
+                        XbotSwervePoint cornerPoint = new XbotSwervePoint(
                                 nearestCorner,
                                 currentTarget.getRotation2d(),
                                 10
@@ -216,12 +215,12 @@ public class LowResField {
                             pointClosestToSource = firstArbitraryCorner;
                         }
 
-                        XbotSwervePoint swervePointNearTarget = XbotSwervePoint.createXbotSwervePoint(
+                        XbotSwervePoint swervePointNearTarget = new XbotSwervePoint(
                                 pointClosestToTarget,
                                 currentTarget.getRotation2d(),
                                 10
                         );
-                        XbotSwervePoint swervePointNearSource = XbotSwervePoint.createXbotSwervePoint(
+                        XbotSwervePoint swervePointNearSource = new XbotSwervePoint(
                                 pointClosestToSource,
                                 currentTarget.getRotation2d(),
                                 10
@@ -261,7 +260,7 @@ public class LowResField {
 
                         log.info("Adding point closest to 'inside' point:" + pointClosestToInside);
 
-                        XbotSwervePoint swervePointNearInside = XbotSwervePoint.createXbotSwervePoint(
+                        XbotSwervePoint swervePointNearInside = new XbotSwervePoint(
                                 pointClosestToInside,
                                 currentTarget.getRotation2d(),
                                 10
@@ -274,7 +273,7 @@ public class LowResField {
                         // General, most straightforward case. Get the nearest corner to the average intersection,
                         // and prepare for another loop.
                         var nearestCorner = o.getClosestCornerToPoint(averageIntersection);
-                        XbotSwervePoint cornerPoint = XbotSwervePoint.createXbotSwervePoint(
+                        XbotSwervePoint cornerPoint = new XbotSwervePoint(
                                 nearestCorner,
                                 currentTarget.getRotation2d(),
                                 10

--- a/src/main/java/xbot/common/trajectory/SimpleTimeInterpolator.java
+++ b/src/main/java/xbot/common/trajectory/SimpleTimeInterpolator.java
@@ -91,7 +91,8 @@ public class SimpleTimeInterpolator {
         accumulatedProductiveSeconds += secondsSinceLastExecute;
 
         // If we somehow have no points to visit, don't do anything.
-        if (keyPoints.size() == 0) {
+
+        if (keyPoints == null || keyPoints.size() == 0) {
             log.warn("No key points to visit!");
             return new InterpolationResult(currentLocation, true, Rotation2d.fromDegrees(0));
         }

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -118,7 +118,7 @@ public class SwerveSimpleTrajectoryLogic {
             log.info("Generating path avoiding obstacles");
 
             // Visualize direct raycast
-            var start = XbotSwervePoint.createXbotSwervePoint(currentPose.getTranslation(), currentPose.getRotation(), 0);
+            var start = new XbotSwervePoint(currentPose.getTranslation(), currentPose.getRotation(), 0);
             var raycast = XbotSwervePoint.generateTrajectory(List.of(
                 start, keyPoints.get(0))
             );

--- a/src/main/java/xbot/common/trajectory/XbotSwervePoint.java
+++ b/src/main/java/xbot/common/trajectory/XbotSwervePoint.java
@@ -21,10 +21,16 @@ public class XbotSwervePoint implements ProvidesInterpolationData {
         this.secondsToPoint = secondsToPoint;
     }
 
+    public XbotSwervePoint(Translation2d translation, Rotation2d rotation, double secondsToPoint) {
+        this.keyPose = new Pose2d(translation, rotation);
+        this.secondsToPoint = secondsToPoint;
+    }
+
     public XbotSwervePoint(double x, double y, double degrees, double secondsToPoint) {
         this.keyPose = new Pose2d(x, y, Rotation2d.fromDegrees(degrees));
         this.secondsToPoint = secondsToPoint;
     }
+
 
     public void setPose(Pose2d pose) {
         this.keyPose = pose;
@@ -62,11 +68,16 @@ public class XbotSwervePoint implements ProvidesInterpolationData {
         return keyPose.getRotation();
     }
 
-    public static XbotSwervePoint createXbotSwervePoint(Translation2d targetLocation, Rotation2d targetHeading, double durationInSeconds) {
+    public static XbotSwervePoint createPotentiallyFilppedXbotSwervePoint(
+            Translation2d targetLocation, Rotation2d targetHeading, double durationInSeconds) {
         var potentiallyFlippedPose = BasePoseSubsystem.convertBlueToRedIfNeeded(new Pose2d(targetLocation, targetHeading));
-        return new XbotSwervePoint(
-                potentiallyFlippedPose.getX(),
-                potentiallyFlippedPose.getY(),
-                potentiallyFlippedPose.getRotation().getDegrees(), durationInSeconds);
+        return new XbotSwervePoint(potentiallyFlippedPose, durationInSeconds);
     }
+
+    public static XbotSwervePoint createPotentiallyFilppedXbotSwervePoint(
+            Pose2d pose, double durationInSeconds) {
+        var potentiallyFlippedPose = BasePoseSubsystem.convertBlueToRedIfNeeded(pose);
+        return new XbotSwervePoint(potentiallyFlippedPose, durationInSeconds);
+    }
+
 }


### PR DESCRIPTION
# Why are we doing this?
The auto drive code was very unpredictable when on Red Alliance
# Whats changing?
The pathfinding code no longer flips most points by default; it will need to be specifically instructed to go to coordinates on the red side of the field.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] tested on simulator 
