### PR TITLE
Fix a bug where you could reserve button 1 AND button A on the controller

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/XXboxController.java
+++ b/src/main/java/xbot/common/controls/sensors/XXboxController.java
@@ -88,6 +88,9 @@ public abstract class XXboxController extends XJoystick implements IRumbler, IGa
             } else {
                 AdvancedXboxButtonTrigger candidate = new AdvancedXboxButtonTrigger(this, buttonName);
                 allocatedButtons.put(buttonName, candidate);
+
+                // Also reserve the "simple" button
+                this.getifAvailable(buttonName.value);
             }
         } else {
             // button already used!
@@ -126,7 +129,7 @@ public abstract class XXboxController extends XJoystick implements IRumbler, IGa
     }
 
     public Translation2d getLeftFieldOrientedVector() {
-        var blueTranslation = new Translation2d(getLeftRawY(), getLeftRawX()); 
+        var blueTranslation = new Translation2d(getLeftRawY(), getLeftRawX());
         if(DriverStation.getAlliance().orElseGet(() -> Alliance.Blue) == Alliance.Blue) {
             return blueTranslation;
         } else {
@@ -136,7 +139,7 @@ public abstract class XXboxController extends XJoystick implements IRumbler, IGa
     }
 
     public Translation2d getRightFieldOrientedVector() {
-        var blueTranslation = new Translation2d(getRightRawY(), getRightRawX()); 
+        var blueTranslation = new Translation2d(getRightRawY(), getRightRawX());
         if(DriverStation.getAlliance().orElseGet(() -> Alliance.Blue) == Alliance.Blue) {
             return blueTranslation;
         } else {

--- a/src/test/java/xbot/common/controls/sensors/XboxControllerTest.java
+++ b/src/test/java/xbot/common/controls/sensors/XboxControllerTest.java
@@ -15,7 +15,7 @@ public class XboxControllerTest extends BaseCommonLibTest {
     @Test(expected = RobotAssertionException.class)
     public void doubleAllocateButton() {
         XXboxController controller = getInjectorComponent().xboxControllerFactory().create(0);
-        
+
         // We expect the robot to get mad if we try to get the same button twice
         //thrown.expect(RobotAssertionException.class);
         controller.getifAvailable(XboxButton.A);
@@ -54,5 +54,13 @@ public class XboxControllerTest extends BaseCommonLibTest {
         ((MockXboxControllerAdapter)controller).setRightStick(0, -1);
         assertFalse(rightPositive.getAsBoolean());
         assertTrue(rightNegative.getAsBoolean());
+    }
+
+    @Test(expected = Exception.class)
+    public void testMixedButtons() {
+        XXboxController controller = getInjectorComponent().xboxControllerFactory().create(0);
+
+        controller.getifAvailable(1);
+        controller.getifAvailable(XboxButton.A);
     }
 }


### PR DESCRIPTION
# Why are we doing this?
Ensure nobody can reserve button 1 and then button A without getting a test-time exception.
# Whats changing?
Reserving an XboxButton also reserves the "basic" button.
# Questions/notes for reviewers

# How this was tested
- [x] unit tests added
