### PR TITLE
Feature/safety feature on setpoint

### DIFF
--- a/src/main/java/xbot/common/command/BaseSetpointSubsystem.java
+++ b/src/main/java/xbot/common/command/BaseSetpointSubsystem.java
@@ -24,6 +24,12 @@ public abstract class BaseSetpointSubsystem<T> extends BaseSubsystem implements 
     }
     
     public boolean isMaintainerAtGoal() {
+
+        if (lastTargetValueUsedforAtGoal == null) {
+            // Nobody has ever called setMaintainerIsAtGoal.
+            return false;
+        }
+
         if (!areTwoTargetsEquivalent(getTargetValue(), lastTargetValueUsedforAtGoal)) {
             // At goal was set when the target was significantly different than it is now.
             // Could happen if somebody updates the target and immediately calls isMaintainerAtGoal.

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
@@ -178,6 +178,11 @@ public class SwerveDriveSubsystem extends BaseSetpointSubsystem<Double> {
     }
 
     @Override
+    protected boolean areTwoTargetsEquivalent(Double target1, Double target2) {
+        return BaseSetpointSubsystem.areTwoDoublesEquivalent(target1, target2);
+    }
+
+    @Override
     public void periodic() {
         if (contract.isDriveReady()) {
             aKitLog.record("CurrentVelocity",

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -330,6 +330,11 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
     }
 
     @Override
+    protected boolean areTwoTargetsEquivalent(Double target1, Double target2) {
+        return BaseSetpointSubsystem.areTwoDoublesEquivalent(target1, target2);
+    }
+
+    @Override
     public void periodic() {
         if (contract.isDriveReady()) {
             setupStatusFramesAsNeeded();

--- a/src/test/java/xbot/common/command/MockSetpointSubsystem.java
+++ b/src/test/java/xbot/common/command/MockSetpointSubsystem.java
@@ -38,4 +38,9 @@ public class MockSetpointSubsystem extends BaseSetpointSubsystem<Double> {
     public boolean isCalibrated() {
         return false;
     }
+
+    @Override
+    protected boolean areTwoTargetsEquivalent(Double target1, Double target2) {
+        return BaseSetpointSubsystem.areTwoDoublesEquivalent(target1, target2);
+    }
 }


### PR DESCRIPTION
# Why are we doing this?
Callers could get wrong `isMaintainerAtGoal()` information if the target was updated before the maintainer had a chance to check.
# Whats changing?
When the maintainer feeds the subsystem, the subsystem remembers the target value at that moment. When running `isMaintainerAtGoal()`, it checks to make sure the target now is equivalent to the one that was in use when the maintainer ran.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
