### PR TITLE
"AKIT-ify" XCANMotorController

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -5,6 +5,9 @@ import com.ctre.phoenix6.configs.OpenLoopRampsConfigs;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
+import org.littletonrobotics.junction.Logger;
+import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
+import xbot.common.controls.io_inputs.XCANMotorControllerInputsAutoLogged;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANBusId;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
@@ -25,6 +28,9 @@ public abstract class XCANMotorController {
     public final int deviceId;
     public final PropertyFactory propertyFactory;
 
+    protected XCANMotorControllerInputsAutoLogged inputs;
+    protected String akitName;
+
     protected XCANMotorController(
             CANMotorControllerInfo info,
             String owningSystemPrefix,
@@ -36,8 +42,12 @@ public abstract class XCANMotorController {
         this.deviceId = info.deviceId();
         this.propertyFactory = propertyFactory;
 
+        this.inputs = new XCANMotorControllerInputsAutoLogged();
+
         this.propertyFactory.setPrefix(owningSystemPrefix + "/" + info.name());
         police.registerDevice(DevicePolice.DeviceType.CAN, busId, info.deviceId(), info.name());
+
+        this.akitName = info.name()+"CANMotorController";
     }
 
     public abstract void setConfiguration(CANMotorControllerOutputConfig outputConfig);
@@ -60,7 +70,7 @@ public abstract class XCANMotorController {
 
     public abstract void setPowerRange(double minPower, double maxPower);
 
-    public abstract Angle getPosition();
+    public Angle getPosition() { return inputs.angle;}
 
     public abstract void setPosition(Angle position);
 
@@ -68,17 +78,23 @@ public abstract class XCANMotorController {
 
     public abstract void setPositionTarget(Angle position, int slot);
 
-    public abstract AngularVelocity getVelocity();
+    public AngularVelocity getVelocity() { return inputs.angularVelocity;};
 
     public abstract void setVelocityTarget(AngularVelocity velocity);
 
     public abstract void setVelocityTarget(AngularVelocity velocity, int slot);
 
     public void periodic() {
-
+        // TODO: ?
+        // In previous versions of the code, we used this to update PID values (if they had changed)
+        // to the motor controller, effectively creating a binding between the property system and the
+        // PID values on the controller. We can check if there is a better way to do this.
     }
 
-    public void refreshDataFrame() {
+    protected abstract void updateInputs(XCANMotorControllerInputs inputs);
 
+    public void refreshDataFrame() {
+        updateInputs(inputs);
+        Logger.processInputs(akitName, inputs);
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -70,7 +70,9 @@ public abstract class XCANMotorController {
 
     public abstract void setPowerRange(double minPower, double maxPower);
 
-    public Angle getPosition() { return inputs.angle;}
+    public Angle getPosition() {
+        return inputs.angle;
+    }
 
     public abstract void setPosition(Angle position);
 
@@ -78,7 +80,9 @@ public abstract class XCANMotorController {
 
     public abstract void setPositionTarget(Angle position, int slot);
 
-    public AngularVelocity getVelocity() { return inputs.angularVelocity;};
+    public AngularVelocity getVelocity() {
+        return inputs.angularVelocity;
+    }
 
     public abstract void setVelocityTarget(AngularVelocity velocity);
 

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -7,6 +7,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
@@ -91,5 +92,11 @@ public class MockCANMotorController extends XCANMotorController {
 
     @Override
     public void setVelocityTarget(AngularVelocity velocity, int slot) {
+    }
+
+    @Override
+    protected void updateInputs(XCANMotorControllerInputs inputs) {
+        inputs.angle = getPosition();
+        inputs.angularVelocity = getVelocity();
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -14,6 +14,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANBusId;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
@@ -178,5 +179,10 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
                 this.assertionManager.fail("Invalid PID slot number: " + slot);
                 return ClosedLoopSlot.kSlot0;
         }
+    }
+
+    protected void updateInputs(XCANMotorControllerInputs inputs) {
+        inputs.angle = getPosition();
+        inputs.angularVelocity = getVelocity();
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -18,6 +18,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
@@ -137,5 +138,10 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     public void setVelocityTarget(AngularVelocity velocity, int slot) {
         var controlRequest = new VelocityDutyCycle(velocity).withSlot(slot);
         this.internalTalonFx.setControl(controlRequest);
+    }
+
+    protected void updateInputs(XCANMotorControllerInputs inputs) {
+        inputs.angle = getPosition();
+        inputs.angularVelocity = getVelocity();
     }
 }

--- a/src/main/java/xbot/common/controls/io_inputs/XCANMotorControllerInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/XCANMotorControllerInputs.java
@@ -1,0 +1,11 @@
+package xbot.common.controls.io_inputs;
+
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import org.littletonrobotics.junction.AutoLog;
+
+@AutoLog
+public class XCANMotorControllerInputs {
+    public Angle angle;
+    public AngularVelocity angularVelocity;
+}


### PR DESCRIPTION
# Why are we doing this?
The XCANMotorController skipped the input processing & `refreshDataFrame()` aspects that get its data recorded by AKIT.
# Whats changing?
- Adds basic XCANMotorControllerInputs, just handling positions and velocity
- Fixes a bug in the naming scheme for motors - steering and drive were using the same functions
# Questions/notes for reviewers

# How this was tested
- [x] tested in simulation
