### PR TITLE
Change default blue->red to "rotational symmetry" rather than "mirror symmetry"

### DIFF
--- a/src/main/java/xbot/common/command/BaseMaintainerCommand.java
+++ b/src/main/java/xbot/common/command/BaseMaintainerCommand.java
@@ -72,6 +72,12 @@ public abstract class BaseMaintainerCommand<T> extends BaseCommand {
     }
 
     @Override
+    public void initialize() {
+        log.info("Initializing");
+        subsystemToMaintain.setTargetValue(subsystemToMaintain.getCurrentValue());
+    }
+
+    @Override
     public void execute() {
         maintain();
         subsystemToMaintain.setMaintainerIsAtGoal(isMaintainerAtGoal());


### PR DESCRIPTION
# Why are we doing this?
The 2025 field is rotationally symmetric between red and blue. For now, changing the default to rotational symmetry, but preserving functions for mirror symmetry.
# Whats changing?
Nothing for consumers of SCL.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
