### PR TITLE
Swerve uses motor pid by default

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
@@ -45,7 +45,7 @@ public class SwerveDriveSubsystem extends BaseSetpointSubsystem<Double> {
         this.contract = electricalContract;
         this.metersPerMotorRotation = pf.createPersistentProperty(
                 "MetersPerMotorRotation", 2.02249 / BasePoseSubsystem.INCHES_IN_A_METER);
-        this.enableDrivePid = pf.createPersistentProperty("EnableDrivePID", false);
+        this.enableDrivePid = pf.createPersistentProperty("EnableDrivePID", true);
         this.minVelocityToEngagePid = pf.createPersistentProperty("MinVelocityToEngagePID", 0.01);
 
         if (electricalContract.isDriveReady()) {


### PR DESCRIPTION
# Why are we doing this?
Motor PIDs have been working well for us.
# Whats changing?
Change drive motors to use onboard pids by default
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
