### PR TITLE
Sim Camera streams

### DIFF
--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIOPhotonVisionSimulated.java
@@ -64,6 +64,9 @@ public class AprilTagVisionIOPhotonVisionSimulated extends AprilTagVisionIOPhoto
         // Add sim camera
         var cameraProperties = new SimCameraProperties();
         cameraSim = new PhotonCameraSim(camera, cameraProperties);
+        cameraSim.enableRawStream(true);
+        cameraSim.enableProcessedStream(true);
+        cameraSim.enableDrawWireframe(true);
         visionSim.addCamera(cameraSim, robotToCamera);
     }
 


### PR DESCRIPTION
# Why are we doing this?

Allow the simulated cameras to stream what they see, making it easier to debug what's going on.

The cameras stream on the normal photonlib ports (starting at 1181)

# Questions/notes for reviewers

# How this was tested
![image](https://github.com/user-attachments/assets/21093d3f-a3f3-4718-8cd6-061d615322f5)


- [ ] unit tests added
- [ ] tested on robot
