### PR TITLE
Feature/cancoder wpi units

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,12 @@ javadoc {
             "</script>";
     options.addStringOption('Xdoclint:-missing', '-quiet')
     options.addBooleanOption("-allow-script-in-comments",true)
+    options.links = [
+            "https://github.wpilib.org/allwpilib/docs/release/java/",
+            "https://api.ctr-electronics.com/phoenix6/release/java/",
+            "https://codedocs.revrobotics.com/java/",
+            "https://photonvision.github.io/photonvision/built-docs/javadoc/"
+    ]
 }
 
 jacocoTestReport {

--- a/src/main/java/xbot/common/controls/io_inputs/XAbsoluteEncoderInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/XAbsoluteEncoderInputs.java
@@ -1,11 +1,13 @@
 package xbot.common.controls.io_inputs;
 
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
 import org.littletonrobotics.junction.AutoLog;
 
 @AutoLog
 public class XAbsoluteEncoderInputs {
-    public double position;
-    public double absolutePosition;
-    public double velocity;
+    public Angle position;
+    public Angle absolutePosition;
+    public AngularVelocity velocity;
     public String deviceHealth;
 }

--- a/src/main/java/xbot/common/controls/io_inputs/XCANCoderInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/XCANCoderInputs.java
@@ -3,6 +3,6 @@ package xbot.common.controls.io_inputs;
 import org.littletonrobotics.junction.AutoLog;
 
 @AutoLog
-public class XCANCoderInputs extends XAbsoluteEncoderInputs{
+public class XCANCoderInputs extends XAbsoluteEncoderInputs {
     public boolean hasResetOccurred;
 }

--- a/src/main/java/xbot/common/controls/sensors/XAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XAbsoluteEncoder.java
@@ -1,5 +1,7 @@
 package xbot.common.controls.sensors;
 
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputsAutoLogged;
@@ -22,19 +24,19 @@ public abstract class XAbsoluteEncoder {
 
     public abstract int getDeviceId();
 
-    public double getPosition() {
+    public Angle getPosition() {
         return inputs.position;
     }
 
-    public double getAbsolutePosition() {
+    public Angle getAbsolutePosition() {
         return inputs.absolutePosition;
     }
 
-    public double getVelocity() {
+    public AngularVelocity getVelocity() {
         return inputs.velocity;
     }
 
-    public abstract void setPosition(double newPostition);
+    public abstract void setPosition(Angle newPostition);
 
     public DeviceHealth getHealth() {
         return DeviceHealth.valueOf(inputs.deviceHealth);

--- a/src/main/java/xbot/common/controls/sensors/XSparkAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XSparkAbsoluteEncoder.java
@@ -1,5 +1,6 @@
 package xbot.common.controls.sensors;
 
+import edu.wpi.first.units.measure.Angle;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputsAutoLogged;
@@ -17,11 +18,11 @@ public abstract class XSparkAbsoluteEncoder {
         this.inverted = inverted;
     }
 
-    public double getPosition() {
-        return getUnderlyingPosition() * (inverted ? -1 : 1);
+    public Angle getPosition() {
+        return getUnderlyingPosition().times(inverted ? -1 : 1);
     }
 
-    public abstract double getUnderlyingPosition();
+    public abstract Angle getUnderlyingPosition();
 
     public abstract void updateInputs(XAbsoluteEncoderInputs inputs);
 

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockAbsoluteEncoder.java
@@ -1,5 +1,8 @@
 package xbot.common.controls.sensors.mock_adapters;
 
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
 import org.json.JSONObject;
 
 import dagger.assisted.Assisted;
@@ -12,11 +15,12 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.DevicePolice.DeviceType;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.math.WrappedRotation2d;
-import xbot.common.properties.BooleanProperty;
-import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.resiliency.DeviceHealth;
 import xbot.common.simulation.ISimulatableSensor;
+
+import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.Rotations;
 
 public class MockAbsoluteEncoder extends XAbsoluteEncoder implements ISimulatableSensor {
 
@@ -25,8 +29,8 @@ public class MockAbsoluteEncoder extends XAbsoluteEncoder implements ISimulatabl
     private double simulationScale;
     private double positionOffset;
 
-    private double velocity;
-    private WrappedRotation2d absolutePosition;
+    private AngularVelocity velocity;
+    private Angle position;
 
     @AssistedFactory
     public abstract static class MockAbsoluteEncoderFactory implements XAbsoluteEncoderFactory {
@@ -43,46 +47,41 @@ public class MockAbsoluteEncoder extends XAbsoluteEncoder implements ISimulatabl
         pf.setPrefix(owningSystemPrefix);
 
         this.deviceId = deviceInfo.channel;
-        this.velocity = 0;
-        this.absolutePosition = new WrappedRotation2d(0);
+        this.velocity = RPM.zero();
+        this.position = Rotations.zero();
         police.registerDevice(DeviceType.CAN, deviceInfo.channel, this);
     }
-    
+
     @Override
     public int getDeviceId() {
         return this.deviceId;
     }
 
-    public double getPosition_internal() {
-        return WrappedRotation2d.fromDegrees(this.absolutePosition.getDegrees() + this.positionOffset).getDegrees() * (inverted ? -1 : 1);
+    public Angle getPosition_internal() {
+        return this.position.plus(Rotations.of(this.positionOffset)).times(inverted ? -1 : 1);
     }
 
-    public double getAbsolutePosition_internal() {
-        return this.absolutePosition.getDegrees() * (inverted ? -1 : 1);
+    public Angle getAbsolutePosition_internal() {
+        return Rotations.of(MathUtil.inputModulus(this.getPosition_internal().in(Rotations), -0.5, 0.5));
     }
 
-    public double getVelocity_internal() {
-        return this.velocity * (inverted ? -1 : 1);
+    public AngularVelocity getVelocity_internal() {
+        return this.velocity.times(inverted ? -1 : 1);
     }
 
     @Override
-    public void setPosition(double newPosition) {
-        this.positionOffset = (WrappedRotation2d.fromDegrees(newPosition).minus(this.absolutePosition).getDegrees());
+    public void setPosition(Angle newPosition) {
+        this.positionOffset = newPosition.minus(this.position).in(Rotations);
     }
-    
 
     public double getPositionOffset() {
         return this.positionOffset;
     }
 
-    public void setAbsolutePosition(double position) {
-        this.absolutePosition = WrappedRotation2d.fromDegrees(position * (inverted ? -1 : 1));
-    }
-
     @Override
     public void ingestSimulationData(JSONObject payload) {
-        setAbsolutePosition(
-            payload.getBigDecimal("EncoderTicks").doubleValue() * this.simulationScale
+        setPosition(
+            Rotations.of(payload.getBigDecimal("EncoderTicks").doubleValue() * this.simulationScale)
         );
     }
 

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockSparkAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockSparkAbsoluteEncoder.java
@@ -1,5 +1,6 @@
 package xbot.common.controls.sensors.mock_adapters;
 
+import edu.wpi.first.units.measure.Angle;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
 import xbot.common.controls.sensors.XSparkAbsoluteEncoder;
 
@@ -9,12 +10,12 @@ public class MockSparkAbsoluteEncoder extends XSparkAbsoluteEncoder {
         super(nameWithPrefix, inverted);
     }
 
-    public void setMockPosition(double position) {
+    public void setMockPosition(Angle position) {
         inputs.position = position;
     }
 
     @Override
-    public double getUnderlyingPosition() {
+    public Angle getUnderlyingPosition() {
         return inputs.position;
     }
 

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
@@ -4,6 +4,8 @@ import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,7 +23,7 @@ import xbot.common.properties.PropertyFactory;
 import xbot.common.resiliency.DeviceHealth;
 
 public class CANCoderAdapter extends XCANCoder {
-    
+
     private static final Logger log = LogManager.getLogger(CANCoderAdapter.class);
 
     private final int deviceId;
@@ -46,7 +48,7 @@ public class CANCoderAdapter extends XCANCoder {
 
         this.inverted = deviceInfo.inverted;
         this.magnetOffset = 0.0;
-        
+
         this.cancoder = new CANcoder(deviceInfo.channel, deviceInfo.canBusId.id());
 
         var currentConfig = getCurrentConfiguration();
@@ -56,7 +58,7 @@ public class CANCoderAdapter extends XCANCoder {
         applyConfiguration(currentConfig);
 
         this.getMagnetOffset();
-        
+
         this.deviceId = deviceInfo.channel;
 
         police.registerDevice(DeviceType.CAN, deviceInfo.canBusId, deviceInfo.channel, this);
@@ -67,16 +69,16 @@ public class CANCoderAdapter extends XCANCoder {
         return this.deviceId;
     }
 
-    public double getPosition_internal() {
-        return this.cancoder.getPosition().getValueAsDouble();
+    public Angle getPosition_internal() {
+        return this.cancoder.getPosition().getValue();
     }
 
-    public double getAbsolutePosition_internal() {
-        return this.cancoder.getAbsolutePosition().getValueAsDouble();
+    public Angle getAbsolutePosition_internal() {
+        return this.cancoder.getAbsolutePosition().getValue();
     }
 
-    public double getVelocity_internal() {
-        return this.cancoder.getVelocity().getValueAsDouble();
+    public AngularVelocity getVelocity_internal() {
+        return this.cancoder.getVelocity().getValue();
     }
 
     public DeviceHealth getHealth_internal() {
@@ -88,7 +90,7 @@ public class CANCoderAdapter extends XCANCoder {
     }
 
     @Override
-    public void setPosition(double newPosition) {
+    public void setPosition(Angle newPosition) {
         this.cancoder.setPosition(newPosition);
     }
 

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -26,9 +26,7 @@ import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.resiliency.DeviceHealth;
 
-import static edu.wpi.first.units.Units.Degree;
 import static edu.wpi.first.units.Units.Degrees;
-import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.Rotations;
 
 @SwerveSingleton
@@ -116,6 +114,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
 
     /**
      * Gets current angle in degrees
+     *
      */
     @Override
     public Double getCurrentValue() {
@@ -241,9 +240,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
      */
     public Angle getAbsoluteEncoderPosition() {
         if (this.contract.areCanCodersReady()) {
-            // With the change to Phoenix6, enocders report -0.5 to 0.5 rather than -180 to 180.
-            // For now, doing a simple multiply. Later this should be a scaling factor in the encoder itself.
-            return Degrees.of(this.encoder.getAbsolutePosition() * 360);
+            return this.encoder.getAbsolutePosition();
         } else {
             return Degrees.zero();
         }

--- a/src/test/java/xbot/common/simulation/SimulatedMockAbsoluteEncoderTest.java
+++ b/src/test/java/xbot/common/simulation/SimulatedMockAbsoluteEncoderTest.java
@@ -1,5 +1,6 @@
 package xbot.common.simulation;
 
+import static edu.wpi.first.units.Units.Rotations;
 import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
@@ -35,9 +36,9 @@ public class SimulatedMockAbsoluteEncoderTest extends BaseSimulationTest {
         JSONArray sensorList = new JSONArray();
         sensorList.put(singleSensor);
         overallPayload.put("Sensors", sensorList);
-        
+
         distributor.distributeSimulationPayload(overallPayload);
 
-        assertEquals(43.2, this.simulatedEncoder.getAbsolutePosition_internal(), 0.001);
+        assertEquals(Rotations.of(43.2), this.simulatedEncoder.getAbsolutePosition_internal());
     }
 }


### PR DESCRIPTION
# Why are we doing this?
We're starting to adopt WPI Units elsewhere in the robot code, so do the same for the CANCoder adapter for consistency.

# Whats changing?
XCANCoder and XAbsoluteEncoder will now return outputs in the form of Angle and AngularVelocity

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
