### PR TITLE
AprilTagVisionSimulated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ import edu.wpi.first.gradlerio.deploy.roborio.RoboRIO
  */
 
 plugins {
-    id "edu.wpi.first.GradleRIO" version "2025.1.1"
+    id "edu.wpi.first.GradleRIO" version "2025.2.1"
     id 'scala'
     id 'checkstyle'
     id 'jacoco'

--- a/src/main/java/xbot/common/injection/modules/SimulationModule.java
+++ b/src/main/java/xbot/common/injection/modules/SimulationModule.java
@@ -5,7 +5,6 @@ import javax.inject.Singleton;
 
 import dagger.Binds;
 import dagger.Module;
-import edu.wpi.first.wpilibj.MockTimer;
 import xbot.common.command.RealSmartDashboardCommandPutter;
 import xbot.common.command.SmartDashboardCommandPutter;
 import xbot.common.controls.sensors.XSettableTimerImpl;
@@ -18,6 +17,10 @@ import xbot.common.properties.PermanentStorage;
 import xbot.common.properties.PreferenceStorage;
 import xbot.common.properties.SmartDashboardTableWrapper;
 import xbot.common.properties.XPropertyManager;
+import xbot.common.subsystems.pose.BasePoseSubsystem;
+import xbot.common.subsystems.pose.SimulatedPositionSupplier;
+import xbot.common.subsystems.vision.AprilTagVisionIOPhotonVision;
+import xbot.common.subsystems.vision.AprilTagVisionIOPhotonVisionSimulated;
 
 /**
  * Module mapping interfaces to implementations for a simulated robot.
@@ -52,4 +55,11 @@ public abstract class SimulationModule {
     @Binds
     @Singleton
     abstract SmartDashboardCommandPutter getSmartDashboardCommandPutter(RealSmartDashboardCommandPutter impl);
+
+    @Binds
+    abstract AprilTagVisionIOPhotonVision.Factory getAprilTagVisionIOPhotonVisionFactory(AprilTagVisionIOPhotonVisionSimulated.Factory impl);
+
+    @Binds
+    @Singleton
+    abstract SimulatedPositionSupplier getSimulatedPositionSupplier(BasePoseSubsystem impl);
 }

--- a/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
@@ -20,7 +20,7 @@ import xbot.common.properties.Property;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.subsystems.drive.swerve.ISwerveAdvisorPoseSupport;
 
-public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFrameRefreshable, ISwerveAdvisorPoseSupport {
+public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFrameRefreshable, ISwerveAdvisorPoseSupport, SimulatedPositionSupplier {
 
     public final XGyro imu;
     protected double leftDriveDistance;
@@ -338,5 +338,9 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFra
     @Override
     public void refreshDataFrame() {
         imu.refreshDataFrame();
+    }
+
+    public Pose2d getSimulatedFieldPose() {
+        return this.getCurrentPose2d();
     }
 }

--- a/src/main/java/xbot/common/subsystems/pose/MockBasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/MockBasePoseSubsystem.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import xbot.common.controls.actuators.XCANTalon;
 import xbot.common.controls.actuators.mock_adapters.MockCANTalon;
 import xbot.common.controls.sensors.XGyro.XGyroFactory;
@@ -48,5 +49,10 @@ public class MockBasePoseSubsystem extends BasePoseSubsystem {
     public void forceTotalXandY(double x, double y) {
         totalDistanceX = x;
         totalDistanceY = y;
+    }
+
+    @Override
+    public Pose2d getGroundTruthPose() {
+        return super.getCurrentPose2d();
     }
 }

--- a/src/main/java/xbot/common/subsystems/pose/SimulatedPositionSupplier.java
+++ b/src/main/java/xbot/common/subsystems/pose/SimulatedPositionSupplier.java
@@ -1,0 +1,7 @@
+package xbot.common.subsystems.pose;
+
+import edu.wpi.first.math.geometry.Pose2d;
+
+public interface SimulatedPositionSupplier {
+    public Pose2d getGroundTruthPose();
+}

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVision.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVision.java
@@ -23,11 +23,21 @@ import java.util.List;
 import java.util.Set;
 import org.photonvision.PhotonCamera;
 
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedInject;
+
 /**
  * IO implementation for real PhotonVision hardware.
  * Based on the AdvantageKit sample implementation by team 6328.
  */
 public class AprilTagVisionIOPhotonVision implements AprilTagVisionIO {
+
+    public abstract static class Factory {
+        public AprilTagVisionIOPhotonVision create(String name, Transform3d robotToCamera, AprilTagFieldLayout fieldLayout) {
+            return new AprilTagVisionIOPhotonVision(name, robotToCamera, fieldLayout);
+        }
+    }
+
     protected final PhotonCamera camera;
     protected final Transform3d robotToCamera;
     private final AprilTagFieldLayout aprilTagFieldLayout;
@@ -39,7 +49,8 @@ public class AprilTagVisionIOPhotonVision implements AprilTagVisionIO {
      * @param robotToCamera The 3D position of the camera relative to the robot.
      * @param fieldLayout The April Tag field layout.
      */
-    public AprilTagVisionIOPhotonVision(String name, Transform3d robotToCamera, AprilTagFieldLayout fieldLayout) {
+    @AssistedInject
+    public AprilTagVisionIOPhotonVision(@Assisted String name, @Assisted Transform3d robotToCamera, @Assisted AprilTagFieldLayout fieldLayout) {
         camera = new PhotonCamera(name);
         this.robotToCamera = robotToCamera;
         this.aprilTagFieldLayout = fieldLayout;

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
@@ -37,25 +37,23 @@ public class AprilTagVisionIOPhotonVisionSimulated extends AprilTagVisionIOPhoto
     }
 
     private static VisionSystemSim visionSim;
-
-    // TODO: this should be getting the Simulator that can give the position but
-    // that needs more stuff to be moved into SCL
     private final SimulatedPositionSupplier poseSupplier;
     private final PhotonCameraSim cameraSim;
 
     /**
-     * Creates a new VisionIOPhotonVision.
+     * Creates a new AprilTagVisionIOPhotonVisionSimulated.
      *
      * @param name          The configured name of the camera.
      * @param robotToCamera The 3D position of the camera relative to the robot.
      * @param fieldLayout   The April Tag field layout.
+     * @param poseSupplier  The simulated position supplier, tells the simulated vision system where the robot is on the simulated field.
      */
     @AssistedInject
     public AprilTagVisionIOPhotonVisionSimulated(@Assisted String name, @Assisted Transform3d robotToCamera,
-            @Assisted AprilTagFieldLayout fieldLayout, SimulatedPositionSupplier poseSubsystem) {
+            @Assisted AprilTagFieldLayout fieldLayout, SimulatedPositionSupplier poseSupplier) {
         super(name, robotToCamera, fieldLayout);
 
-        this.poseSupplier = poseSubsystem;
+        this.poseSupplier = poseSupplier;
 
         // Initialize vision sim
         if (visionSim == null) {

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
@@ -1,0 +1,78 @@
+// Copyright 2021-2025 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package xbot.common.subsystems.vision;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.geometry.Transform3d;
+import xbot.common.subsystems.pose.BasePoseSubsystem;
+import xbot.common.subsystems.pose.SimulatedPositionSupplier;
+
+import org.photonvision.simulation.PhotonCameraSim;
+import org.photonvision.simulation.SimCameraProperties;
+import org.photonvision.simulation.VisionSystemSim;
+
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+
+/**
+ * IO implementation for real PhotonVision hardware.
+ * Based on the AdvantageKit sample implementation by team 6328.
+ */
+public class AprilTagVisionIOPhotonVisionSimulated extends AprilTagVisionIOPhotonVision {
+    @AssistedFactory
+    public abstract static class Factory extends AprilTagVisionIOPhotonVision.Factory {
+        public abstract AprilTagVisionIOPhotonVisionSimulated create(String name, Transform3d robotToCamera, AprilTagFieldLayout fieldLayout);
+    }
+
+    private static VisionSystemSim visionSim;
+
+    // TODO: this should be getting the Simulator that can give the position but
+    // that needs more stuff to be moved into SCL
+    private final SimulatedPositionSupplier poseSupplier;
+    private final PhotonCameraSim cameraSim;
+
+    /**
+     * Creates a new VisionIOPhotonVision.
+     *
+     * @param name          The configured name of the camera.
+     * @param robotToCamera The 3D position of the camera relative to the robot.
+     * @param fieldLayout   The April Tag field layout.
+     */
+    @AssistedInject
+    public AprilTagVisionIOPhotonVisionSimulated(@Assisted String name, @Assisted Transform3d robotToCamera,
+            @Assisted AprilTagFieldLayout fieldLayout, SimulatedPositionSupplier poseSubsystem) {
+        super(name, robotToCamera, fieldLayout);
+
+        this.poseSupplier = poseSubsystem;
+
+        // Initialize vision sim
+        if (visionSim == null) {
+            visionSim = new VisionSystemSim("main");
+            visionSim.addAprilTags(fieldLayout);
+        }
+
+        // Add sim camera
+        var cameraProperties = new SimCameraProperties();
+        cameraSim = new PhotonCameraSim(camera, cameraProperties);
+        visionSim.addCamera(cameraSim, robotToCamera);
+    }
+
+    @Override
+    public void updateInputs(VisionIOInputs inputs) {
+        visionSim.update(poseSupplier.getGroundTruthPose());
+        super.updateInputs(inputs);
+    }
+
+}

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
@@ -15,7 +15,6 @@ package xbot.common.subsystems.vision;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.geometry.Transform3d;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
 import xbot.common.subsystems.pose.SimulatedPositionSupplier;
 
 import org.photonvision.simulation.PhotonCameraSim;
@@ -27,7 +26,7 @@ import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 
 /**
- * IO implementation for real PhotonVision hardware.
+ * IO implementation for a simulated PhotonVision environment.
  * Based on the AdvantageKit sample implementation by team 6328.
  */
 public class AprilTagVisionIOPhotonVisionSimulated extends AprilTagVisionIOPhotonVision {


### PR DESCRIPTION
# Why are we doing this?

This branch is a fork off of the feature/apriltag-vision branch that initially added these april tag vision classes. The next thing we really wanted was the ability to use the simulated april tags so that when driving the robot locally in the simulator we can get back 'tags' the simulated robot sees and test our logic.

# Whats changing?

Copies in the *Simulated logic from the MapleSim skeleton project. Added Dagger injection goo to allow swapping between these implementations.

Updated wpilib to 2025.2.1 because we need it to get the 2025 april tags for reefscape.

# Future work

Neither branch has actually been used yet in a robot project so this is all on prospect for now.

# Questions/notes for reviewers

I'm still iffy on the dagger side of this, is there a better way of structing things?

# How this was tested
Not tested at all, just compiles

- [ ] unit tests added
- [ ] tested on robot
