### PR TITLE
Add PIDProperties to the XCANMotor

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANMotorControllerFactoryImpl.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorControllerFactoryImpl.java
@@ -23,7 +23,11 @@ public class XCANMotorControllerFactoryImpl implements XCANMotorController.XCANM
     }
 
     @Override
-    public XCANMotorController create(CANMotorControllerInfo info, String owningSystemPrefix, String pidPropertyPrefix, XCANMotorControllerPIDProperties defaultPIDProperties) {
+    public XCANMotorController create(
+            CANMotorControllerInfo info,
+            String owningSystemPrefix,
+            String pidPropertyPrefix,
+            XCANMotorControllerPIDProperties defaultPIDProperties) {
         switch (info.type()) {
             case TalonFx -> {
                 return talonFxFactory.create(info, owningSystemPrefix, pidPropertyPrefix, defaultPIDProperties);

--- a/src/main/java/xbot/common/controls/actuators/XCANMotorControllerFactoryImpl.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorControllerFactoryImpl.java
@@ -23,13 +23,13 @@ public class XCANMotorControllerFactoryImpl implements XCANMotorController.XCANM
     }
 
     @Override
-    public XCANMotorController create(CANMotorControllerInfo info, String owningSystemPrefix, String pidPropertyPrefix) {
+    public XCANMotorController create(CANMotorControllerInfo info, String owningSystemPrefix, String pidPropertyPrefix, XCANMotorControllerPIDProperties defaultPIDProperties) {
         switch (info.type()) {
             case TalonFx -> {
-                return talonFxFactory.create(info, owningSystemPrefix, pidPropertyPrefix);
+                return talonFxFactory.create(info, owningSystemPrefix, pidPropertyPrefix, defaultPIDProperties);
             }
             case SparkMax -> {
-                return sparkMaxFactory.create(info, owningSystemPrefix, pidPropertyPrefix);
+                return sparkMaxFactory.create(info, owningSystemPrefix, pidPropertyPrefix, defaultPIDProperties);
             }
             default -> throw new IllegalArgumentException("Unknown motor controller type: " + info.type());
         }

--- a/src/main/java/xbot/common/controls/actuators/XCANMotorControllerPIDProperties.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorControllerPIDProperties.java
@@ -1,0 +1,14 @@
+package xbot.common.controls.actuators;
+
+public record XCANMotorControllerPIDProperties(double p,
+                                        double i,
+                                        double d,
+                                        double feedForward,
+                                        double maxOutput,
+                                        double minOutput
+) {
+    public XCANMotorControllerPIDProperties()
+    {
+        this(0, 0, 0, 0, 1, -1);
+    }
+}

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -33,7 +33,7 @@ public class MockCANMotorController extends XCANMotorController {
             DevicePolice police,
             @Assisted("pidPropertyPrefix") String pidPropertyPrefix
     ) {
-        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix);
+        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, null);
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -7,6 +7,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
@@ -17,12 +18,21 @@ import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.RPM;
 
 public class MockCANMotorController extends XCANMotorController {
+
+    public double p;
+    public double i;
+    public double d;
+    public double f;
+    public double maxPower;
+    public double minPower;
+
     @AssistedFactory
     public abstract static class MockCANMotorControllerFactory implements XCANMotorControllerFactory {
         public abstract MockCANMotorController create(
                 @Assisted("info") CANMotorControllerInfo info,
                 @Assisted("owningSystemPrefix") String owningSystemPrefix,
-                @Assisted("pidPropertyPrefix") String pidPropertyPrefix);
+                @Assisted("pidPropertyPrefix") String pidPropertyPrefix,
+                @Assisted("defaultPIDProperties") XCANMotorControllerPIDProperties defaultPIDProperties);
     }
 
     @AssistedInject
@@ -31,9 +41,10 @@ public class MockCANMotorController extends XCANMotorController {
             @Assisted("owningSystemPrefix") String owningSystemPrefix,
             PropertyFactory propertyFactory,
             DevicePolice police,
-            @Assisted("pidPropertyPrefix") String pidPropertyPrefix
+            @Assisted("pidPropertyPrefix") String pidPropertyPrefix,
+            @Assisted("defaultPIDProperties") XCANMotorControllerPIDProperties defaultPIDProperties
     ) {
-        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, null);
+        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, defaultPIDProperties);
     }
 
     @Override
@@ -52,8 +63,11 @@ public class MockCANMotorController extends XCANMotorController {
     }
 
     @Override
-    public void setPidProperties(double p, double i, double d, double velocityFF, int slot) {
-
+    public void setPidDirectly(double p, double i, double d, double velocityFF, int slot) {
+        this.p = p;
+        this.i = i;
+        this.d = d;
+        this.f = velocityFF;
     }
 
     @Override
@@ -62,6 +76,8 @@ public class MockCANMotorController extends XCANMotorController {
 
     @Override
     public void setPowerRange(double minPower, double maxPower) {
+        this.minPower = minPower;
+        this.maxPower = maxPower;
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -52,7 +52,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
             RobotAssertionManager assertionManager,
             @Assisted("pidPropertyPrefix") String pidPropertyPrefix
     ) {
-        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix);
+        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, null);
         this.internalSparkMax = new SparkMax(info.deviceId(), SparkLowLevel.MotorType.kBrushless);
         this.assertionManager = assertionManager;
 

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -14,6 +14,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANBusId;
@@ -34,7 +35,8 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
         public abstract CANSparkMaxWpiAdapter create(
                 @Assisted("info") CANMotorControllerInfo info,
                 @Assisted("owningSystemPrefix") String owningSystemPrefix,
-                @Assisted("pidPropertyPrefix") String pidPropertyPrefix);
+                @Assisted("pidPropertyPrefix") String pidPropertyPrefix,
+                @Assisted("defaultPIDProperties") XCANMotorControllerPIDProperties defaultPIDProperties);
     }
 
     private final SparkMax internalSparkMax;
@@ -50,9 +52,10 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
             PropertyFactory propertyFactory,
             DevicePolice police,
             RobotAssertionManager assertionManager,
-            @Assisted("pidPropertyPrefix") String pidPropertyPrefix
+            @Assisted("pidPropertyPrefix") String pidPropertyPrefix,
+            @Assisted("defaultPIDProperties") XCANMotorControllerPIDProperties defaultPIDProperties
     ) {
-        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, null);
+        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, defaultPIDProperties);
         this.internalSparkMax = new SparkMax(info.deviceId(), SparkLowLevel.MotorType.kBrushless);
         this.assertionManager = assertionManager;
 
