### PR TITLE
Remove simulation shims that allowed old simulators to access drive intents

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/BaseDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseDriveSubsystem.java
@@ -6,38 +6,35 @@ import xbot.common.math.PIDManager;
 import xbot.common.math.XYPair;
 
 public abstract class BaseDriveSubsystem extends BaseSubsystem {
-    
+
     public abstract PIDManager getPositionalPid();
     public abstract PIDManager getRotateToHeadingPid();
     public abstract PIDManager getRotateDecayPid();
     boolean isQuickTurn;
 
-    public Translation2d lastRawCommandedDirection = new Translation2d();
-    public double lastRawCommandedRotation = 0;
-
     public abstract void move(XYPair translate, double rotate);
-    
+
     /**
      * Returns the total distance tracked by the encoder
      * - On the LEFT side of the robot
      * - Pointing in the direction of +Y travel
      */
     public abstract double getLeftTotalDistance();
-    
+
     /**
      * Returns the total distance tracked by the encoder
      * - On the RIGHT side of the robot
      * - Pointing in the direction of +Y travel
      */
     public abstract double getRightTotalDistance();
-    
+
     /**
      * Returns the total distance tracked by the encoder
      * - In the center of the robot
      * - Pointing in the direction of +X travel
      */
     public abstract double getTransverseDistance();
-    
+
     /**
      * Commands each of the XCANTalons to respond to translation/rotation input.
      * Each "wheel" is independently responsible, and as such there isn't any actual
@@ -48,7 +45,7 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
      *        normalized so that 1 is the maximum?
      */
     public void drive(XYPair translation, double rotation, boolean normalize) {
-    
+
         double normalizationFactor = 1;
         if (normalize) {
             normalizationFactor = Math.max(1, getMaxOutput(translation, rotation));
@@ -59,7 +56,7 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
 
         move(translationIntent, rotationIntent);
     }
-    
+
     /**
      * Commands each of the XCANTalons to respond to translation/rotation input.
      * Each "wheel" is independently responsible, and as such there isn't any actual
@@ -70,7 +67,7 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
     public void drive(XYPair translation, double rotation) {
         drive(translation, rotation, false);
     }
-    
+
     /**
      * Classic tank drive.
      * @param left Power to the left drive motor. Range between -1 and 1.
@@ -79,28 +76,24 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
     public void drive(double left, double right) {
         // the amount of "forward" we want to go is the average of the two joysticks
         double yTranslation = (left + right) / 2;
-        
-        // the amount of rotation we want is the difference between the two joysticks, normalized 
+
+        // the amount of rotation we want is the difference between the two joysticks, normalized
         // to (-1, 1).
         double rotation = (right - left) /  2;
-        
+
         drive(new XYPair(0, yTranslation), rotation);
     }
-    
-    public void fieldOrientedDrive(
-            XYPair translation, 
-            double rotation, 
-            double currentHeading, 
-            boolean normalize) {
-        // rotate the translation vector into the robot coordinate frame
-        lastRawCommandedDirection = new Translation2d(translation.x, translation.y);
-        lastRawCommandedRotation = rotation;
 
+    public void fieldOrientedDrive(
+            XYPair translation,
+            double rotation,
+            double currentHeading,
+            boolean normalize) {
         XYPair fieldRelativeVector = translation.clone();
-        
+
         // 90 degrees is the defined "forward" direction for a driver
         fieldRelativeVector.rotate(-currentHeading);
-        
+
         // send the rotated vector to be driven
         drive(fieldRelativeVector, rotation, normalize);
     }
@@ -116,7 +109,7 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
      * Slightly adapted from 254's 2016 CheesyDriveHelper.java.
      */
     public void cheesyDrive(double translation, double rotation) {
-        
+
         double overPower;
         double angularPower;
 
@@ -140,7 +133,7 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
 
         double rightPwm = translation + angularPower;
         double leftPwm = translation - angularPower;
-        
+
         if (overPower >= 0) {
             if (leftPwm > 1.0) {
                 rightPwm -= overPower * (leftPwm - 1.0);
@@ -159,7 +152,7 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
 
         drive(leftPwm, rightPwm);
     }
-    
+
     public void stop() {
         drive(new XYPair(0, 0), 0);
     }
@@ -181,7 +174,7 @@ public abstract class BaseDriveSubsystem extends BaseSubsystem {
     public void tankDrive(double left, double right) {
         drive(left, right);
     }
-    
+
     /**
      * Determine the largest commanded output for a given wheel for a given
      * translation/rotation input. For example, you would see a maximum output of

--- a/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
@@ -193,9 +193,6 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
             double currentHeading,
             XYPair centerOfRotationInches) {
 
-        lastRawCommandedDirection = new Translation2d(translation.x, translation.y);
-        lastRawCommandedRotation = rotation;
-
         // rotate the translation vector into the robot coordinate frame
         XYPair fieldRelativeVector = translation.clone();
 
@@ -332,8 +329,6 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
      * @param centerOfRotationInches The center of rotation.
      */
     public void move(XYPair translate, double rotate, XYPair centerOfRotationInches) {
-
-        lastRawCommandedRotation = rotate;
 
         if (activateBrakeOverride) {
             this.setWheelsToXMode();


### PR DESCRIPTION
# Why are we doing this?
We're moving to MapleSim, so this older approach of getting robot position/translation can be removed.
# What's changing?