### PR TITLE
Add hooks to be able to run SysId routines on a swerve steering motor

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -215,6 +215,8 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
 
     public abstract void setVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot);
 
+    public abstract void setVoltage(Voltage voltage);
+
     public Voltage getVoltage() {
         return inputs.voltage;
     }

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -10,6 +10,7 @@ import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Velocity;
+import edu.wpi.first.units.measure.Voltage;
 import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
@@ -129,6 +130,11 @@ public class MockCANMotorController extends XCANMotorController {
     @Override
     public void setVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
 
+    }
+
+    @Override
+    public void setVoltage(Voltage voltage) {
+        this.power = MathUtil.clamp(voltage.in(Volts) / 12.0, -1.0, 1.0);
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -218,6 +218,11 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
                 .setReference(velocity.in(RPM), controlType, getClosedLoopSlot(slot));
     }
 
+    @Override
+    public void setVoltage(Voltage voltage) {
+        this.internalSparkMax.setVoltage(voltage);
+    }
+
     private ClosedLoopSlot getClosedLoopSlot(int slot) {
         return switch (slot) {
             case 0 -> ClosedLoopSlot.kSlot0;

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -15,6 +15,7 @@ import com.ctre.phoenix6.controls.PositionDutyCycle;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VelocityDutyCycle;
 import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
@@ -203,6 +204,11 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
             }
         }
         this.internalTalonFx.setControl(controlRequest);
+    }
+
+    @Override
+    public void setVoltage(Voltage voltage) {
+        this.internalTalonFx.setControl(new VoltageOut(voltage));
     }
 
     public Voltage getVoltage() {

--- a/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
@@ -485,6 +485,10 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
         setActiveModule(this.activeModule.next());
     }
 
+    public SwerveModuleSubsystem getActiveSwerveModuleSubsystem() {
+        return this.getSwerveModuleSubsystem(this.activeModule);
+    }
+
     private SwerveModuleSubsystem getSwerveModuleSubsystem(SwerveModuleLocation location) {
         switch (location) {
             case FRONT_LEFT:
@@ -499,10 +503,6 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
                 log.warn("Attempted to get a SwerveModuleSubsystem for an invalid SwerveModuleLocation. Returning front left so that something is returned.");
                 return this.getFrontLeftSwerveModuleSubsystem();
         }
-    }
-
-    private SwerveModuleSubsystem getActiveSwerveModuleSubsystem() {
-        return this.getSwerveModuleSubsystem(this.activeModule);
     }
 
     private void stopInactiveModules() {

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -6,7 +6,6 @@ import dagger.Lazy;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Voltage;
-import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import org.apache.logging.log4j.LogManager;
@@ -34,9 +33,6 @@ import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
 
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Rotations;
-import static edu.wpi.first.units.Units.Second;
-import static edu.wpi.first.units.Units.Seconds;
-import static edu.wpi.first.units.Units.Volts;
 
 @SwerveSingleton
 public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
@@ -176,10 +172,20 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
         return !canCoderUnavailable || calibrated;
     }
 
+    /**
+     * Gets a command to run the SysId routine in the quasistatic mode.
+     * @param direction The direction to run the SysId routine.
+     * @return The command to run the SysId routine.
+     */
     public Command sysIdQuasistatic(SysIdRoutine.Direction direction) {
         return sysId.quasistatic(direction);
     }
 
+    /**
+     * Gets a command to run the SysId routine in the dynamic mode.
+     * @param direction The direction to run the SysId routine.
+     * @return The command to run the SysId routine.
+     */
     public Command sysIdDynamic(SysIdRoutine.Direction direction) {
         return sysId.dynamic(direction);
     }
@@ -226,10 +232,18 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
         return !currentCanCoderPosition.isNear(currentMotorControllerPosition, Degrees.of(maxDelta));
     }
 
+    /**
+     * Gets the motor controller for this steering module.
+     * @return The motor controller for this steering module.
+     */
     public XCANMotorController getMotorController() {
         return this.motorController;
     }
 
+    /**
+     * Gets the CANCoder for this steering module.
+     * @return The CANCoder for this steering module.
+     */
     public XCANCoder getEncoder() {
         return this.encoder;
     }
@@ -381,6 +395,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
         }
     }
 
+    @Override
     public void refreshDataFrame() {
         if (contract.isDriveReady()) {
             motorController.refreshDataFrame();

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -2,7 +2,6 @@ package xbot.common.subsystems.drive.swerve;
 
 import javax.inject.Inject;
 
-import dagger.Lazy;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Voltage;
@@ -29,7 +28,6 @@ import xbot.common.math.PIDManager.PIDManagerFactory;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.resiliency.DeviceHealth;
-import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
 
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Rotations;
@@ -47,7 +45,6 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
     private boolean useMotorControllerPid;
     private final DoubleProperty maxMotorEncoderDrift;
     private final SysIdRoutine sysId;
-    private final Lazy<BaseSwerveDriveSubsystem> swerveDriveSubsystem;
 
     private Rotation2d currentModuleHeadingRotation2d;
     private XCANMotorController motorController;
@@ -58,14 +55,12 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
 
     @Inject
     public SwerveSteeringSubsystem(SwerveInstance swerveInstance, XCANMotorController.XCANMotorControllerFactory mcFactory, XCANCoderFactory canCoderFactory,
-                                   PropertyFactory pf, PIDManagerFactory pidf, XSwerveDriveElectricalContract electricalContract,
-                                   Lazy<BaseSwerveDriveSubsystem> swerveDriveSubsystem) {
+                                   PropertyFactory pf, PIDManagerFactory pidf, XSwerveDriveElectricalContract electricalContract) {
         this.label = swerveInstance.label();
         log.info("Creating SwerveRotationSubsystem {}", this.label);
         aKitLog.setPrefix(this.getPrefix());
 
         this.contract = electricalContract;
-        this.swerveDriveSubsystem = swerveDriveSubsystem;
         // Create properties shared among all instances
         pf.setPrefix(super.getPrefix());
         this.pid = pidf.create(super.getPrefix() + "PID", 0.2, 0.0, 0.005, -1.0, 1.0);


### PR DESCRIPTION
# Why are we doing this?
We want to be able to run the SysId routines on a swerve steering motor, to see if we can make use of SysId.

# Whats changing?
Adding the bits necessary for SysId to run.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
