### PR TITLE
Set the default current for Spark Max motor controllers to 40A.

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -8,9 +8,7 @@ import com.revrobotics.CANSparkBase.SoftLimitDirection;
 import com.revrobotics.CANSparkLowLevel;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.REVLibError;
-import com.revrobotics.SparkAbsoluteEncoder;
 import com.revrobotics.SparkPIDController.ArbFFUnits;
-
 import org.apache.logging.log4j.LogManager;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.io_inputs.XCANSparkMaxInputs;
@@ -32,11 +30,11 @@ public abstract class XCANSparkMax {
     PropertyFactory propertyFactory;
 
     protected boolean usesPropertySystem = true;
-    private DoubleProperty kPprop;
-    private DoubleProperty kIprop;
-    private DoubleProperty kDprop;
+    private DoubleProperty kPProp;
+    private DoubleProperty kIProp;
+    private DoubleProperty kDProp;
     private DoubleProperty kIzProp;
-    private DoubleProperty kFFprop;
+    private DoubleProperty kFFProp;
     private DoubleProperty kMaxOutputProp;
     private DoubleProperty kMinOutputProp;
 
@@ -58,6 +56,10 @@ public abstract class XCANSparkMax {
 
         public XCANSparkMax create(DeviceInfo deviceInfo, String owningSystemPrefix, String name, String pidPropertyPrefix) {
             return create(deviceInfo, owningSystemPrefix, name, pidPropertyPrefix, new XCANSparkMaxPIDProperties());
+        }
+
+        public XCANSparkMax create(DeviceInfo deviceInfo, String owningSystemPrefix, String name) {
+            return create(deviceInfo, owningSystemPrefix, name, owningSystemPrefix+"/"+name, new XCANSparkMaxPIDProperties());
         }
 
         public XCANSparkMax createWithoutProperties(DeviceInfo deviceInfo, String owningSystemPrefix, String name) {
@@ -88,11 +90,11 @@ public abstract class XCANSparkMax {
             this.propertyFactory = pf;
 
             this.propertyFactory.setPrefix(pidPropertyPrefix);
-            kPprop = pf.createPersistentProperty("kP", defaultPIDProperties.p());
-            kIprop = pf.createPersistentProperty("kI", defaultPIDProperties.i());
-            kDprop = pf.createPersistentProperty("kD", defaultPIDProperties.d());
-            kIzProp = pf.createPersistentProperty("kIzone", defaultPIDProperties.iZone());
-            kFFprop = pf.createPersistentProperty("kFeedForward", defaultPIDProperties.feedForward());
+            kPProp = pf.createPersistentProperty("kP", defaultPIDProperties.p());
+            kIProp = pf.createPersistentProperty("kI", defaultPIDProperties.i());
+            kDProp = pf.createPersistentProperty("kD", defaultPIDProperties.d());
+            kIzProp = pf.createPersistentProperty("kIZone", defaultPIDProperties.iZone());
+            kFFProp = pf.createPersistentProperty("kFeedForward", defaultPIDProperties.feedForward());
             kMaxOutputProp = pf.createPersistentProperty("kMaxOutput", defaultPIDProperties.maxOutput());
             kMinOutputProp = pf.createPersistentProperty("kMinOutput", defaultPIDProperties.minOutput());
         }
@@ -108,11 +110,11 @@ public abstract class XCANSparkMax {
 
     private void setAllProperties() {
         if (usesPropertySystem) {
-            setP(kPprop.get());
-            setI(kIprop.get());
-            setD(kDprop.get());
+            setP(kPProp.get());
+            setI(kIProp.get());
+            setD(kDProp.get());
             setIZone(kIzProp.get());
-            setFF(kFFprop.get());
+            setFF(kFFProp.get());
             setOutputRange(kMinOutputProp.get(), kMaxOutputProp.get());
         } else {
             log.warn("setAllProperties called on a SparkMax that doesn't use the property system");
@@ -125,11 +127,11 @@ public abstract class XCANSparkMax {
                 setAllProperties();
                 firstPeriodicCall = false;
             }
-            kPprop.hasChangedSinceLastCheck(this::setP);
-            kIprop.hasChangedSinceLastCheck(this::setI);
-            kDprop.hasChangedSinceLastCheck(this::setD);
+            kPProp.hasChangedSinceLastCheck(this::setP);
+            kIProp.hasChangedSinceLastCheck(this::setI);
+            kDProp.hasChangedSinceLastCheck(this::setD);
             kIzProp.hasChangedSinceLastCheck(this::setIZone);
-            kFFprop.hasChangedSinceLastCheck(this::setFF);
+            kFFProp.hasChangedSinceLastCheck(this::setFF);
             kMaxOutputProp.hasChangedSinceLastCheck((value) -> setOutputRange(kMinOutputProp.get(), value));
             kMinOutputProp.hasChangedSinceLastCheck((value) -> setOutputRange(value, kMaxOutputProp.get()));
         }
@@ -144,9 +146,9 @@ public abstract class XCANSparkMax {
     public abstract void set(double speed);
 
     /**
-     * Sets the voltage output of the SpeedController. This is equivillant to a call
+     * Sets the voltage output of the SpeedController. This is equivalent to a call
      * to SetReference(output, rev::ControlType::kVoltage). The behavior of this
-     * call differs slightly from the WPILib documetation for this call since the
+     * call differs slightly from the WPILib documentation for this call since the
      * device internally sets the desired voltage (not a compensation value). That
      * means that this *can* be a 'set-and-forget' call.
      *
@@ -499,7 +501,7 @@ public abstract class XCANSparkMax {
     /**
      * Get the value of a specific fault
      *
-     * @param faultID The ID of the fault to retrive
+     * @param faultID The ID of the fault to retrieve
      *
      * @return True if the fault with the given ID occurred.
      */
@@ -509,7 +511,7 @@ public abstract class XCANSparkMax {
     /**
      * Get the value of a specific sticky fault
      *
-     * @param faultID The ID of the sticky fault to retrive
+     * @param faultID The ID of the sticky fault to retrieve
      *
      * @return True if the sticky fault with the given ID occurred.
      */
@@ -557,10 +559,10 @@ public abstract class XCANSparkMax {
 
     /**
      * Sets timeout for sending CAN messages with SetParameter* and GetParameter*
-     * calls. These calls will block for up to this amoutn of time before returning
-     * a timeout erro. A timeout of 0 will make the SetParameter* calls
+     * calls. These calls will block for up to this amount of time before returning
+     * a timeout error. A timeout of 0 will make the SetParameter* calls
      * non-blocking, and instead will check the response in a separate thread. With
-     * this configuration, any error messages will appear on the drivestration but
+     * this configuration, any error messages will appear on the driver station but
      * will not be returned by the GetLastError() call.
      *
      * @param milliseconds The timeout in milliseconds.
@@ -612,7 +614,7 @@ public abstract class XCANSparkMax {
     public abstract boolean isSoftLimitEnabled(SoftLimitDirection direction);
 
     /**
-     * All device errors are tracked on a per thread basis for all devices in that
+     * All device errors are tracked on a per-thread basis for all devices in that
      * thread. This is meant to be called immediately following another call that
      * has the possibility of returning an error to validate if an error has
      * occurred.
@@ -810,6 +812,6 @@ public abstract class XCANSparkMax {
 
     public void refreshDataFrame() {
         updateInputs(inputs);
-        Logger.getInstance().processInputs(akitName, inputs);
+        Logger.processInputs(akitName, inputs);
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
@@ -1,26 +1,20 @@
 package xbot.common.controls.actuators.mock_adapters;
 
-import java.math.BigDecimal;
-
 import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.ExternalFollower;
 import com.revrobotics.CANSparkBase.FaultID;
-import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkBase.SoftLimitDirection;
 import com.revrobotics.CANSparkLowLevel;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMaxLowLevel;
 import com.revrobotics.REVLibError;
 import com.revrobotics.SparkLimitSwitch.Type;
 import com.revrobotics.SparkPIDController.ArbFFUnits;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.json.JSONObject;
-
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
 import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.actuators.XCANSparkMaxPIDProperties;
 import xbot.common.controls.io_inputs.XCANSparkMaxInputs;
@@ -34,11 +28,13 @@ import xbot.common.properties.PropertyFactory;
 import xbot.common.simulation.ISimulatableMotor;
 import xbot.common.simulation.ISimulatableSensor;
 
+import java.math.BigDecimal;
+
 public class MockCANSparkMax extends XCANSparkMax implements ISimulatableMotor, ISimulatableSensor {
-    private static Logger log = LogManager.getLogger(MockCANSparkMax.class);
+    private static final Logger log = LogManager.getLogger(MockCANSparkMax.class);
     private double power = 0;
     private double velocity = 0;
-    private double simulationScalingValue;
+    private final double simulationScalingValue;
     boolean inverted = false;
     public XEncoder internalEncoder = null;
     double positionOffset = 0;

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -3,7 +3,6 @@ package xbot.common.controls.actuators.wpi_adapters;
 import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.ExternalFollower;
 import com.revrobotics.CANSparkBase.FaultID;
-import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkBase.SoftLimitDirection;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
@@ -33,7 +32,7 @@ import xbot.common.properties.PropertyFactory;
 
 public class CANSparkMaxWpiAdapter extends XCANSparkMax {
 
-    private CANSparkMax internalSpark;
+    private final CANSparkMax internalSpark;
 
     @AssistedFactory
     public abstract static class CANSparkMaxWpiAdapterFactory extends XCANSparkMaxFactory {
@@ -54,6 +53,7 @@ public class CANSparkMaxWpiAdapter extends XCANSparkMax {
         super(deviceInfo, owningSystemPrefix, name, propMan, police, pidPropertyPrefix, defaultPIDProperties);
         internalSpark = new CANSparkMax(deviceInfo.channel, MotorType.kBrushless);
         setInverted(deviceInfo.inverted);
+        setSmartCurrentLimit(40);
     }
 
     @Override


### PR DESCRIPTION
Since I'm touching Spark Max classes, I'm also cleaning up warnings, and undoing a breaking change to XCANSparkMaxFactory

# Why are we doing this?

https://app.asana.com/0/38541457243752/1206617786624122/f

# Whats changing?

* Set default current to 40A on all SparkMax instances
* Restore a create() overload on XCANSparkMaxFactory
* Clean up IDE warnings

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
