### PR TITLE
Base setupoint command should always require at least 1 subsystem

### DIFF
--- a/src/main/java/xbot/common/command/BaseSetpointCommand.java
+++ b/src/main/java/xbot/common/command/BaseSetpointCommand.java
@@ -2,9 +2,11 @@ package xbot.common.command;
 
 public abstract class BaseSetpointCommand extends BaseCommand {
 
-    public BaseSetpointCommand(SupportsSetpointLock... systems) {
-        for (SupportsSetpointLock system : systems) {
-            this.addRequirements(system.getSetpointLock());
+    public BaseSetpointCommand(SupportsSetpointLock system, SupportsSetpointLock... additionalSystems) {
+        // must require at least 1 system
+        this.addRequirements(system.getSetpointLock());
+        for (SupportsSetpointLock additionalSystem : additionalSystems) {
+            this.addRequirements(additionalSystem.getSetpointLock());
         }
     }
 


### PR DESCRIPTION
# Why are we doing this?
Bugs have made it into the comp code because people forget to pass in the current subsystem in super() call because the `...` in Java allows an empty list of args.

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
