### PR TITLE
Return corners when we are too greedy.

### DIFF
--- a/src/main/java/xbot/common/trajectory/LowResField.java
+++ b/src/main/java/xbot/common/trajectory/LowResField.java
@@ -254,8 +254,10 @@ public class LowResField {
                         if (arbitraryCornerA.getDistance(insidePoint)
                                 < arbitraryCornerB.getDistance(insidePoint)) {
                             pointClosestToInside = arbitraryCornerA;
+                            o.restoreCorner(arbitraryCornerB);
                         } else {
                             pointClosestToInside = arbitraryCornerB;
+                            o.restoreCorner(arbitraryCornerA);
                         }
 
                         log.info("Adding point closest to 'inside' point:" + pointClosestToInside);
@@ -297,7 +299,7 @@ public class LowResField {
                     while (swervePointStack.size() > 0) {
                         path.add(swervePointStack.pop());
                     }
-                    log.info("Popped stack into path.");
+                    log.info("No collision, so popping stack into path.");
                     log.info("Setting target to ultimate target");
 
                     currentTarget = ultimateTarget;

--- a/src/main/java/xbot/common/trajectory/Obstacle.java
+++ b/src/main/java/xbot/common/trajectory/Obstacle.java
@@ -261,6 +261,21 @@ public class Obstacle extends Rectangle2D.Double {
         return candidate;
     }
 
+    public void restoreCorner(Translation2d corner) {
+        if (corner == topLeft) {
+            topLeftAvailable = true;
+        }
+        if (corner == topRight) {
+            topRightAvailable = true;
+        }
+        if (corner == bottomLeft) {
+            bottomLeftAvailable = true;
+        }
+        if (corner == bottomRight) {
+            bottomRightAvailable = true;
+        }
+    }
+
     private double bonusOffset = 0.5;
 
     public double getBonusOffset() {


### PR DESCRIPTION
# Why are we doing this?
In cases where obstacles were just slightly misaligned with each other, the existing "greedy" algorithm to find the shortest route would sometimes invalidate too many options, leading to some really ugly drive patterns. This allows the route planner to return any corners it used when deciding between two options.
# Whats changing?
When handling the "Handling mixed case - two parallel lines, one inside" case, after grabbing the two nearest corners to find the one closest to the robot, return the other one back to the obstacle.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] tested on simulator
