### PR TITLE
Handle SwerveLogic case where you try to go to where you already are

### DIFF
--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -251,6 +251,15 @@ public class SwerveSimpleTrajectoryLogic {
             }
         }
 
+        // If you attempt to invoke this method where the start point and all intermediate points are the same point,
+        // then all the points will be obliterated because there's no distance between any of them.
+        // However, we should still return something that can represent that we are pretty happy with our position,
+        // and has a non-zero duration so the interpolator won't get confused.
+        if (velocityAdjustedPoints.size() == 0) {
+            var dummyPoint = new XbotSwervePoint(initialPoint.keyPose, 0.05);
+            velocityAdjustedPoints.add(dummyPoint);
+        }
+
         return velocityAdjustedPoints;
     }
 


### PR DESCRIPTION
# Why are we doing this?
Noticed this when messing around with autos in the simulator. Produces a lot of warnings.
# Whats changing?
If you try to go to where you already are, it just adds a point at where you are with 0.1 seconds so you can "get there" quickly.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] tested in simulator
