### PR TITLE
Add factory helpers for making SetTargetCommands

### DIFF
--- a/src/main/java/xbot/common/command/BaseSetpointSubsystem.java
+++ b/src/main/java/xbot/common/command/BaseSetpointSubsystem.java
@@ -63,6 +63,16 @@ public abstract class BaseSetpointSubsystem<T> extends BaseSubsystem implements 
 
     protected abstract boolean areTwoTargetsEquivalent(T target1, T target2);
 
+    public SetTargetCommand<T> createSetTargetCommand() {
+        return new SetTargetCommand<T>(this);
+    }
+
+    public SetTargetCommand<T> createSetTargetCommand(T value) {
+        var command = new SetTargetCommand<T>(this);
+        command.setTargetValue(value);
+        return command;
+    }
+
     // Implementation for most common kind of setpoint subsystem
     public static boolean areTwoDoublesEquivalent(double target1, double target2) {
         return Math.abs(target1 - target2) < 0.00001;


### PR DESCRIPTION
# Why are we doing this?

This should make it easier to make SetTargetCommands for a BaseSetpointSubsystem, including with a specific value

# How this was tested
Very simple methods, not tested

- [ ] unit tests added
- [ ] tested on robot
