### PR TITLE
Unit-based-properties: DistanceProperty proof of concept

### DIFF
--- a/src/main/java/xbot/common/logging/Pluralizer.java
+++ b/src/main/java/xbot/common/logging/Pluralizer.java
@@ -1,6 +1,6 @@
 package xbot.common.logging;
 
-// logic copilot suggestion code from from apache.commons.text
+// basic logic written by Copilot 
 // CHECKSTYLE:OFF
 public class Pluralizer {
     public static String pluralize(String word) {

--- a/src/main/java/xbot/common/logging/Pluralizer.java
+++ b/src/main/java/xbot/common/logging/Pluralizer.java
@@ -1,0 +1,15 @@
+package xbot.common.logging;
+
+// logic copilot suggestion code from from apache.commons.text
+public class Pluralizer {
+    public static String pluralize(String word) {
+        // Basic pluralization logic
+        if (word.endsWith("y")) {
+            return word.substring(0, word.length() - 1) + "ies";
+        } else if (word.endsWith("s") || word.endsWith("x") || word.endsWith("z") || word.endsWith("ch") || word.endsWith("sh")) {
+            return word + "es";
+        } else {
+            return word + "s";
+        }
+    }
+}

--- a/src/main/java/xbot/common/logging/Pluralizer.java
+++ b/src/main/java/xbot/common/logging/Pluralizer.java
@@ -1,12 +1,14 @@
 package xbot.common.logging;
 
 // logic copilot suggestion code from from apache.commons.text
+// CHECKSTYLE:OFF
 public class Pluralizer {
     public static String pluralize(String word) {
         // Basic pluralization logic
         if (word.endsWith("y")) {
             return word.substring(0, word.length() - 1) + "ies";
-        } else if (word.endsWith("s") || word.endsWith("x") || word.endsWith("z") || word.endsWith("ch") || word.endsWith("sh")) {
+        } else if (word.endsWith("s") || word.endsWith("x") || word.endsWith("z") || word.endsWith("ch")
+                || word.endsWith("sh")) {
             return word + "es";
         } else {
             return word + "s";

--- a/src/main/java/xbot/common/properties/DistanceProperty.java
+++ b/src/main/java/xbot/common/properties/DistanceProperty.java
@@ -4,6 +4,7 @@
  */
 package xbot.common.properties;
 
+import java.util.function.Consumer;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.inputs.LoggableInputs;
@@ -11,7 +12,8 @@ import org.littletonrobotics.junction.inputs.LoggableInputs;
 import edu.wpi.first.units.DistanceUnit;
 import edu.wpi.first.units.measure.Distance;
 
-import java.util.function.Consumer;
+
+import xbot.common.logging.Pluralizer;
 
 /**
  * This manages a Distance  in the property system.
@@ -39,7 +41,7 @@ public class DistanceProperty extends Property {
     }
 
     public DistanceProperty(String prefix, String name, Distance defaultValue, XPropertyManager manager, PropertyLevel level) {
-        super(prefix, name  + "-in-" + defaultValue.unit().name(), manager, level);
+        super(prefix, name  + "-in-" + Pluralizer.pluralize(defaultValue.unit().name()), manager, level);
         this.defaultValue = defaultValue;
         this.defaultUnit = defaultValue.unit();
 
@@ -59,7 +61,7 @@ public class DistanceProperty extends Property {
 
 
     public Distance get_internal() {
-        Distance nullableTableValue = defaultUnit.of(activeStore.getDouble(key));
+        Double nullableTableValue = activeStore.getDouble(key);
 
         if(nullableTableValue == null) {
             //log.error("Property key \"" + key + "\" not present in the underlying store!"
@@ -68,7 +70,7 @@ public class DistanceProperty extends Property {
             return defaultValue;
         }
 
-        return nullableTableValue;
+        return defaultUnit.of(nullableTableValue);
     }
 
     public void set(Distance value) {

--- a/src/main/java/xbot/common/properties/DistanceProperty.java
+++ b/src/main/java/xbot/common/properties/DistanceProperty.java
@@ -1,0 +1,103 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package xbot.common.properties;
+
+import org.littletonrobotics.junction.LogTable;
+import org.littletonrobotics.junction.Logger;
+import org.littletonrobotics.junction.inputs.LoggableInputs;
+
+import edu.wpi.first.units.DistanceUnit;
+import edu.wpi.first.units.measure.Distance;
+
+import java.util.function.Consumer;
+
+/**
+ * This manages a Distance  in the property system.
+ *
+ * @author Alex
+ */
+public class DistanceProperty extends Property {
+    final Distance defaultValue;
+    final DistanceUnit defaultUnit;
+    Distance lastValue;
+    Distance currentValue;
+
+    private final LoggableInputs inputs = new LoggableInputs() {
+        public void toLog(LogTable table) {
+            table.put(suffix, currentValue);
+        }
+
+        public void fromLog(LogTable table) {
+            currentValue = table.get(suffix, defaultValue);
+        }
+    };
+
+    public DistanceProperty(String prefix, String name, Distance defaultValue, XPropertyManager manager) {
+        this(prefix, name, defaultValue, manager, PropertyLevel.Important);
+    }
+
+    public DistanceProperty(String prefix, String name, Distance defaultValue, XPropertyManager manager, PropertyLevel level) {
+        super(prefix, name  + "-in-" + defaultValue.unit().name(), manager, level);
+        this.defaultValue = defaultValue;
+        this.defaultUnit = defaultValue.unit();
+
+        // Check for non-default on load; also store a "last value" we can use
+        // to check if a property has changed recently.
+        Distance firstValue = get_internal();
+        if (get_internal() != defaultValue) {
+            log.info("Property " + key + " has the non-default value " + firstValue);
+        }
+        lastValue = firstValue;
+        currentValue = firstValue;
+    }
+
+    public Distance get() {
+        return currentValue;
+    }
+
+
+    public Distance get_internal() {
+        Distance nullableTableValue = defaultUnit.of(activeStore.getDouble(key));
+
+        if(nullableTableValue == null) {
+            //log.error("Property key \"" + key + "\" not present in the underlying store!"
+            //        + " IF THIS IS AN IMPORTANT ROBOT PROPERTY, MAKE SURE IT HAS A SANE VALUE BEFORE ENABLING THE ROBOT!");
+            set(defaultValue);
+            return defaultValue;
+        }
+
+        return nullableTableValue;
+    }
+
+    public void set(Distance value) {
+        activeStore.setDouble(key, value.in(defaultUnit));
+        currentValue = value;
+    }
+
+    public void hasChangedSinceLastCheck(Consumer<Distance> callback) {
+        Distance currentValue = get();
+        if (!currentValue.isEquivalent(lastValue)) {
+            callback.accept(currentValue);
+        }
+        lastValue = currentValue;
+    }
+
+    public boolean hasChangedSinceLastCheck() {
+        Distance currentValue = get();
+        boolean changed = !currentValue.isEquivalent(lastValue);
+        lastValue = currentValue;
+        return changed;
+    }
+
+    public boolean isSetToDefault() {
+        return get() == defaultValue;
+    }
+
+    @Override
+    public void refreshDataFrame() {
+        currentValue = get_internal();
+        Logger.processInputs(prefix, inputs);
+    }
+}

--- a/src/main/java/xbot/common/properties/PropertyFactory.java
+++ b/src/main/java/xbot/common/properties/PropertyFactory.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import edu.wpi.first.units.measure.Distance;
 import xbot.common.logging.RobotAssertionManager;
 import xbot.common.properties.Property.PropertyLevel;
 import xbot.common.properties.Property.PropertyPersistenceType;
@@ -178,5 +179,13 @@ public class PropertyFactory {
         return new DoubleProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, level);
     }
 
+    public DistanceProperty createPersistentProperty(String suffix, Distance defaultValue) {
+        return this.createPersistentProperty(suffix, defaultValue, defaultLevel);
+    }
+
+    public DistanceProperty createPersistentProperty(String suffix, Distance defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new DistanceProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, level);
+    }
 
 }

--- a/src/test/java/xbot/common/properties/PropertyFactoryTest.java
+++ b/src/test/java/xbot/common/properties/PropertyFactoryTest.java
@@ -2,6 +2,8 @@ package xbot.common.properties;
 
 import xbot.common.injection.BaseCommonLibTest;
 
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Meters;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -17,5 +19,23 @@ public class PropertyFactoryTest extends BaseCommonLibTest {
 
         factory.setPrefix("simplePrefixWithNoSlashes");
         assertEquals(-1, factory.getCleanPrefix().indexOf("//"));
-    } 
+    }
+
+    @Test
+    public void testDistanceProperty() {
+        PropertyFactory factory = getInjectorComponent().propertyFactory();
+        factory.setPrefix("myPrefix");
+
+        // should get back the same value as we put in with the same unit as the defaultValue
+        DistanceProperty propertyMeters = factory.createPersistentProperty("test", Meters.of(1.0));
+        assertEquals(1.0, propertyMeters.get().in(Meters), 0.0001);
+        // suffix should be modified to state the units
+        assertEquals("test-in-Meters", propertyMeters.suffix);
+
+        // should get back the same value as we put in with the same unit as the defaultValue
+        DistanceProperty propertyInches = factory.createPersistentProperty("test", Inches.of(12.0));
+        assertEquals(12.0, propertyInches.get().in(Inches), 0.0001);
+        // suffix should be modified to state the units
+        assertEquals("test-in-Inches", propertyInches.suffix);
+    }
 }


### PR DESCRIPTION
# Why are we doing this?

As we're using Unit-ed measures more and more, an awkward seam in our current code is our heavy use of DoubleProperties that could be anything. Right now it's up to the property creator to do a good job of saying what the units it'll be interpreted of as (and students almost never do this without prompting).

I've done an example of DistanceProperty here and if this looks good I'll do the other ones we're using heavily like AngleProperty and VelocityProperty which I imagine will cover most of the bases.

NOTE: I tried doing a generic UnitProperty<U extends Unit> but the typing of Unit.of/in is too loose and I couldn't get it working. Unit.of returns Measure<?> for example.

# Whats changing?

- New DistanceProperty class, bit notable behaviors here are:
  - The measure is inferred from the default value (since we need that anyway)
  - The **measures name is appended to the property name** so that in network tables it'll be obvious what the unit is. Example: a property called "maxDistance" that's in meters should show up in the tables as "maxDistance-in-Meters"

# Questions/notes for reviewers
# How this was tested
- [x] unit tests added
- [ ] tested on robot
