### PR TITLE
Feature/fix spark max in sim

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANSparkMax.java
@@ -828,7 +828,7 @@ public abstract class XCANSparkMax {
         //Logger.processInputs(akitName+"Last", lastInputs);
 
         double suspiciousPositionValue = 0.244; // The value returned by the SparkMax when it times out
-        boolean sparkReportingSuspiciousPosition = Math.abs(Math.abs(inputs.position) - suspiciousPositionValue) < 0.05;
+        boolean sparkReportingSuspiciousPosition = Math.abs(inputs.position - suspiciousPositionValue) < 0.05;
         boolean sparkReportingSuspiciousBusVoltage = Math.abs(inputs.busVoltage) < 0.001;
         boolean someKindOfErrorCode = inputs.lastErrorId != 0;
 

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANSparkMax.java
@@ -242,6 +242,10 @@ public class MockCANSparkMax extends XCANSparkMax implements ISimulatableMotor, 
         return this.outputCurrent = outputCurrent;
     }
 
+    public double getOutputCurrent_internal() {
+        return outputCurrent;
+    }
+
     @Override
     public double getMotorTemperature() {
         return 0;
@@ -676,9 +680,9 @@ public class MockCANSparkMax extends XCANSparkMax implements ISimulatableMotor, 
         inputs.lastErrorId = getLastError().value;
         inputs.velocity = getVelocity_internal();
         inputs.position = getPosition_internal();
-        inputs.appliedOutput = getAppliedOutput();
+        inputs.appliedOutput = get();
         inputs.busVoltage = 12;
-        inputs.outputCurrent = getOutputCurrent();
+        inputs.outputCurrent = getOutputCurrent_internal();
         inputs.isForwardLimitSwitchPressed = forwardLimitSwitchState;
         inputs.isReverseLimitSwitchPressed = reverseLimitSwitchState;
     }


### PR DESCRIPTION
# Why are we doing this?
MockSparkMax wasn't reading the right values in simulation.
# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
