### PR TITLE
Add the ability to fully reset the scheduler

### DIFF
--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -174,6 +174,7 @@ public abstract class BaseRobot extends LoggedRobot {
         // Get the property manager and get all properties from the robot disk
         propertyManager = injectorComponent.propertyManager();
         xScheduler = injectorComponent.scheduler();
+        xScheduler.reset();
         // All this does is set the timeout period for the scheduler - the actual loop still runs at 50hz.
         CommandScheduler.getInstance().setPeriod(0.05);
         autonomousCommandSelector = injectorComponent.autonomousCommandSelector();

--- a/src/main/java/xbot/common/command/XScheduler.java
+++ b/src/main/java/xbot/common/command/XScheduler.java
@@ -17,25 +17,25 @@ import edu.wpi.first.wpilibj2.command.Subsystem;
  */
 @Singleton
 public class XScheduler {
-    
+
     private static Logger log = LogManager.getLogger(XScheduler.class);
-    
+
     boolean crashedPreviously = false;
-    
+
     int numberOfCrashes = 0;
-    
+
     CommandScheduler scheduler;
-    
+
     @Inject
     public XScheduler() {
         this.scheduler = CommandScheduler.getInstance();
     }
-    
+
     public int getNumberOfCrashes()
     {
         return numberOfCrashes;
     }
-    
+
     public void run() {
         try {
             scheduler.run();
@@ -54,8 +54,17 @@ public class XScheduler {
         }
     }
 
-    public void removeAll() {
+    public void reset() {
         scheduler.cancelAll();
+        scheduler.unregisterAllSubsystems();
+    }
+
+    public void cancelAll() {
+        scheduler.cancelAll();
+    }
+
+    public void unregisterAllSubsystems() {
+        scheduler.unregisterAllSubsystems();
     }
 
     public void registerSubsystem(Subsystem... subsystems) {

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockLaserCAN.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockLaserCAN.java
@@ -1,6 +1,5 @@
 package xbot.common.controls.sensors.mock_adapters;
 
-import org.json.JSONObject;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;

--- a/src/test/java/xbot/common/command/SetpointSystemTest.java
+++ b/src/test/java/xbot/common/command/SetpointSystemTest.java
@@ -26,9 +26,9 @@ public class SetpointSystemTest extends BaseCommonLibTest {
     @Ignore
     public void testSetpointCommandsCollide() {
         XScheduler xScheduler = getInjectorComponent().scheduler();
-        xScheduler.removeAll();
-        xScheduler.removeAll();
-        xScheduler.removeAll();
+        xScheduler.cancelAll();
+        xScheduler.cancelAll();
+        xScheduler.cancelAll();
         xScheduler.run();
         xScheduler.run();
         xScheduler.run();

--- a/src/test/java/xbot/common/command/XSchedulerTest.java
+++ b/src/test/java/xbot/common/command/XSchedulerTest.java
@@ -18,7 +18,7 @@ public class XSchedulerTest extends BaseCommonLibTest {
 
     @After
     public void tearDown() {
-        getInjectorComponent().scheduler().removeAll();
+        getInjectorComponent().scheduler().reset();
     }
 
     @Test
@@ -43,7 +43,7 @@ public class XSchedulerTest extends BaseCommonLibTest {
         // scheduler should have been emptied.
     }
 
-    @Test 
+    @Test
     @Ignore("I can't make the scheduler crash - this needs more investigation later.")
     public void testSchedulerCrashes() {
         BaseCommand crashingCommand = new CrashingInExecCommand();
@@ -59,7 +59,7 @@ public class XSchedulerTest extends BaseCommonLibTest {
             CommandScheduler.getInstance().run();
             CommandScheduler.getInstance().run();
             CommandScheduler.getInstance().run();
-            
+
         } catch (Exception e) {
             hitCrash = true;
         }


### PR DESCRIPTION
# Why are we doing this?
When robot unit tests run the scheduler, it uses a static instance of the CommandScheduler created by WPI Lib. That means that we need to be able to clear stale subsystems out of the scheduler if we want to instantiate another scheduler or we could get unexpected behavior when running multiple tests.

# Whats changing?
Add the ability to fully clean out the CommandScheduler. BaseRobot will do this on initialize just in case it's being run as part of a test, but on a real robot the scheduler will start empty.

# Questions/notes for reviewers

# How this was tested
- [x] unit tests added
- [ ] tested on robot