@@ -96,7 +99,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setPidProperties(double p, double i, double d, double velocityFF, int slot) {
+    public void setPidDirectly(double p, double i, double d, double velocityFF, int slot) {
         var config = new SparkMaxConfig();
         config.closedLoop
                 .p(p, getClosedLoopSlot(slot))

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -44,7 +44,7 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
             DevicePolice police,
             @Assisted("pidPropertyPrefix") String pidPropertyPrefix
     ) {
-        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix);
+        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, null);
         this.internalTalonFx = new TalonFX(info.deviceId(), info.busId().id());
 
         setConfiguration(info.outputConfig());

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -18,6 +18,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
@@ -31,7 +32,8 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         public abstract CANTalonFxWpiAdapter create(
                 @Assisted("info") CANMotorControllerInfo info,
                 @Assisted("owningSystemPrefix") String owningSystemPrefix,
-                @Assisted("pidPropertyPrefix") String pidPropertyPrefix);
+                @Assisted("pidPropertyPrefix") String pidPropertyPrefix,
+                @Assisted("defaultPIDProperties") XCANMotorControllerPIDProperties defaultPIDProperties);
     }
 
     private final TalonFX internalTalonFx;
@@ -42,9 +44,10 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
             @Assisted("owningSystemPrefix") String owningSystemPrefix,
             PropertyFactory propertyFactory,
             DevicePolice police,
