### PR TITLE
Keep track of PhotonResult timestamp and propegate other inputs

### DIFF
--- a/src/main/java/org/photonvision/PhotonCameraExtended.java
+++ b/src/main/java/org/photonvision/PhotonCameraExtended.java
@@ -1,12 +1,20 @@
 package org.photonvision;
 
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.DriverStation;
 import org.apache.logging.log4j.LogManager;
 import org.littletonrobotics.junction.Logger;
 import org.photonvision.targeting.PhotonPipelineResult;
 import xbot.common.controls.io_inputs.PhotonCameraExtendedInputs;
 import xbot.common.controls.io_inputs.PhotonCameraExtendedInputsAutoLogged;
+import xbot.common.controls.sensors.XTimer;
+
+import java.util.Optional;
 
 public class PhotonCameraExtended extends PhotonCamera {
 
@@ -27,13 +35,31 @@ public class PhotonCameraExtended extends PhotonCamera {
 
     @Override
     public PhotonPipelineResult getLatestResult() {
-        return io.pipelineResult;
+        var result = io.pipelineResult;
+        // PhotonPipelineResult doesn't serialize the timestamp,
+        // so we need to restore it for simulation playback
+        if (result.getTimestampSeconds() == -1.0) {
+            result.setTimestampSeconds(io.pipelineResultTimestamp);
+        }
+        return result;
     }
 
     public double[] getCameraMatrixRaw() { return io.cameraMatrix; }
 
     public double[] getDistCoeffsRaw() {
         return io.distCoeffs;
+    }
+
+    @Override
+    public Optional<Matrix<N3, N3>> getCameraMatrix() {
+        double[] cameraMatrix = this.getCameraMatrixRaw();
+        return cameraMatrix != null && cameraMatrix.length == 9 ? Optional.of(MatBuilder.fill(Nat.N3(), Nat.N3(), cameraMatrix)) : Optional.empty();
+    }
+
+    @Override
+    public Optional<Matrix<N5, N1>> getDistCoeffs() {
+        double[] distCoeffs = this.getDistCoeffsRaw();
+        return distCoeffs != null && distCoeffs.length == 5 ? Optional.of(MatBuilder.fill(Nat.N5(), Nat.N1(), distCoeffs)) : Optional.empty();
     }
 
     public boolean doesLibraryVersionMatchCoprocessorVersion() {
@@ -61,6 +87,7 @@ public class PhotonCameraExtended extends PhotonCamera {
             inputs.cameraMatrix = cameraIntrinsicsSubscriber.get();
             inputs.distCoeffs = cameraDistortionSubscriber.get();
             inputs.pipelineResult = super.getLatestResult();
+            inputs.pipelineResultTimestamp = inputs.pipelineResult.getTimestampSeconds();
             inputs.versionEntry = versionEntry.get("");
             inputs.isConnected = isConnected();
         } catch (Exception e) {

--- a/src/main/java/org/photonvision/PhotonCameraExtended.java
+++ b/src/main/java/org/photonvision/PhotonCameraExtended.java
@@ -39,7 +39,14 @@ public class PhotonCameraExtended extends PhotonCamera {
         // PhotonPipelineResult doesn't serialize the timestamp,
         // so we need to restore it for simulation playback
         if (result.getTimestampSeconds() == -1.0) {
-            result.setTimestampSeconds(io.pipelineResultTimestamp);
+            var loggedTimestamp = io.pipelineResultTimestamp;
+            if (loggedTimestamp == 0.0) {
+                // The timestamp is not logged (old data), so we need to estimate it.
+                result.setTimestampSeconds(XTimer.getFPGATimestamp()
+                        - (result.getLatencyMillis() / 1000));
+            } else {
+                result.setTimestampSeconds(loggedTimestamp);
+            }
         }
         return result;
     }

--- a/src/main/java/xbot/common/controls/io_inputs/PhotonCameraExtendedInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/PhotonCameraExtendedInputs.java
@@ -6,6 +6,7 @@ import org.photonvision.targeting.PhotonPipelineResult;
 @AutoLog
 public class PhotonCameraExtendedInputs {
     public PhotonPipelineResult pipelineResult;
+    public double pipelineResultTimestamp;
     public double[] cameraMatrix;
     public double[] distCoeffs;
     public boolean inputsUnhealthy;


### PR DESCRIPTION
# Why are we doing this?

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
