### PR TITLE
Disable limit switches on motor controllers for swerve drives

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
@@ -3,6 +3,7 @@ package xbot.common.subsystems.drive.swerve;
 import com.revrobotics.CANSparkBase;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.REVLibError;
+import com.revrobotics.SparkLimitSwitch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import xbot.common.command.BaseSetpointSubsystem;
@@ -66,6 +67,8 @@ public class SwerveDriveSubsystem extends BaseSetpointSubsystem<Double> {
             this.motorController.setSmartCurrentLimit(45);
             this.motorController.setIdleMode(CANSparkMax.IdleMode.kBrake);
             this.motorController.enableVoltageCompensation(12);
+            this.motorController.setForwardLimitSwitch(SparkLimitSwitch.Type.kNormallyClosed, false);
+            this.motorController.setReverseLimitSwitch(SparkLimitSwitch.Type.kNormallyClosed, false);
         }
     }
 

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 
 import com.revrobotics.CANSparkBase;
 import com.revrobotics.REVLibError;
+import com.revrobotics.SparkLimitSwitch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -79,6 +80,8 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
                     ));
             this.motorController.setClosedLoopRampRate(0.02);
             this.motorController.setOpenLoopRampRate(0.05);
+            this.motorController.setForwardLimitSwitch(SparkLimitSwitch.Type.kNormallyClosed, false);
+            this.motorController.setReverseLimitSwitch(SparkLimitSwitch.Type.kNormallyClosed, false);
         }
         if (electricalContract.areCanCodersReady()) {
             this.encoder = canCoderFactory.create(electricalContract.getSteeringEncoder(swerveInstance), this.getPrefix());


### PR DESCRIPTION
# Why are we doing this?

We are using the Swerve Drive motor controllers for an absolute encorder for another mechanism.  The absolute encoder pinout conflicts with the limit switchces that are enabled by default, causing swerve drive problems.

# Whats changing?

Disable limit switches on all swerve motor controllers

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