-            @Assisted("pidPropertyPrefix") String pidPropertyPrefix
+            @Assisted("pidPropertyPrefix") String pidPropertyPrefix,
+            @Assisted("defaultPIDProperties") XCANMotorControllerPIDProperties defaultPIDProperties
     ) {
-        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, null);
+        super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, defaultPIDProperties);
         this.internalTalonFx = new TalonFX(info.deviceId(), info.busId().id());
 
         setConfiguration(info.outputConfig());
@@ -67,7 +70,7 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setPidProperties(double p, double i, double d, double velocityFF, int slot) {
+    public void setPidDirectly(double p, double i, double d, double velocityFF, int slot) {
         var slotConfig = new SlotConfigs()
                 .withKP(p)
                 .withKI(i)

--- a/src/main/java/xbot/common/properties/DoubleProperty.java
+++ b/src/main/java/xbot/common/properties/DoubleProperty.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 
 /**
  * This manages a double in the property system.
- * 
+ *
  * @author Alex
  */
 public class DoubleProperty extends Property {
@@ -52,26 +52,26 @@ public class DoubleProperty extends Property {
     public double get() {
         return currentValue;
     }
-    
+
 
     public double get_internal() {
         Double nullableTableValue = activeStore.getDouble(key);
-        
+
         if(nullableTableValue == null) {
             //log.error("Property key \"" + key + "\" not present in the underlying store!"
             //        + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
             set(defaultValue);
             return defaultValue;
         }
-        
+
         return nullableTableValue;
     }
-    
+
     public void set(double value) {
         activeStore.setDouble(key, value);
         currentValue = value;
     }
-    
+
     public void hasChangedSinceLastCheck(Consumer<Double> callback) {
         double currentValue = get();
         // TODO: Check if we can just use direct equality here, since we are in fact comparing a value to itself.
@@ -79,6 +79,14 @@ public class DoubleProperty extends Property {
             callback.accept(currentValue);
         }
         lastValue = currentValue;
+    }
+
+    public boolean hasChangedSinceLastCheck() {
+        double currentValue = get();
+        // TODO: Check if we can just use direct equality here, since we are in fact comparing a value to itself.
+        boolean changed = (Math.abs(currentValue - lastValue) > 0.00000000001);
+        lastValue = currentValue;
+        return changed;
     }
 
     public boolean isSetToDefault() {

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import xbot.common.command.BaseSetpointSubsystem;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
 import xbot.common.injection.swerve.SwerveInstance;
 import xbot.common.injection.swerve.SwerveSingleton;
@@ -47,8 +48,9 @@ public class SwerveDriveSubsystem extends BaseSetpointSubsystem<Double> {
             this.motorController = mcFactory.create(
                     electricalContract.getDriveMotor(swerveInstance),
                     "DriveMotor",
-                    super.getPrefix() + "/DrivePID");
-            this.motorController.setPidProperties(
+                    super.getPrefix() + "DrivePID",
+                    new XCANMotorControllerPIDProperties(1, 0, 0, 0, 1, -1));
+            this.motorController.setPidDirectly(
                     0.00001,
                     0.000001,
                     0,

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -11,6 +11,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.MathUtil;
 import xbot.common.command.BaseSetpointSubsystem;
 import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.controls.sensors.XCANCoder;
 import xbot.common.controls.sensors.XCANCoder.XCANCoderFactory;
 import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
@@ -66,8 +67,9 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
             this.motorController = mcFactory.create(
                     electricalContract.getSteeringMotor(swerveInstance),
                     "SteeringMC",
-                    super.getPrefix() + "/SteeringPID");
-            this.motorController.setPidProperties(
+                    super.getPrefix() + "SteeringPID",
+                    new XCANMotorControllerPIDProperties(1, 0, 0, 0, 1, -1));
+            this.motorController.setPidDirectly(
                     0.5,
                     0,
                     0,

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -20,7 +20,12 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
     @Test
     public void createWithoutPIDProperties() {
 
-        CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1, new CANMotorControllerOutputConfig());
+        CANMotorControllerInfo info = new CANMotorControllerInfo(
+                "Test",
+                MotorControllerType.TalonFx,
+                CANBusId.DefaultCanivore,
+                1,
+                new CANMotorControllerOutputConfig());
 
         XCANMotorController motor = getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", null);
 
@@ -36,7 +41,8 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
 
     @Test
     public void createWithPidProperties() {
-        CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1, new CANMotorControllerOutputConfig());
+        CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1,
+                new CANMotorControllerOutputConfig());
 
         XCANMotorControllerPIDProperties pidProperties = new XCANMotorControllerPIDProperties(1, 2, 3, 4, 1, -1);
 

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -1,0 +1,54 @@
+package xbot.common.controls.actuators;
+
+import org.junit.Test;
+import xbot.common.controls.actuators.mock_adapters.MockCANMotorController;
+import xbot.common.injection.BaseCommonLibTest;
+import xbot.common.injection.electrical_contract.CANBusId;
+import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
+import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
+import xbot.common.injection.electrical_contract.MotorControllerType;
+
+import static org.junit.Assert.assertEquals;
+
+public class CANMotorControllerTest extends BaseCommonLibTest {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+    }
+
+    @Test
+    public void createWithoutPIDProperties() {
+
+        CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1, new CANMotorControllerOutputConfig());
+
+        XCANMotorController motor = getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", null);
+
+        motor.refreshDataFrame();
+        motor.periodic();
+
+        MockCANMotorController mockMotor = (MockCANMotorController) motor;
+        assertEquals(0, mockMotor.p, 0.001);
+        assertEquals(0, mockMotor.i, 0.001);
+        assertEquals(0, mockMotor.d, 0.001);
+        assertEquals(0, mockMotor.f, 0.001);
+    }
+
+    @Test
+    public void createWithPidProperties() {
+        CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1, new CANMotorControllerOutputConfig());
+
+        XCANMotorControllerPIDProperties pidProperties = new XCANMotorControllerPIDProperties(1, 2, 3, 4, 1, -1);
+
+        XCANMotorController motor = getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", pidProperties);
+
+        motor.refreshDataFrame();
+        motor.periodic();
+
+        MockCANMotorController mockMotor = (MockCANMotorController) motor;
+        assertEquals(1, mockMotor.p, 0.001);
+        assertEquals(2, mockMotor.i, 0.001);
+        assertEquals(3, mockMotor.d, 0.001);
+        assertEquals(4, mockMotor.f, 0.001);
+    }
+}

--- a/src/test/java/xbot/common/injection/factories/TestAllFactoryClasses.java
+++ b/src/test/java/xbot/common/injection/factories/TestAllFactoryClasses.java
@@ -40,7 +40,8 @@ public class TestAllFactoryClasses extends BaseCommonLibTest {
                                 12,
                                 new CANMotorControllerOutputConfig()),
                         "",
-                        "");
+                        "",
+                        null);
         XJoystick j = getInjectorComponent().joystickFactory().create(1, 12);
         getInjectorComponent().joystickButtonFactory().create(j, 1);
         getInjectorComponent().analogHidButtonFactory().create(j, 1, -1, 1);
@@ -75,10 +76,10 @@ public class TestAllFactoryClasses extends BaseCommonLibTest {
         getInjectorComponent().canCoderFactory().create(new DeviceInfo("test",7), "test");
         getInjectorComponent().dutyCycleEncoderFactory().create(new DeviceInfo("test",8));
     }
-    
+
     @Test(expected = RobotAssertionException.class)
     public void doubleAllocate() {
-        getInjectorComponent().canTalonFactory().create(new CANTalonInfo(1));    
+        getInjectorComponent().canTalonFactory().create(new CANTalonInfo(1));
         getInjectorComponent().canTalonFactory().create(new CANTalonInfo(1));
         assertTrue("You shouldn't be able to double-allocate!", false);
     }


### PR DESCRIPTION
# Why are we doing this?
- This allows us to rapidly tune PID(F) parameters at runtime for motors.
# Whats changing?
- Porting logic from XCANSparkMAX to th enewer XCANMotor
# Questions/notes for reviewers

# How this was tested
- [x] unit tests added
- [x] tested in simulation
