### PR TITLE
Add setPowerInternal method to MockCANMotorController 

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -105,6 +105,14 @@ public class MockCANMotorController extends XCANMotorController {
         this.power = MathUtil.clamp(power, -1.0, 1.0);
     }
 
+    /*
+     * Set the internal power of the motor controller without changing the controlMode.
+     * Useful for simulating an internal pid on a motor controller.
+     */
+    public void setPowerInternal(double power) {
+        this.power = MathUtil.clamp(power, -1.0, 1.0);
+    }
+
     @Override
     public double getPower() {
         return this.power;


### PR DESCRIPTION
This would be called by code simulating an internal pid, setting the output of the pid operation without changing the control mode.

# Why are we doing this?

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
