### PR TITLE
Various swerve control & visualization fixes

### DIFF
--- a/src/main/java/xbot/common/advantage/AKitLogger.java
+++ b/src/main/java/xbot/common/advantage/AKitLogger.java
@@ -16,13 +16,13 @@ public class AKitLogger {
     public enum LogLevel {
         DEBUG, INFO
     }
-    private static LogLevel globalLogLevel = LogLevel.INFO;
+    private static LogLevel globalLogLevel = LogLevel.DEBUG;
 
     private String prefix = "";
     private LogLevel logLevel = globalLogLevel;
 
     /**
-     * This controls the log level for all AKitLoggers. 
+     * This controls the log level for all AKitLoggers.
      * This will generally be set to INFO during competitions so that debug logs are not sent
      * to the network table.
      * @param level new level to set
@@ -34,19 +34,28 @@ public class AKitLogger {
     public AKitLogger(String prefix) {
         this.prefix = prefix;
     }
-    
+
     public AKitLogger(IPropertySupport parent) {
         this(parent.getPrefix());
     }
 
     /**
      * Set the log level for this particular logger instance.
-     * Log calls made after this will have that level when checking 
+     * Log calls made after this will have that level when checking
      * if they should record or not.
      * @param level new level to set
      */
     public void setLogLevel(LogLevel level) {
         this.logLevel = level;
+    }
+
+    /**
+     * Changes the log prefix. May be needed for subsystems that have the same name, such as
+     * multiple instances of the Swerve modules.
+     * @param prefix logging prefix, should end with a "/"
+     */
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
     }
 
     protected boolean shouldSkipLogging() {

--- a/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
@@ -603,6 +603,7 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
         rearLeftSwerveModuleSubsystem.refreshDataFrame();
         rearRightSwerveModuleSubsystem.refreshDataFrame();
 
+        aKitLog.setLogLevel(AKitLogger.LogLevel.INFO);
         aKitLog.record("CurrentSwerveState", getSwerveModuleStates());
     }
 }

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
@@ -35,6 +35,7 @@ public class SwerveDriveSubsystem extends BaseSetpointSubsystem<Double> {
                                 PropertyFactory pf, XSwerveDriveElectricalContract electricalContract) {
         this.label = swerveInstance.label();
         log.info("Creating SwerveDriveSubsystem {}", this.label);
+        aKitLog.setPrefix(this.getPrefix());
 
         // Create properties shared among all instances
         pf.setPrefix(super.getPrefix());

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -53,6 +53,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
                                    PropertyFactory pf, PIDManagerFactory pidf, XSwerveDriveElectricalContract electricalContract) {
         this.label = swerveInstance.label();
         log.info("Creating SwerveRotationSubsystem {}", this.label);
+        aKitLog.setPrefix(this.getPrefix());
 
         this.contract = electricalContract;
         // Create properties shared among all instances


### PR DESCRIPTION
# Why are we doing this?
Small bugs found during debugging of 2023 and 2024 swerve drives
# Whats changing?
- Allows each swerve module to log unique data
- Change the "swerve display" to INFO level
- Change Mock CANCoder to use newer -0.5 to 0.5 range.
# Questions/notes for reviewers

# How this was tested
- [x] tested in sim
