### PR TITLE
added method setAllSwerveModulesToTargetState

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
@@ -422,7 +422,11 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
 
     }
 
-    public void setTargetSwerveStates(SwerveModuleState swerveModuleState) {
+    /*
+        Method sets all swerve modules to one target SwerveModuleState.
+        This should only be used when all swerve modules need to be at the same target state.
+     */
+    public void setAllSwerveModulesToTargetState(SwerveModuleState swerveModuleState) {
         this.getFrontLeftSwerveModuleSubsystem().setTargetState(swerveModuleState);
         this.getFrontRightSwerveModuleSubsystem().setTargetState(swerveModuleState);
         this.getRearLeftSwerveModuleSubsystem().setTargetState(swerveModuleState);

--- a/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
@@ -422,6 +422,13 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
 
     }
 
+    public void setTargetSwerveStates(SwerveModuleState swerveModuleState) {
+        this.getFrontLeftSwerveModuleSubsystem().setTargetState(swerveModuleState);
+        this.getFrontRightSwerveModuleSubsystem().setTargetState(swerveModuleState);
+        this.getRearLeftSwerveModuleSubsystem().setTargetState(swerveModuleState);
+        this.getRearRightSwerveModuleSubsystem().setTargetState(swerveModuleState);
+    }
+
     /***
      * Give the same power to all steering modules, and the another power to all the drive wheels.
      * Does not currently use PID! As a result, wheel positions will vary wildly!


### PR DESCRIPTION
# Why are we doing this?
This method is used for the CalibrateDriveCommand. I needed a method to zero the swerve modules.
# Whats changing?
BaseSwerveDriveSubsystem
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
