### PR TITLE
Feature/auburn1

### DIFF
--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -99,9 +99,9 @@ public abstract class BaseRobot extends LoggedRobot {
 
         Logger.recordMetadata("ProjectName", "XbotProject"); // Set a metadata value
         if (isReal() || forceWebots) {
-            var logDirectory = new File("/media/logs");
+            var logDirectory = new File("/U/logs");
             if (logDirectory.exists() && logDirectory.isDirectory() && logDirectory.canWrite()) {
-                Logger.addDataReceiver(new WPILOGWriter("/media/logs/logs")); // Log to a USB stick with label LOGSDRIVE plugged into the inner usb port
+                Logger.addDataReceiver(new WPILOGWriter("/U/logs")); // Log to a USB stick with label LOGSDRIVE plugged into the inner usb port
             }
             Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
             new PowerDistribution(1, PowerDistribution.ModuleType.kRev); // Enables power distribution logging

--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -812,16 +812,32 @@ public abstract class XCANSparkMax {
     // Methods for integrating with AdvantageKit
     protected abstract void updateInputs(XCANSparkMaxInputs inputs);
 
+    boolean lostTrustInPosition = false;
+
     public void refreshDataFrame() {
         updateInputs(inputs);
         Logger.processInputs(akitName, inputs);
+        Logger.processInputs(akitName+"Last", lastInputs);
 
-        if(inputs.lastErrorId != 0) {
+        boolean someKindOfErrorCode = inputs.lastErrorId != 0;
+        if(someKindOfErrorCode) {
             // Something has gone wrong. Most likely this is a timeout
             // and the underlying data can't be trusted. Replace the inputs with data from the previous frame.
-            inputs = lastInputs;
+            lostTrustInPosition = true;
         }
 
-        lastInputs = inputs;
+        if (lostTrustInPosition) {
+            inputs = lastInputs;
+            if (Math.abs(inputs.position) > 1 && !someKindOfErrorCode) {
+                lostTrustInPosition = false;
+            }
+        } else {
+            lastInputs = inputs;
+        }
+
+
+        Logger.recordOutput(akitName+"/LostTrust", lostTrustInPosition);
+
+
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -827,12 +827,12 @@ public abstract class XCANSparkMax {
         }
 
         if (lostTrustInPosition) {
-            inputs = lastInputs;
+            inputs = lastInputs.clone();
             if (Math.abs(inputs.position) > 1 && !someKindOfErrorCode) {
                 lostTrustInPosition = false;
             }
         } else {
-            lastInputs = inputs;
+            lastInputs = inputs.clone();
         }
 
 


### PR DESCRIPTION
# Why are we doing this?
Combined changes from Day1 of Auburn
# What's changing?
* Go back to just logging in any USB slot rather than a specific one
* Handle bad data coming from the underlying CAN bus by using data from previous frames until it self-heals.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
