### PR TITLE
Fix Digital Input AKIT names and mark Maintainer properties important

### DIFF
--- a/src/main/java/edu/wpi/first/wpilibj/MockDigitalInput.java
+++ b/src/main/java/edu/wpi/first/wpilibj/MockDigitalInput.java
@@ -20,12 +20,17 @@ public class MockDigitalInput extends XDigitalInput implements ISimulatableSenso
     @AssistedFactory
     public abstract static class MockDigitalInputFactory implements XDigitalInputFactory
     {
-        public abstract MockDigitalInput create(@Assisted("info")DeviceInfo info);
+        public abstract MockDigitalInput create(
+                @Assisted("info")DeviceInfo info,
+                @Assisted("owningSystemPrefix") String owningSystemPrefix);
     }
 
     @AssistedInject
-    public MockDigitalInput(@Assisted("info") DeviceInfo info, DevicePolice police) {
-        super(police, info);
+    public MockDigitalInput(
+            @Assisted("info") DeviceInfo info,
+            @Assisted("owningSystemPrefix") String owningSystemPrefix,
+            DevicePolice police) {
+        super(police, info, owningSystemPrefix);
         this.channel = info.channel;
     }
 

--- a/src/main/java/xbot/common/command/BaseMaintainerCommand.java
+++ b/src/main/java/xbot/common/command/BaseMaintainerCommand.java
@@ -55,7 +55,7 @@ public abstract class BaseMaintainerCommand<T> extends BaseCommand {
         this.addRequirements(subsystemToMaintain);
 
         pf.setPrefix(this);
-        pf.setDefaultLevel(Property.PropertyLevel.Debug);
+        pf.setDefaultLevel(Property.PropertyLevel.Important);
         errorToleranceProp = pf.createPersistentProperty("Error Tolerance", defaultErrorTolerance);
         errorTimeStableWindowProp = pf.createPersistentProperty("Error Time Stable Window", defaultTimeStableWindow);
 

--- a/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
+++ b/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
@@ -13,15 +13,17 @@ public abstract class XDigitalInput implements XBaseIO {
     boolean inverted;
     final XDigitalInputsAutoLogged inputs;
     final DeviceInfo info;
+    private String akitName;
     
     public interface XDigitalInputFactory {
-        XDigitalInput create(DeviceInfo info);
+        XDigitalInput create(DeviceInfo info, String owningSystemPrefix);
     }
 
-    public XDigitalInput(DevicePolice police, DeviceInfo info) {
+    public XDigitalInput(DevicePolice police, DeviceInfo info, String owningSystemPrefix) {
         police.registerDevice(DeviceType.DigitalIO, info.channel, this);
         inputs = new XDigitalInputsAutoLogged();
         this.info = info;
+        akitName = owningSystemPrefix + info.name + "DigitalInput";
     }
     
     public boolean get() {
@@ -40,6 +42,6 @@ public abstract class XDigitalInput implements XBaseIO {
 
     public void refreshDataFrame() {
         updateInputs(inputs);
-        Logger.getInstance().processInputs(info.name+"/DigitalInput", inputs);
+        Logger.getInstance().processInputs(akitName, inputs);
     }
 }

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/DigitalInputWPIAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/DigitalInputWPIAdapter.java
@@ -17,7 +17,7 @@ public class DigitalInputWPIAdapter extends XDigitalInput {
     @AssistedFactory
     public abstract static class DigitalInputWPIAdapterFactory implements XDigitalInputFactory
     {
-        public abstract DigitalInputWPIAdapter create(@Assisted("info")DeviceInfo info);
+        public abstract DigitalInputWPIAdapter create(@Assisted("info")DeviceInfo info, @Assisted("owningSystemPrefix")String owningSystemPrefix);
     }
 
     /**
@@ -27,8 +27,11 @@ public class DigitalInputWPIAdapter extends XDigitalInput {
      *            the DIO channel for the digital input 0-9 are on-board, 10-25 are on the MXP
      */
     @AssistedInject
-    public DigitalInputWPIAdapter(@Assisted("info") DeviceInfo info, DevicePolice police) {
-        super(police, info);
+    public DigitalInputWPIAdapter(
+            @Assisted("info") DeviceInfo info,
+            @Assisted("owningSystemPrefix")String owningSystemPrefix,
+            DevicePolice police) {
+        super(police, info, owningSystemPrefix);
         adapter = new DigitalInput(info.channel);
     }
 

--- a/src/main/java/xbot/common/properties/BooleanProperty.java
+++ b/src/main/java/xbot/common/properties/BooleanProperty.java
@@ -52,8 +52,8 @@ public class BooleanProperty extends Property {
         Boolean nullableTableValue = activeStore.getBoolean(key);
         
         if(nullableTableValue == null) {
-            log.error("Property key \"" + key + "\" not present in the underlying store!"
-                    + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
+            //log.error("Property key \"" + key + "\" not present in the underlying store!"
+            //        + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             set(defaultValue);
             return defaultValue;
         }

--- a/src/main/java/xbot/common/properties/DoubleProperty.java
+++ b/src/main/java/xbot/common/properties/DoubleProperty.java
@@ -58,8 +58,8 @@ public class DoubleProperty extends Property {
         Double nullableTableValue = activeStore.getDouble(key);
         
         if(nullableTableValue == null) {
-            log.error("Property key \"" + key + "\" not present in the underlying store!"
-                    + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
+            //log.error("Property key \"" + key + "\" not present in the underlying store!"
+            //        + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             set(defaultValue);
             return defaultValue;
         }

--- a/src/main/java/xbot/common/properties/StringProperty.java
+++ b/src/main/java/xbot/common/properties/StringProperty.java
@@ -53,8 +53,8 @@ public class StringProperty extends Property {
         String nullableTableValue = activeStore.getString(key);
         
         if(nullableTableValue == null) {
-            log.error("Property key \"" + key + "\" not present in the underlying store!"
-                    + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
+            //log.error("Property key \"" + key + "\" not present in the underlying store!"
+            //        + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             set(defaultValue);
             return defaultValue;
         }

--- a/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
@@ -16,6 +16,7 @@ import xbot.common.math.WrappedRotation2d;
 import xbot.common.math.XYPair;
 import xbot.common.properties.BooleanProperty;
 import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.Property;
 import xbot.common.properties.PropertyFactory;
 
 public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFrameRefreshable {
@@ -54,7 +55,8 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFra
         // Right when the system is initialized, we need to have the old value be
         // the same as the current value, to avoid any sudden changes later
         currentHeading = WrappedRotation2d.fromDegrees(0);
-        
+
+        propManager.setDefaultLevel(Property.PropertyLevel.Debug);
         rioRotated = propManager.createPersistentProperty("RIO rotated", false);
         inherentRioPitch = propManager.createPersistentProperty("Inherent RIO pitch", 0.0);
         inherentRioRoll = propManager.createPersistentProperty("Inherent RIO roll", 0.0);
@@ -69,8 +71,8 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFra
 
         aKitLog.record("AdjustedHeadingDegrees", currentHeading.getDegrees());
         aKitLog.record("AdjustedHeadingRadians", currentHeading.getRadians());
-        aKitLog.record("AdjustedPitchDegrees", this.getRobotPitch());
-        aKitLog.record("AdjustedRollDegrees", this.getRobotRoll());
+        //aKitLog.record("AdjustedPitchDegrees", this.getRobotPitch());
+        //aKitLog.record("AdjustedRollDegrees", this.getRobotRoll());
         aKitLog.record("AdjustedYawVelocityDegrees", getYawAngularVelocity());
     }  
     

--- a/src/test/java/xbot/common/injection/factories/TestAllFactoryClasses.java
+++ b/src/test/java/xbot/common/injection/factories/TestAllFactoryClasses.java
@@ -22,7 +22,7 @@ public class TestAllFactoryClasses extends BaseCommonLibTest {
         getInjectorComponent().pidPropertyManagerFactory().create("pid", 0, 0, 0, 0);
         getInjectorComponent().powerDistributionPanelFactory().create();
         getInjectorComponent().encoderFactory().create("foo", 1, 2, 1);
-        getInjectorComponent().digitalInputFactory().create(new DeviceInfo("foo", 5));
+        getInjectorComponent().digitalInputFactory().create(new DeviceInfo("foo", 5), "TestPrefix");
         getInjectorComponent().analogInputFactory().create(1);
         getInjectorComponent().xboxControllerFactory().create(2);
         getInjectorComponent().solenoidFactory().create(1);


### PR DESCRIPTION
# Why are we doing this?

# What's changing?
- Fixes for digital inputs not having parents
- Comment out useless spew when properties not found (speeds up robot boot)
- Add "important" tag to maintainer properties around stability
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
