### PR TITLE
Navigational Fixes

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/SwerveKinematicsCalculator.java
+++ b/src/main/java/xbot/common/subsystems/drive/SwerveKinematicsCalculator.java
@@ -253,7 +253,7 @@ public class SwerveKinematicsCalculator {
 
     public Distance getDistanceTravelledAtTime(Time time) {
         if (time.in(Seconds) < 0) {
-            assertionManager.throwException("Invalid time to getDistanceTravelledInMetersAtTime", new Exception());
+            // Can happen when very off track right as a point is reached. Just focus on returning to the key point.
             return Meters.zero();
         }
         double elapsedTime = 0;

--- a/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
@@ -3,11 +3,9 @@ package xbot.common.subsystems.pose;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj.DriverStation;
-import org.littletonrobotics.junction.Logger;
 import edu.wpi.first.math.geometry.Rotation2d;
 import xbot.common.advantage.DataFrameRefreshable;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.controls.sensors.XGyro;
@@ -127,10 +125,20 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFra
     /**
      * @return Current heading but if the navX is still booting up it will return 0
      */
-    public WrappedRotation2d getCurrentHeading() {
+    public WrappedRotation2d getCurrentHeadingGyroOnly() {
         updateCurrentHeading();
         return currentHeading;
     }
+
+    /**
+     * Can be overriden by subclasses to provide a different heading source
+     * (e.g. a vision system, pose estimator, etc)
+     * @return
+     */
+    public WrappedRotation2d getCurrentHeading() {
+        return getCurrentHeadingGyroOnly();
+    }
+
 
     public XYPair getFieldOrientedTotalDistanceTraveled() {
         return getTravelVector().clone();
@@ -141,7 +149,7 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFra
     }
 
     public FieldPose getCurrentFieldPose() {
-        return new FieldPose(getTravelVector(), getCurrentHeading());
+        return new FieldPose(getTravelVector(), getCurrentHeadingGyroOnly());
     }
 
     public Pose2d getCurrentPose2d() {
@@ -149,7 +157,7 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFra
         return new Pose2d(
                 travelVector.x,
                 travelVector.y,
-                Rotation2d.fromDegrees(getCurrentHeading().getDegrees())
+                Rotation2d.fromDegrees(getCurrentHeadingGyroOnly().getDegrees())
         );
     }
 

--- a/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/BasePoseSubsystem.java
@@ -133,7 +133,7 @@ public abstract class BasePoseSubsystem extends BaseSubsystem implements DataFra
     /**
      * Can be overriden by subclasses to provide a different heading source
      * (e.g. a vision system, pose estimator, etc)
-     * @return
+     * @return Current heading but if the navX is still booting up it will return 0
      */
     public WrappedRotation2d getCurrentHeading() {
         return getCurrentHeadingGyroOnly();

--- a/src/main/java/xbot/common/trajectory/SimpleTimeInterpolator.java
+++ b/src/main/java/xbot/common/trajectory/SimpleTimeInterpolator.java
@@ -99,7 +99,7 @@ public class SimpleTimeInterpolator {
     }
 
     public void initialize(ProvidesInterpolationData baseline, SwerveSimpleTrajectoryMode mode) {
-        log.info("Initializing a SimpleTimeInterpolator");
+        log.debug("Initializing a SimpleTimeInterpolator");
         this.baseline = baseline;
         accumulatedProductiveSeconds = 0;
         previousTimestamp = XTimer.getFPGATimestamp();
@@ -163,12 +163,12 @@ public class SimpleTimeInterpolator {
             baseline = targetKeyPoint;
             accumulatedProductiveSeconds = 0;
             lerpFraction = 0;
-            log.info("LerpFraction is above one, so advancing to next keypoint");
+            log.debug("LerpFraction is above one, so advancing to next keypoint");
             index++;
 
             // And set our new target to the next element of the list
             targetKeyPoint = keyPoints.get(index);
-            log.info("Baseline is now " + baseline.getTranslation2d()
+            log.debug("Baseline is now " + baseline.getTranslation2d()
                     + " and target is now " + targetKeyPoint.getTranslation2d());
 
             if (usingKinematics) {

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -143,7 +143,7 @@ public class SwerveSimpleTrajectoryLogic {
     public void reset(Pose2d currentPose) {
         log.info("Resetting");
         keyPoints = keyPointsProvider.get();
-        log.info("Key points size: " + keyPoints.size());
+        log.debug("Key points size: " + keyPoints.size());
 
         var initialPoint = new XbotSwervePoint(currentPose, 0);
 

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -407,7 +407,7 @@ public class SwerveSimpleTrajectoryLogic {
         lastResult = interpolator.calculateTarget(currentPose.getTranslation());
         var chasePoint = lastResult.chasePoint;
 
-        aKitLog.record("chasePoint", new Pose2d(chasePoint, Rotation2d.fromDegrees(0)));
+        aKitLog.record("chasePoint", new Pose2d(chasePoint, lastResult.chaseHeading));
 
         XYPair targetPosition = new XYPair(chasePoint.getX(), chasePoint.getY());
         XYPair currentPosition = new XYPair(currentPose.getX(), currentPose.getY());


### PR DESCRIPTION
# Why are we doing this?
There are some old assumptions baked into the BasePoseSubsystem that don't play nice with our modern world of vision-assisted pose updating.
# Whats changing?
- Create explicit function for only updating from gyro data
- Existing `getCurrentHeading` command can now return data from subclasses (e.g. PoseEstimator data)
- Debug spew reduced for swerve navigation
- Interpolation "ghost" now has orientation
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on sim
