### PR TITLE
Change logs directory to new permanent location

### DIFF
--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -99,9 +99,9 @@ public abstract class BaseRobot extends LoggedRobot {
 
         Logger.recordMetadata("ProjectName", "XbotProject"); // Set a metadata value
         if (isReal() || forceWebots) {
-            var logDirectory = new File("/U");
+            var logDirectory = new File("/media/logs");
             if (logDirectory.exists() && logDirectory.isDirectory() && logDirectory.canWrite()) {
-                Logger.addDataReceiver(new WPILOGWriter("/U/logs")); // Log to a USB stick ("/U/logs")
+                Logger.addDataReceiver(new WPILOGWriter("/media/logs/logs")); // Log to a USB stick with label LOGSDRIVE plugged into the inner usb port
             }
             Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
             new PowerDistribution(1, PowerDistribution.ModuleType.kRev); // Enables power distribution logging


### PR DESCRIPTION
# Why are we doing this?

Added /etc/fstab entry to mount our usb drive to this location in a stable fashion:
```
LABEL=LOGSDRIVE     /media/logs    vfat   defaults 0 0
```
# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
