### PR TITLE
Adding Heading Module helper functions for holding rotation

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
+++ b/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
@@ -25,6 +25,8 @@ public class HeadingModule {
     
     public final double defaultPValue = 1/80d;
 
+    private double frozenHeading = 0;
+
     @AssistedFactory
     public abstract static class HeadingModuleFactory {
         public abstract HeadingModule create(@Assisted("headingDrivePid") PIDManager headingDrivePid);
@@ -69,7 +71,19 @@ public class HeadingModule {
         return rotationalPower;        
     }
 
+    public double calculateDeltaHeadingPower(double desiredDeltaHeadingInDegrees) {
+        return calculateHeadingPower(pose.getCurrentHeading().getDegrees() + desiredDeltaHeadingInDegrees);
+    }
+
     public double calculateHeadingPower(Rotation2d desiredHeading) { 
         return calculateHeadingPower(desiredHeading.getDegrees());
+    }
+
+    public void freezeHeading() {
+        frozenHeading = pose.getCurrentHeading().getDegrees();
+    }
+
+    public double calculateFrozenHeadingPower() {
+        return calculateHeadingPower(frozenHeading);
     }
 }

--- a/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
+++ b/src/main/java/xbot/common/subsystems/drive/control_logic/HeadingModule.java
@@ -71,12 +71,12 @@ public class HeadingModule {
         return rotationalPower;        
     }
 
-    public double calculateDeltaHeadingPower(double desiredDeltaHeadingInDegrees) {
-        return calculateHeadingPower(pose.getCurrentHeading().getDegrees() + desiredDeltaHeadingInDegrees);
+    public double calculateHeadingPower(Rotation2d desiredHeading) {
+        return calculateHeadingPower(desiredHeading.getDegrees());
     }
 
-    public double calculateHeadingPower(Rotation2d desiredHeading) { 
-        return calculateHeadingPower(desiredHeading.getDegrees());
+    public double calculateDeltaHeadingPower(double desiredDeltaHeadingInDegrees) {
+        return calculateHeadingPower(pose.getCurrentHeading().getDegrees() + desiredDeltaHeadingInDegrees);
     }
 
     public void freezeHeading() {


### PR DESCRIPTION
# Why are we doing this?
The HeadingModule can now hold onto a useful heading and keep pointing at it
# Whats changing?
Adds `freezeHeading()` and `calculateFrozenHeadingPower()` methods to the Heading Module. We were often doing this thing in commands where the command would have a little state machine to do this, but since this repeats, I've put it into the HeadingModule.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
