### PR TITLE
added new method setPosition_internal

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockAbsoluteEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockAbsoluteEncoder.java
@@ -61,6 +61,10 @@ public class MockAbsoluteEncoder extends XAbsoluteEncoder implements ISimulatabl
         return this.position.plus(Rotations.of(this.positionOffset)).times(inverted ? -1 : 1);
     }
 
+    public void setPosition_internal(Angle position) {
+        this.position = position;
+    }
+
     public Angle getAbsolutePosition_internal() {
         return Rotations.of(MathUtil.inputModulus(this.getPosition_internal().in(Rotations), -0.5, 0.5));
     }


### PR DESCRIPTION
# Why are we doing this?
allows us to simulate absolute encoders
# Whats changing?
MockAbsoluteEncoder
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
