### PR TITLE
Support multiple kinds of cameras in Electrical Contract

### DIFF
--- a/src/main/java/xbot/common/injection/electrical_contract/XCameraElectricalContract.java
+++ b/src/main/java/xbot/common/injection/electrical_contract/XCameraElectricalContract.java
@@ -9,5 +9,7 @@ public interface XCameraElectricalContract {
      *
      * @return An array of CameraInfo objects, each representing a camera on the robot.
      */
-    CameraInfo[] getCameraInfo();
+    CameraInfo[] getAprilTagCameraInfo();
+
+    CameraInfo[] getNoteCameraInfo();
 }


### PR DESCRIPTION
Didn't even realize this was an SCL file - will evaluate a cleaner way to do this when we have multiple "kinds" of cameras.

# Why are we doing this?
Need some way to separate note cameras from apriltag cameras.
# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
