### PR TITLE
Add log level concept to AKitLogger

### DIFF
--- a/src/main/java/xbot/common/advantage/AKitLogger.java
+++ b/src/main/java/xbot/common/advantage/AKitLogger.java
@@ -13,8 +13,23 @@ import us.hebi.quickbuf.ProtoMessage;
 import xbot.common.properties.IPropertySupport;
 
 public class AKitLogger {
+    public enum LogLevel {
+        DEBUG, INFO
+    }
+    private static LogLevel globalLogLevel = LogLevel.DEBUG;
 
     private String prefix = "";
+    private LogLevel logLevel = globalLogLevel;
+
+    /**
+     * This controls the log level for all AKitLoggers. 
+     * This will generally be set to INFO during competitions so that debug logs are not sent
+     * to the network table.
+     * @param level
+     */
+    public static void setGlobalLogLevel(LogLevel level) {
+        globalLogLevel = level;
+    }
 
     public AKitLogger(String prefix) {
         this.prefix = prefix;
@@ -24,91 +39,158 @@ public class AKitLogger {
         this(parent.getPrefix());
     }
 
+    public void setLogLevel(LogLevel level) {
+        this.logLevel = level;
+    }
+
     public void record(String key, byte[] value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, boolean value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, int value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, long value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, float value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, double value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, String value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public <E extends Enum<E>> void record(String key, E value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public <U extends Unit<U>> void record(String key, Measure<U> value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, boolean[] value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, int[] value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, long[] value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, float[] value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, double[] value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, String[] value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public <T> void record(String key, Struct<T> struct, T value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, struct, value);
     }
 
     @SuppressWarnings("unchecked")
     public <T> void record(String key, Struct<T> struct, T... value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, struct, value);
     }
 
     //CHECKSTYLE:OFF
     public <T, MessageType extends ProtoMessage<?>> void record(String key, Protobuf<T, MessageType> proto, T value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, proto, value);
     }
     //CHECKSTYLE:ON
 
     public <T extends WPISerializable> void record(String key, T value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     @SuppressWarnings("unchecked")
     public <T extends StructSerializable> void record(String key, T... value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, Mechanism2d value) {
+        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+            return;
+        }
         Logger.recordOutput(this.prefix + key, value);
     }
 

--- a/src/main/java/xbot/common/advantage/AKitLogger.java
+++ b/src/main/java/xbot/common/advantage/AKitLogger.java
@@ -25,7 +25,7 @@ public class AKitLogger {
      * This controls the log level for all AKitLoggers. 
      * This will generally be set to INFO during competitions so that debug logs are not sent
      * to the network table.
-     * @param level
+     * @param level new level to set
      */
     public static void setGlobalLogLevel(LogLevel level) {
         globalLogLevel = level;
@@ -39,6 +39,12 @@ public class AKitLogger {
         this(parent.getPrefix());
     }
 
+    /**
+     * Set the log level for this particular logger instance.
+     * Log calls made after this will have that level when checking 
+     * if they should record or not.
+     * @param level new level to set
+     */
     public void setLogLevel(LogLevel level) {
         this.logLevel = level;
     }

--- a/src/main/java/xbot/common/advantage/AKitLogger.java
+++ b/src/main/java/xbot/common/advantage/AKitLogger.java
@@ -49,113 +49,117 @@ public class AKitLogger {
         this.logLevel = level;
     }
 
+    protected boolean shouldSkipLogging() {
+        return this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO;
+    }
+
     public void record(String key, byte[] value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, boolean value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, int value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, long value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, float value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, double value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, String value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public <E extends Enum<E>> void record(String key, E value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public <U extends Unit<U>> void record(String key, Measure<U> value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, boolean[] value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, int[] value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, long[] value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, float[] value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, double[] value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, String[] value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public <T> void record(String key, Struct<T> struct, T value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, struct, value);
@@ -163,7 +167,7 @@ public class AKitLogger {
 
     @SuppressWarnings("unchecked")
     public <T> void record(String key, Struct<T> struct, T... value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, struct, value);
@@ -171,7 +175,7 @@ public class AKitLogger {
 
     //CHECKSTYLE:OFF
     public <T, MessageType extends ProtoMessage<?>> void record(String key, Protobuf<T, MessageType> proto, T value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, proto, value);
@@ -179,7 +183,7 @@ public class AKitLogger {
     //CHECKSTYLE:ON
 
     public <T extends WPISerializable> void record(String key, T value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
@@ -187,14 +191,14 @@ public class AKitLogger {
 
     @SuppressWarnings("unchecked")
     public <T extends StructSerializable> void record(String key, T... value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);
     }
 
     public void record(String key, Mechanism2d value) {
-        if(this.logLevel == LogLevel.DEBUG && globalLogLevel == LogLevel.INFO) {
+        if(this.shouldSkipLogging()) {
             return;
         }
         Logger.recordOutput(this.prefix + key, value);


### PR DESCRIPTION
# Why are we doing this?
We're starting to have too many values being sent to akit. This should allow us to mark some as debug and not send them during competitions at least.

https://app.asana.com/0/38541457243752/1206617786624119

# Whats changing?
- new static log level on AKitLogger that would be set to INFO during competitions (statically, maybe in Robot.java?) and otherwise DEBUG
- individual loggers can be set into debug or info mode before calling to log. If the global level is info but the local level is debug, the call to log will no-op

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
