### PR TITLE
Add limit switches to the AKIT spark max

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -762,9 +762,13 @@ public abstract class XCANSparkMax {
 
     public abstract void setReverseLimitSwitch(com.revrobotics.SparkLimitSwitch.Type switchType, boolean enabled);
 
-    public abstract boolean getForwardLimitSwitchPressed(com.revrobotics.SparkLimitSwitch.Type switchType);
+    public boolean getForwardLimitSwitchPressed() {
+        return inputs.isForwardLimitSwitchPressed;
+    }
 
-    public abstract boolean getReverseLimitSwitchPressed(com.revrobotics.SparkLimitSwitch.Type switchType);
+    public boolean getReverseLimitSwitchPressed() {
+        return inputs.isReverseLimitSwitchPressed;
+    }
 
     public abstract REVLibError setPeriodicFramePeriod(CANSparkLowLevel.PeriodicFrame frame, int periodMs);
 

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
@@ -709,5 +709,7 @@ public class MockCANSparkMax extends XCANSparkMax implements ISimulatableMotor, 
         inputs.appliedOutput = getAppliedOutput();
         inputs.busVoltage = getBusVoltage();
         inputs.outputCurrent = getOutputCurrent();
+        inputs.isForwardLimitSwitchPressed = forwardLimitSwitchState;
+        inputs.isReverseLimitSwitchPressed = reverseLimitSwitchState;
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
@@ -681,16 +681,6 @@ public class MockCANSparkMax extends XCANSparkMax implements ISimulatableMotor, 
     }
 
     @Override
-    public boolean getForwardLimitSwitchPressed(Type switchType) {
-        return forwardLimitSwitchState;
-    }
-
-    @Override
-    public boolean getReverseLimitSwitchPressed(Type switchType) {
-        return reverseLimitSwitchState;
-    }
-
-    @Override
     public REVLibError setPeriodicFramePeriod(CANSparkLowLevel.PeriodicFrame frame, int periodMs) {
         return REVLibError.kOk;
     }

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -584,14 +584,27 @@ public class CANSparkMaxWpiAdapter extends XCANSparkMax {
         return getPIDControllerInstance().toString();
     }
 
+    com.revrobotics.SparkLimitSwitch.Type forwardSwitchType = null;
+    com.revrobotics.SparkLimitSwitch.Type reverseSwitchType = null;
+
     @Override
     public void setForwardLimitSwitch(com.revrobotics.SparkLimitSwitch.Type switchType, boolean enabled) {
         internalSpark.getForwardLimitSwitch(switchType).enableLimitSwitch(enabled);
+        if (enabled) {
+            forwardSwitchType = switchType;
+        } else {
+            forwardSwitchType = null;
+        }
     }
 
     @Override
     public void setReverseLimitSwitch(com.revrobotics.SparkLimitSwitch.Type switchType, boolean enabled) {
         internalSpark.getReverseLimitSwitch(switchType).enableLimitSwitch(enabled);
+        if (enabled) {
+            reverseSwitchType = switchType;
+        } else {
+            reverseSwitchType = null;
+        }
     }
 
     @Override
@@ -602,6 +615,20 @@ public class CANSparkMaxWpiAdapter extends XCANSparkMax {
     @Override
     public boolean getReverseLimitSwitchPressed(com.revrobotics.SparkLimitSwitch.Type switchType) {
         return internalSpark.getReverseLimitSwitch(switchType).isPressed();
+    }
+
+    private boolean getForwardLimitSwitchPressed_internal() {
+        if (forwardSwitchType == null) {
+            return false;
+        }
+        return internalSpark.getForwardLimitSwitch(forwardSwitchType).isPressed();
+    }
+
+    private boolean getReverseLimitSwitchPressed_internal() {
+        if (reverseSwitchType == null) {
+            return false;
+        }
+        return internalSpark.getReverseLimitSwitch(reverseSwitchType).isPressed();
     }
 
     @Override
@@ -619,5 +646,7 @@ public class CANSparkMaxWpiAdapter extends XCANSparkMax {
         inputs.appliedOutput = getAppliedOutput_internal();
         inputs.busVoltage = getBusVoltage_internal();
         inputs.outputCurrent = getOutputCurrent_internal();
+        inputs.isForwardLimitSwitchPressed = getForwardLimitSwitchPressed_internal();
+        inputs.isReverseLimitSwitchPressed = getReverseLimitSwitchPressed_internal();
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -607,16 +607,6 @@ public class CANSparkMaxWpiAdapter extends XCANSparkMax {
         }
     }
 
-    @Override
-    public boolean getForwardLimitSwitchPressed(com.revrobotics.SparkLimitSwitch.Type switchType) {
-        return internalSpark.getForwardLimitSwitch(switchType).isPressed();
-    }
-
-    @Override
-    public boolean getReverseLimitSwitchPressed(com.revrobotics.SparkLimitSwitch.Type switchType) {
-        return internalSpark.getReverseLimitSwitch(switchType).isPressed();
-    }
-
     private boolean getForwardLimitSwitchPressed_internal() {
         if (forwardSwitchType == null) {
             return false;

--- a/src/main/java/xbot/common/controls/io_inputs/XCANSparkMaxInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/XCANSparkMaxInputs.java
@@ -12,4 +12,6 @@ public class XCANSparkMaxInputs
     public double appliedOutput;
     public double busVoltage;
     public double outputCurrent;
+    public boolean isForwardLimitSwitchPressed;
+    public boolean isReverseLimitSwitchPressed;
 }


### PR DESCRIPTION
# Why are we doing this?
This will log the values of the limit switches every robot cycle; necessary if we want to do any sort of log replay in the future. Also implicitly puts their values onto NetworkTables for ease of viewing.

# Whats changing?
CANSparkMax now has limit switch values as part of the "inputs" object for AKIT.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] tested on simulator
