### PR TITLE
Akit Compatability for Camera and Telemetry fix for SparkMAX

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -43,6 +43,7 @@ public abstract class XCANSparkMax {
     protected boolean firstPeriodicCall = true;
 
     protected XCANSparkMaxInputsAutoLogged inputs;
+    protected XCANSparkMaxInputsAutoLogged lastInputs;
 
     private static final org.apache.logging.log4j.Logger log = LogManager.getLogger(XCANSparkMax.class);
 
@@ -813,5 +814,13 @@ public abstract class XCANSparkMax {
     public void refreshDataFrame() {
         updateInputs(inputs);
         Logger.processInputs(akitName, inputs);
+
+        if(inputs.lastErrorId != 0) {
+            // Something has gone wrong. Most likely this is a timeout
+            // and the underlying data can't be trusted. Replace the inputs with data from the previous frame.
+            inputs = lastInputs;
+        }
+
+        lastInputs = inputs;
     }
 }

--- a/src/main/java/xbot/common/controls/io_inputs/PhotonCameraExtendedInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/PhotonCameraExtendedInputs.java
@@ -9,4 +9,6 @@ public class PhotonCameraExtendedInputs {
     public double[] cameraMatrix;
     public double[] distCoeffs;
     public boolean inputsUnhealthy;
+    public String versionEntry;
+    public boolean isConnected;
 }

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagCamera.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagCamera.java
@@ -24,8 +24,9 @@ public class AprilTagCamera extends SimpleCamera {
      */
     public AprilTagCamera(CameraInfo cameraInfo,
                           Supplier<Double> poseStableTime,
-                          AprilTagFieldLayout fieldLayout) {
-        super(cameraInfo);
+                          AprilTagFieldLayout fieldLayout,
+                          String prefix) {
+        super(cameraInfo, prefix);
         this.poseEstimator = new PhotonPoseEstimator(fieldLayout,
                 PhotonPoseEstimator.PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
                 this.camera,

--- a/src/main/java/xbot/common/subsystems/vision/SimpleCamera.java
+++ b/src/main/java/xbot/common/subsystems/vision/SimpleCamera.java
@@ -15,8 +15,8 @@ public abstract class SimpleCamera {
      *
      * @param cameraInfo The information about the camera.
      */
-    protected SimpleCamera(CameraInfo cameraInfo) {
-        this.camera = new PhotonCameraExtended(cameraInfo.networkTablesName());
+    protected SimpleCamera(CameraInfo cameraInfo, String prefix) {
+        this.camera = new PhotonCameraExtended(cameraInfo.networkTablesName(), prefix);
         this.friendlyName = cameraInfo.friendlyName();
     }
 
@@ -45,6 +45,6 @@ public abstract class SimpleCamera {
      */
     public boolean isCameraWorking() {
         return getCamera().doesLibraryVersionMatchCoprocessorVersion()
-                && getCamera().isConnected();
+                && getCamera().isConnectedAkitCompatible();
     }
 }


### PR DESCRIPTION
# Why are we doing this?
* Cameras weren't actually logging their data, so later replays won't be accurate.
* We were noticing pose errors that are related to CAN timeouts, where the library will report 0 (more or less) rotations rather than caching the last value. This causes havoc for positioning.
# Whats changing?
* Cameras now log their data to disk
* XCANSparkMAX checks for errors, and if it sees them, rolls back to the inputs from a previous frame.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
