### PR TITLE
Feature/motor controller scaled position

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -139,31 +139,31 @@ public class MockCANMotorController extends XCANMotorController {
     }
 
     @Override
-    public void setPositionTarget(Angle position, MotorPidMode mode, int slot) {
+    public void setRawPositionTarget(Angle position, MotorPidMode mode, int slot) {
         controlMode = ControlMode.Position;
         this.targetPosition = position;
     }
 
-    public Angle getTargetPosition() {
+    public Angle getRawTargetPosition() {
         return targetPosition;
     }
 
     @Override
-    public AngularVelocity getVelocity() {
+    public AngularVelocity getRawVelocity() {
         return velocity;
     }
 
-    public void setVelocity(AngularVelocity velocity) {
+    public void setRawVelocity(AngularVelocity velocity) {
         this.velocity = velocity;
     }
 
     @Override
-    public void setVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
+    public void setRawVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
         controlMode = ControlMode.Velocity;
         this.targetVelocity = velocity;
     }
 
-    public AngularVelocity getTargetVelocity() {
+    public AngularVelocity getRawTargetVelocity() {
         return targetVelocity;
     }
 

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -129,12 +129,12 @@ public class MockCANMotorController extends XCANMotorController {
     }
 
     @Override
-    public Angle getPosition() {
+    public Angle getRawPosition() {
         return this.position;
     }
 
     @Override
-    public void setPosition(Angle position) {
+    public void setRawPosition(Angle position) {
         this.position = position;
     }
 

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -139,9 +139,13 @@ public class MockCANMotorController extends XCANMotorController {
     }
 
     @Override
-    public void setRawPositionTarget(Angle position, MotorPidMode mode, int slot) {
+    public void setRawPositionTarget(Angle rawPosition, MotorPidMode mode, int slot) {
         controlMode = ControlMode.Position;
-        this.targetPosition = position;
+        this.targetPosition = rawPosition;
+    }
+
+    public Angle getTargetPosition() {
+        return convertRawAngleToScaledAngle(targetPosition);
     }
 
     public Angle getRawTargetPosition() {
@@ -153,14 +157,18 @@ public class MockCANMotorController extends XCANMotorController {
         return velocity;
     }
 
-    public void setRawVelocity(AngularVelocity velocity) {
-        this.velocity = velocity;
+    public void setVelocity(AngularVelocity velocity) {
+        this.velocity = convertScaledVelocityToRawVelocity(velocity);
+    }
+
+    public void setRawVelocity(AngularVelocity rawVelocity) {
+        this.velocity = rawVelocity;
     }
 
     @Override
-    public void setRawVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
+    public void setRawVelocityTarget(AngularVelocity rawVelocity, MotorPidMode mode, int slot) {
         controlMode = ControlMode.Velocity;
-        this.targetVelocity = velocity;
+        this.targetVelocity = rawVelocity;
     }
 
     public AngularVelocity getRawTargetVelocity() {

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -175,13 +175,13 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public Angle getPosition() {
+    public Angle getRawPosition() {
         return Rotations.of(this.internalSparkMax.getEncoder().getPosition());
     }
 
     @Override
-    public void setPosition(Angle position) {
-        this.internalSparkMax.getEncoder().setPosition(0);
+    public void setRawPosition(Angle position) {
+        this.internalSparkMax.getEncoder().setPosition(position.in(Rotations));
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -185,7 +185,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setRawPositionTarget(Angle position, MotorPidMode mode, int slot) {
+    public void setRawPositionTarget(Angle rawPosition, MotorPidMode mode, int slot) {
         SparkBase.ControlType controlType;
         switch (mode) {
             case DutyCycle, Voltage -> controlType = SparkBase.ControlType.kPosition;
@@ -197,7 +197,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
         }
         this.internalSparkMax
                 .getClosedLoopController()
-                .setReference(position.in(Rotations), controlType, getClosedLoopSlot(slot));
+                .setReference(rawPosition.in(Rotations), controlType, getClosedLoopSlot(slot));
     }
 
     @Override
@@ -206,7 +206,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setRawVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
+    public void setRawVelocityTarget(AngularVelocity rawVelocity, MotorPidMode mode, int slot) {
         SparkBase.ControlType controlType;
         switch (mode) {
             case DutyCycle, Voltage -> controlType = SparkBase.ControlType.kVelocity;
@@ -218,7 +218,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
         }
         this.internalSparkMax
                 .getClosedLoopController()
-                .setReference(velocity.in(RPM), controlType, getClosedLoopSlot(slot));
+                .setReference(rawVelocity.in(RPM), controlType, getClosedLoopSlot(slot));
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -185,7 +185,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setPositionTarget(Angle position, MotorPidMode mode, int slot) {
+    public void setRawPositionTarget(Angle position, MotorPidMode mode, int slot) {
         SparkBase.ControlType controlType;
         switch (mode) {
             case DutyCycle, Voltage -> controlType = SparkBase.ControlType.kPosition;
@@ -201,12 +201,12 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public AngularVelocity getVelocity() {
+    public AngularVelocity getRawVelocity() {
         return RPM.of(this.internalSparkMax.getEncoder().getVelocity());
     }
 
     @Override
-    public void setVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
+    public void setRawVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
         SparkBase.ControlType controlType;
         switch (mode) {
             case DutyCycle, Voltage -> controlType = SparkBase.ControlType.kVelocity;

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -163,7 +163,7 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setPositionTarget(Angle position, MotorPidMode mode, int slot) {
+    public void setRawPositionTarget(Angle position, MotorPidMode mode, int slot) {
         ControlRequest controlRequest;
         switch (mode) {
             case DutyCycle -> controlRequest = new PositionDutyCycle(position).withSlot(slot);
@@ -179,17 +179,13 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         this.internalTalonFx.setControl(controlRequest);
     }
 
-    /**
-     * Gets the angular velocity of the motor output shaft.
-     * @return The velocity in unitless AngularVelocity
-     */
     @Override
-    public AngularVelocity getVelocity() {
+    public AngularVelocity getRawVelocity() {
         return this.internalTalonFx.getRotorVelocity().getValue();
     }
 
     @Override
-    public void setVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
+    public void setRawVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
         ControlRequest controlRequest;
         switch (mode) {
             case DutyCycle -> controlRequest = new VelocityDutyCycle(velocity).withSlot(slot);

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -152,17 +152,13 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         this.internalTalonFx.getConfigurator().apply(motorConfigs);
     }
 
-    /**
-     * Gets the current position of the motor output shaft.
-     * @return The current position in unitless Angle
-     */
     @Override
-    public Angle getPosition() {
+    public Angle getRawPosition() {
         return this.internalTalonFx.getRotorPosition().getValue();
     }
 
     @Override
-    public void setPosition(Angle position) {
+    public void setRawPosition(Angle position) {
         this.internalTalonFx.setPosition(position);
     }
 

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -164,14 +164,14 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setRawPositionTarget(Angle position, MotorPidMode mode, int slot) {
+    public void setRawPositionTarget(Angle rawPosition, MotorPidMode mode, int slot) {
         ControlRequest controlRequest;
         switch (mode) {
-            case DutyCycle -> controlRequest = new PositionDutyCycle(position).withSlot(slot);
-            case Voltage -> controlRequest = new PositionVoltage(position).withSlot(slot);
-            case TrapezoidalVoltage -> controlRequest = new MotionMagicVoltage(position).withSlot(slot);
+            case DutyCycle -> controlRequest = new PositionDutyCycle(rawPosition).withSlot(slot);
+            case Voltage -> controlRequest = new PositionVoltage(rawPosition).withSlot(slot);
+            case TrapezoidalVoltage -> controlRequest = new MotionMagicVoltage(rawPosition).withSlot(slot);
             default -> {
-                controlRequest = new PositionDutyCycle(position).withSlot(slot);
+                controlRequest = new PositionDutyCycle(rawPosition).withSlot(slot);
                 //noinspection resource
                 new Alert(this.getClass().getName(),
                         "Tried to use unsupported mode in setPositionTarget " + mode + ", defaulting to DutyCycle", Alert.AlertType.kWarning).set(true);
@@ -186,14 +186,14 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     @Override
-    public void setRawVelocityTarget(AngularVelocity velocity, MotorPidMode mode, int slot) {
+    public void setRawVelocityTarget(AngularVelocity rawVelocity, MotorPidMode mode, int slot) {
         ControlRequest controlRequest;
         switch (mode) {
-            case DutyCycle -> controlRequest = new VelocityDutyCycle(velocity).withSlot(slot);
-            case Voltage -> controlRequest = new VelocityVoltage(velocity).withSlot(slot);
-            case TrapezoidalVoltage -> controlRequest = new MotionMagicVelocityVoltage(velocity).withSlot(slot);
+            case DutyCycle -> controlRequest = new VelocityDutyCycle(rawVelocity).withSlot(slot);
+            case Voltage -> controlRequest = new VelocityVoltage(rawVelocity).withSlot(slot);
+            case TrapezoidalVoltage -> controlRequest = new MotionMagicVelocityVoltage(rawVelocity).withSlot(slot);
             default -> {
-                controlRequest = new VelocityDutyCycle(velocity).withSlot(slot);
+                controlRequest = new VelocityDutyCycle(rawVelocity).withSlot(slot);
                 //noinspection resource
                 new Alert(this.getClass().getName(),
                         "Tried to use unsupported mode in setVelocityTarget " + mode + ", defaulting to DutyCycle", Alert.AlertType.kWarning).set(true);

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveSubsystem.java
@@ -159,7 +159,7 @@ public class SwerveDriveSubsystem extends BaseSetpointSubsystem<Double> {
         // Get the target speed in RPM
         double targetRPM = targetVelocity / this.metersPerMotorRotation.get() * 60.0;
         aKitLog.record("TargetRPM", targetRPM);
-        getMotorController().ifPresent(mc -> mc.setVelocityTarget(RPM.of(targetRPM), XCANMotorController.MotorPidMode.DutyCycle, 0));
+        getMotorController().ifPresent(mc -> mc.setRawVelocityTarget(RPM.of(targetRPM), XCANMotorController.MotorPidMode.DutyCycle, 0));
     }
 
     public void setNoviceMode(boolean enabled) {

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -12,6 +12,7 @@ import xbot.common.injection.electrical_contract.MotorControllerType;
 
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -91,7 +92,7 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
     public void testScaleFactors() {
         CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1,
                 new CANMotorControllerOutputConfig());
-        XCANMotorController motor = getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", null);
+        var motor = (MockCANMotorController)getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", null);
 
         motor.setAngleScaleFactor(Rotations.per(Rotations).of(2));
         motor.setDistancePerAngleScaleFactor(Meters.per(Rotations).of(4));
@@ -105,10 +106,18 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
         assertTrue(Meters.of(2).isNear(motor.getPositionAsDistance(), 0.001));
         assertTrue(Rotations.of(0.5).isNear(motor.getRawPosition(), 0.001));
 
+        motor.setRawVelocity(RotationsPerSecond.of(1));
+        assertTrue(RotationsPerSecond.of(2).isNear(motor.getVelocity(), 0.001));
+
+        motor.setVelocityTarget(RotationsPerSecond.of(1));
+        assertTrue(RotationsPerSecond.of(0.5).isNear(motor.getRawTargetVelocity(), 0.001));
+
         motor.setAngleScaleFactor(null);
         assertTrue(motor.getPosition().isEquivalent(motor.getRawPosition()));
         motor.setPosition(Rotations.of(10));
         assertTrue(motor.getPosition().isEquivalent(motor.getRawPosition()));
         assertTrue(Rotations.of(10).isNear(motor.getRawPosition(), 0.001));
+        motor.setVelocityTarget(RotationsPerSecond.of(1));
+        assertTrue(RotationsPerSecond.of(1).isNear(motor.getRawTargetVelocity(), 0.001));
     }
 }

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -96,9 +96,19 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
         motor.setAngleScaleFactor(Rotations.per(Rotations).of(2));
         motor.setDistancePerAngleScaleFactor(Meters.per(Rotations).of(4));
 
-        motor.setPosition(Rotations.of(1));
+        motor.setRawPosition(Rotations.of(1));
 
         assertTrue(Meters.of(4).isNear(motor.getPositionAsDistance(), 0.001));
-        assertTrue(Rotations.of(2).isNear(motor.getPositionAsScaledAngle(), 0.001));
+        assertTrue(Rotations.of(2).isNear(motor.getPosition(), 0.001));
+
+        motor.setPosition(Rotations.of(1));
+        assertTrue(Meters.of(2).isNear(motor.getPositionAsDistance(), 0.001));
+        assertTrue(Rotations.of(0.5).isNear(motor.getRawPosition(), 0.001));
+
+        motor.setAngleScaleFactor(null);
+        assertTrue(motor.getPosition().isEquivalent(motor.getRawPosition()));
+        motor.setPosition(Rotations.of(10));
+        assertTrue(motor.getPosition().isEquivalent(motor.getRawPosition()));
+        assertTrue(Rotations.of(10).isNear(motor.getRawPosition(), 0.001));
     }
 }

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -93,7 +93,7 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
         var motor = (MockCANMotorController)getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", null);
 
         motor.setAngleScaleFactor(Rotations.per(Rotations).of(2));
-        motor.setDistancePerAngleScaleFactor(Meters.per(Rotations).of(4));
+        motor.setDistancePerMotorRotationsScaleFactor(Meters.per(Rotations).of(4));
 
         motor.setRawPosition(Rotations.of(1));
 

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -1,7 +1,5 @@
 package xbot.common.controls.actuators;
 
-import edu.wpi.first.units.AngleUnit;
-import edu.wpi.first.units.PerUnit;
 import org.junit.Test;
 import xbot.common.controls.actuators.mock_adapters.MockCANMotorController;
 import xbot.common.injection.BaseCommonLibTest;

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -1,5 +1,7 @@
 package xbot.common.controls.actuators;
 
+import edu.wpi.first.units.AngleUnit;
+import edu.wpi.first.units.PerUnit;
 import org.junit.Test;
 import xbot.common.controls.actuators.mock_adapters.MockCANMotorController;
 import xbot.common.injection.BaseCommonLibTest;
@@ -8,7 +10,10 @@ import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
 import xbot.common.injection.electrical_contract.MotorControllerType;
 
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.Rotations;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CANMotorControllerTest extends BaseCommonLibTest {
 
@@ -80,5 +85,20 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
         motor.refreshDataFrame();
         motor.periodic();
         assertEquals(0, motor.getPower(), 0.001);
+    }
+
+    @Test
+    public void testScaleFactors() {
+        CANMotorControllerInfo info = new CANMotorControllerInfo("Test", MotorControllerType.TalonFx, CANBusId.DefaultCanivore, 1,
+                new CANMotorControllerOutputConfig());
+        XCANMotorController motor = getInjectorComponent().motorControllerFactory().create(info, "TestOwningPrefix", "TestPIDPrefix", null);
+
+        motor.setAngleScaleFactor(Rotations.per(Rotations).of(2));
+        motor.setDistancePerAngleScaleFactor(Meters.per(Rotations).of(4));
+
+        motor.setPosition(Rotations.of(1));
+
+        assertTrue(Meters.of(4).isNear(motor.getPositionAsDistance(), 0.001));
+        assertTrue(Rotations.of(2).isNear(motor.getPositionAsScaledAngle(), 0.001));
     }
 }


### PR DESCRIPTION
# Why are we doing this?
The robot code is littered with unit conversions and scaling factors, which are often done incorrectly. If we can centralize the unit conversion and scaling logic, it means there are fewer opportunities for bugs.

# Whats changing?
Add support for an angle scaling factor in all motor controller types when getting or setting positions. Unscaled versions are added via "raw" versions of the methods.

By default the behavior of existing code does not change.

# Questions/notes for reviewers

# How this was tested
- [x] unit tests added
- [ ] tested on robot
