### PR TITLE
Base subsystem refreshable

### DIFF
--- a/src/main/java/org/photonvision/PhotonCameraExtended.java
+++ b/src/main/java/org/photonvision/PhotonCameraExtended.java
@@ -9,13 +9,15 @@ import edu.wpi.first.math.numbers.N8;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import org.apache.logging.log4j.LogManager;
 import org.photonvision.targeting.PhotonPipelineResult;
+
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.io_inputs.PhotonCameraExtendedInputs;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-public class PhotonCameraExtended extends PhotonCamera {
+public class PhotonCameraExtended extends PhotonCamera implements DataFrameRefreshable {
 
     PhotonCameraExtendedInputs io;
     org.apache.logging.log4j.Logger log = LogManager.getLogger(this.getClass());

--- a/src/main/java/xbot/common/command/BaseSubsystem.java
+++ b/src/main/java/xbot/common/command/BaseSubsystem.java
@@ -1,16 +1,21 @@
 package xbot.common.command;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import xbot.common.advantage.AKitLogger;
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.properties.IPropertySupport;
 
-public abstract class BaseSubsystem extends SubsystemBase implements IPropertySupport {
+public abstract class BaseSubsystem extends SubsystemBase implements IPropertySupport, DataFrameRefreshable {
     
     protected final Logger log;
     protected final AKitLogger aKitLog;
+    protected final List<DataFrameRefreshable> dataFrameRefreshables = new ArrayList<>();
 
     public BaseSubsystem() {
         log = LogManager.getLogger(this.getName());
@@ -19,5 +24,16 @@ public abstract class BaseSubsystem extends SubsystemBase implements IPropertySu
 
     public String getPrefix() {
         return this.getName() + "/";
+    }
+
+    protected void registerDataFrameRefreshable(DataFrameRefreshable refreshable) {
+        dataFrameRefreshables.add(refreshable);
+    }
+    
+    @Override
+    public void refreshDataFrame() {
+        for (DataFrameRefreshable refreshable : dataFrameRefreshables) {
+            refreshable.refreshDataFrame();
+        }
     }
 }

--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -10,6 +10,8 @@ import edu.wpi.first.units.measure.Velocity;
 import edu.wpi.first.units.measure.Voltage;
 import org.apache.logging.log4j.LogManager;
 import org.littletonrobotics.junction.Logger;
+
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputsAutoLogged;
 import xbot.common.injection.DevicePolice;
@@ -20,7 +22,7 @@ import xbot.common.logic.LogicUtils;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 
-public abstract class XCANMotorController {
+public abstract class XCANMotorController implements DataFrameRefreshable {
 
     /**
      * The PID mode to use when setting a target position or velocity.

--- a/src/main/java/xbot/common/controls/sensors/XAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XAbsoluteEncoder.java
@@ -3,12 +3,14 @@ package xbot.common.controls.sensors;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import org.littletonrobotics.junction.Logger;
+
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputsAutoLogged;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.resiliency.DeviceHealth;
 
-public abstract class XAbsoluteEncoder {
+public abstract class XAbsoluteEncoder implements DataFrameRefreshable {
 
     XAbsoluteEncoderInputsAutoLogged inputs;
     protected DeviceInfo info;

--- a/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
+++ b/src/main/java/xbot/common/controls/sensors/XDigitalInput.java
@@ -1,6 +1,8 @@
 package xbot.common.controls.sensors;
 
 import org.littletonrobotics.junction.Logger;
+
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.XBaseIO;
 import xbot.common.controls.io_inputs.XDigitalInputs;
 import xbot.common.controls.io_inputs.XDigitalInputsAutoLogged;
@@ -8,7 +10,7 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.DevicePolice.DeviceType;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 
-public abstract class XDigitalInput implements XBaseIO {
+public abstract class XDigitalInput implements XBaseIO, DataFrameRefreshable {
 
     boolean inverted;
     final XDigitalInputsAutoLogged inputs;

--- a/src/main/java/xbot/common/controls/sensors/XDutyCycleEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XDutyCycleEncoder.java
@@ -2,6 +2,8 @@ package xbot.common.controls.sensors;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import org.littletonrobotics.junction.Logger;
+
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.XBaseIO;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
 import xbot.common.controls.io_inputs.XDutyCycleEncoderInputs;
@@ -11,7 +13,7 @@ import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.math.ContiguousDouble;
 import xbot.common.math.WrappedRotation2d;
 
-public abstract class XDutyCycleEncoder implements XBaseIO {
+public abstract class XDutyCycleEncoder implements XBaseIO, DataFrameRefreshable {
 
     protected int channel;
     XDutyCycleEncoderInputsAutoLogged inputs;

--- a/src/main/java/xbot/common/controls/sensors/XGyro.java
+++ b/src/main/java/xbot/common/controls/sensors/XGyro.java
@@ -1,11 +1,13 @@
 package xbot.common.controls.sensors;
 
 import org.littletonrobotics.junction.Logger;
+
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.io_inputs.XGyroIoInputs;
 import xbot.common.controls.io_inputs.XGyroIoInputsAutoLogged;
 import xbot.common.math.WrappedRotation2d;
 
-public abstract class XGyro
+public abstract class XGyro implements DataFrameRefreshable
 {
     public enum InterfaceType {
         spi,

--- a/src/main/java/xbot/common/controls/sensors/XSparkAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XSparkAbsoluteEncoder.java
@@ -2,10 +2,12 @@ package xbot.common.controls.sensors;
 
 import edu.wpi.first.units.measure.Angle;
 import org.littletonrobotics.junction.Logger;
+
+import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputs;
 import xbot.common.controls.io_inputs.XAbsoluteEncoderInputsAutoLogged;
 
-public abstract class XSparkAbsoluteEncoder {
+public abstract class XSparkAbsoluteEncoder implements DataFrameRefreshable {
 
     protected XAbsoluteEncoderInputsAutoLogged inputs;
     boolean inverted;


### PR DESCRIPTION
# Why are we doing this?

It's too easy to forget to setup a refreshDataFrame() call on your subsystem.

# Whats changing?

Have every Subsystem be DataFrameRefreshable and create a register call that can be used to register devices as we create them so it's harder to forget.

Added the interface to a bunch of devices that already implemented the contract.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
