### PR TITLE
XDigitalInput supports inversion at creation time

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
+++ b/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
@@ -24,6 +24,7 @@ public abstract class XDigitalInput implements XBaseIO {
         inputs = new XDigitalInputsAutoLogged();
         this.info = info;
         akitName = owningSystemPrefix + info.name + "DigitalInput";
+        this.setInverted(info.inverted);
     }
     
     public boolean get() {

--- a/src/test/java/xbot/common/controls/sensors/DigitalInputTest.java
+++ b/src/test/java/xbot/common/controls/sensors/DigitalInputTest.java
@@ -1,0 +1,23 @@
+package xbot.common.controls.sensors;
+
+import org.junit.Test;
+import xbot.common.injection.BaseCommonLibTest;
+import xbot.common.injection.electrical_contract.DeviceInfo;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DigitalInputTest extends BaseCommonLibTest {
+    @Test
+    public void testInversion() {
+        DeviceInfo info = new DeviceInfo("TestInput", 0, false, 0);
+        XDigitalInput digitalInput = getInjectorComponent().digitalInputFactory().create(info, "testPrefix");
+
+        assertFalse(digitalInput.getInverted());
+
+        info = new DeviceInfo("TestInput", 1, true, 0);
+        digitalInput = getInjectorComponent().digitalInputFactory().create(info, "testPrefix");
+
+        assertTrue(digitalInput.getInverted());
+    }
+}


### PR DESCRIPTION
# Why are we doing this?
It's nice to set up inversion via electrical contracts rather than after creating the object.
# Whats changing?
XDigitalInput now respects the inversion parameter of the DeviceInfo when being created.
# Questions/notes for reviewers

# How this was tested
- [x] unit tests added
- [ ] tested on robot
