### PR TITLE
Add crude software-based motor limits

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -11,6 +11,8 @@ import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Velocity;
 import edu.wpi.first.units.measure.Voltage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
@@ -30,6 +32,8 @@ public class MockCANMotorController extends XCANMotorController {
         Position,
         Velocity
     }
+
+    private static final Logger log = LogManager.getLogger(MockCANMotorController.class);
 
     private ControlMode controlMode = ControlMode.DutyCycle;
     private double power = 0.0;
@@ -102,6 +106,9 @@ public class MockCANMotorController extends XCANMotorController {
 
     @Override
     public void setPower(double power) {
+        if (!isValidPowerRequest(power)) {
+            return;
+        }
         controlMode = ControlMode.DutyCycle;
         this.power = MathUtil.clamp(power, -1.0, 1.0);
     }
@@ -166,6 +173,9 @@ public class MockCANMotorController extends XCANMotorController {
 
     @Override
     public void setVoltage(Voltage voltage) {
+        if (!isValidVoltageRequest(voltage)) {
+            return;
+        }
         this.power = MathUtil.clamp(voltage.in(Volts) / 12.0, -1.0, 1.0);
     }
 

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -11,8 +11,6 @@ import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Velocity;
 import edu.wpi.first.units.measure.Voltage;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
 import xbot.common.controls.io_inputs.XCANMotorControllerInputs;
@@ -32,8 +30,6 @@ public class MockCANMotorController extends XCANMotorController {
         Position,
         Velocity
     }
-
-    private static final Logger log = LogManager.getLogger(MockCANMotorController.class);
 
     private ControlMode controlMode = ControlMode.DutyCycle;
     private double power = 0.0;

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -150,6 +150,9 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
 
     @Override
     public void setPower(double power) {
+        if (!isValidPowerRequest(power)) {
+            return;
+        }
         this.internalSparkMax.set(MathUtil.clamp(power, minPower, maxPower));
     }
 
@@ -220,6 +223,9 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
 
     @Override
     public void setVoltage(Voltage voltage) {
+        if (!isValidVoltageRequest(voltage)) {
+            return;
+        }
         this.internalSparkMax.setVoltage(voltage);
     }
 

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -6,7 +6,9 @@ import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
 import com.ctre.phoenix6.configs.OpenLoopRampsConfigs;
 import com.ctre.phoenix6.configs.SlotConfigs;
+import com.ctre.phoenix6.configs.SoftwareLimitSwitchConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.controls.ControlRequest;
 import com.ctre.phoenix6.controls.DutyCycleOut;
 import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
@@ -39,6 +41,8 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
 import xbot.common.properties.PropertyFactory;
+
+import static edu.wpi.first.units.Units.Volts;
 
 public class CANTalonFxWpiAdapter extends XCANMotorController {
 
@@ -131,6 +135,9 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
 
     @Override
     public void setPower(double power) {
+        if (!isValidPowerRequest(power)) {
+            return;
+        }
         this.internalTalonFx.setControl(new DutyCycleOut(power));
     }
 
@@ -208,6 +215,9 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
 
     @Override
     public void setVoltage(Voltage voltage) {
+        if (!isValidVoltageRequest(voltage)) {
+            return;
+        }
         this.internalTalonFx.setControl(new VoltageOut(voltage));
     }
 

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -6,9 +6,7 @@ import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
 import com.ctre.phoenix6.configs.OpenLoopRampsConfigs;
 import com.ctre.phoenix6.configs.SlotConfigs;
-import com.ctre.phoenix6.configs.SoftwareLimitSwitchConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.controls.ControlRequest;
 import com.ctre.phoenix6.controls.DutyCycleOut;
 import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
@@ -41,8 +39,6 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
 import xbot.common.properties.PropertyFactory;
-
-import static edu.wpi.first.units.Units.Volts;
 
 public class CANTalonFxWpiAdapter extends XCANMotorController {
 

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -59,4 +59,26 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
         assertEquals(4, mockMotor.f, 0.001);
         assertEquals(5, mockMotor.g, 0.001);
     }
+
+    @Test
+    public void softwareLimitTests() {
+        CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1,
+                new CANMotorControllerOutputConfig());
+        XCANMotorController motor = getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", null);
+
+        motor.setSoftwareForwardLimit(() -> true);
+        motor.setSoftwareReverseLimit(() -> false);
+
+        motor.setPower(1);
+        assertEquals(0, motor.getPower(), 0.001);
+
+        motor.setPower(-1);
+        assertEquals(-1, motor.getPower(), 0.001);
+
+        motor.setSoftwareReverseLimit(() -> true);
+
+        motor.refreshDataFrame();
+        motor.periodic();
+        assertEquals(0, motor.getPower(), 0.001);
+    }
 }


### PR DESCRIPTION
# Why are we doing this?
We don't have a great way to force a motor to stop if a condition is hit. Add a crude implementation that checks a supplier on every robot periodic() loop.

# Whats changing?

# Questions/notes for reviewers
This isn't a perfect solution, we only check every 50ms, which could be more than enough time for the robot to rip itself apart.

# How this was tested
- [x] unit tests added
- [ ] tested on robot
