### PR TITLE
Autonomous messaging and make execute() not abstract.

### DIFF
--- a/src/main/java/xbot/common/command/BaseCommand.java
+++ b/src/main/java/xbot/common/command/BaseCommand.java
@@ -46,9 +46,6 @@ public abstract class BaseCommand extends Command implements IPropertySupport {
     @Override
     public abstract void initialize();
 
-    @Override
-    public abstract void execute();    
-
     public void includeOnSmartDashboard() {
         if (commandPutter != null) {
             commandPutter.addCommandToSmartDashboard(this);

--- a/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
+++ b/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -52,4 +53,9 @@ public class AutonomousCommandSelector extends BaseSubsystem {
         aKitLog.record("Auto Program State", state);
     }
 
+    public Command createAutonomousStateMessageCommand(String message) {
+        return new  InstantCommand(() -> {
+                    this.setAutonomousState(message);
+        });
+    }
 }


### PR DESCRIPTION
# Why are we doing this?
We have more and more commands with `execute` being a no-op. At this point it no longer seems to have a pedagogical reason to be enforced on every command.
# Whats changing?
- `execute` no longer mandatory on all commands.
- Convenience function on AutonomousSelector for updating a dashboard property.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] tested on simulator
