### PR TITLE
Add GameField to represent the field dimensions and perform basic pos…

### DIFF
--- a/src/main/java/xbot/common/subsystems/pose/GameField.java
+++ b/src/main/java/xbot/common/subsystems/pose/GameField.java
@@ -98,7 +98,7 @@ public class GameField {
      */
     public Rotation2d getMirroredRotation(Rotation2d original) {
         return switch (symmetry) {
-            case Mirrored -> original.times(-1);
+            case Mirrored -> Rotation2d.fromDegrees(original.getDegrees() - (original.getDegrees() - 90.0) * 2);
             case Rotational -> original.rotateBy(Rotation2d.fromDegrees(180));
         };
     }

--- a/src/main/java/xbot/common/subsystems/pose/GameField.java
+++ b/src/main/java/xbot/common/subsystems/pose/GameField.java
@@ -1,0 +1,114 @@
+package xbot.common.subsystems.pose;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.units.measure.Distance;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static edu.wpi.first.units.Units.Meters;
+
+/**
+ * Represents the field the robot is on and provides helpers for transforming field coordinates.
+ */
+@Singleton
+public class GameField {
+    /**
+     * Represents the symmetry type of the field.
+     */
+    public enum Symmetry {
+        /**
+         * The field is rotationally symmetric.
+         */
+        Rotational,
+
+        /**
+         * The field is mirrored along the Y axis.
+         */
+        Mirrored
+    }
+
+    private final Distance fieldWidth;
+    private final Distance fieldLength;
+    private final Symmetry symmetry;
+
+    /**
+     * Creates a new GameField.
+     * @param fieldLayout The layout of the field.
+     * @param symmetry The symmetry of the field.
+     */
+    @Inject
+    public GameField(AprilTagFieldLayout fieldLayout, GameField.Symmetry symmetry) {
+        this.fieldWidth = Meters.of(fieldLayout.getFieldWidth());
+        this.fieldLength = Meters.of(fieldLayout.getFieldLength());
+        this.symmetry = symmetry;
+    }
+
+    /**
+     * Gets the width of the field.
+     * @return The width of the field.
+     */
+    public Distance getFieldWidth() {
+        return fieldWidth;
+    }
+
+    /**
+     * Gets the length of the field.
+     * @return The length of the field.
+     */
+    public Distance getFieldLength() {
+        return fieldLength;
+    }
+
+    /**
+     * Gets the symmetry of the field.
+     * @return The symmetry of the field.
+     */
+    public Symmetry getSymmetry() {
+        return symmetry;
+    }
+
+    /**
+     * Gets the center of the field.
+     * @return The center of the field. Distances are in meters.
+     */
+    public Translation2d getFieldCenter() {
+        return new Translation2d(fieldLength.div(2), fieldWidth.div(2));
+    }
+
+    /**
+     * Gets the mirrored translation of a given translation per the field symmetry.
+     * @param original The original translation. Distances are in meters.
+     * @return The mirrored translation. Distances are in meters.
+     */
+    public Translation2d getMirroredTranslation(Translation2d original) {
+        return switch (symmetry) {
+            case Mirrored -> new Translation2d(fieldLength.in(Meters) - original.getX(), original.getY());
+            case Rotational -> new Translation2d(fieldLength.in(Meters) - original.getX(), fieldWidth.in(Meters) - original.getY());
+        };
+    }
+
+    /**
+     * Gets the mirrored rotation of a given rotation per the field symmetry.
+     * @param original The original rotation.
+     * @return The mirrored rotation.
+     */
+    public Rotation2d getMirroredRotation(Rotation2d original) {
+        return switch (symmetry) {
+            case Mirrored -> original.times(-1);
+            case Rotational -> original.rotateBy(Rotation2d.fromDegrees(180));
+        };
+    }
+
+    /**
+     * Gets the mirrored pose of a given pose per the field symmetry.
+     * @param original The original pose. Distances are in meters.
+     * @return The mirrored pose. Distances are in meters.
+     */
+    public Pose2d getMirroredPose(Pose2d original) {
+        return new Pose2d(getMirroredTranslation(original.getTranslation()), getMirroredRotation(original.getRotation()));
+    }
+}

--- a/src/test/java/xbot/common/injection/components/CommonLibTestComponent.java
+++ b/src/test/java/xbot/common/injection/components/CommonLibTestComponent.java
@@ -12,6 +12,7 @@ import xbot.common.injection.modules.MockControlsModule;
 import xbot.common.injection.modules.MockDevicesModule;
 import xbot.common.injection.modules.UnitTestModule;
 import xbot.common.injection.modules.UnitTestRobotModule;
+import xbot.common.subsystems.pose.GameField;
 import xbot.common.subsystems.pose.commands.ResetDistanceCommand;
 import xbot.common.subsystems.pose.commands.SetRobotHeadingCommand;
 import xbot.common.subsystems.simple.MockSimpleMotorSubsystem;
@@ -37,4 +38,6 @@ public abstract class CommonLibTestComponent extends PurePursuitTestComponent {
     public abstract MockSimpleMotorSubsystem mockSimpleMotorSubsystem();
 
     public abstract AprilTagVisionSubsystem getAprilTagVisionSubsystem();
+
+    public abstract GameField getGameField();
 }

--- a/src/test/java/xbot/common/injection/modules/CommonLibTestModule.java
+++ b/src/test/java/xbot/common/injection/modules/CommonLibTestModule.java
@@ -1,9 +1,12 @@
 package xbot.common.injection.modules;
 
 import dagger.Binds;
+import dagger.BindsInstance;
 import dagger.Module;
+import dagger.Provides;
 import xbot.common.injection.MockCameraElectricalContract;
 import xbot.common.injection.electrical_contract.XCameraElectricalContract;
+import xbot.common.subsystems.pose.GameField;
 
 import javax.inject.Singleton;
 
@@ -12,4 +15,10 @@ public abstract class CommonLibTestModule {
     @Binds
     @Singleton
     public abstract XCameraElectricalContract getMockCameraElectricalContract(MockCameraElectricalContract impl);
+
+    @Provides
+    @Singleton
+    public static GameField.Symmetry getSymmetry() {
+        return GameField.Symmetry.Rotational;
+    }
 }

--- a/src/test/java/xbot/common/subsystems/pose/GameFieldTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/GameFieldTest.java
@@ -1,0 +1,170 @@
+package xbot.common.subsystems.pose;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import org.junit.Test;
+
+import static edu.wpi.first.units.Units.Meters;
+import static org.junit.Assert.assertEquals;
+
+public class GameFieldTest {
+    @Test
+    public void testGetFieldWidth() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+        var symmetry = GameField.Symmetry.Rotational;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(8.052, gameField.getFieldWidth().in(Meters), 0.001);
+    }
+
+    @Test
+    public void testGetFieldLength() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+        var symmetry = GameField.Symmetry.Rotational;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(17.548, gameField.getFieldLength().in(Meters), 0.001);
+    }
+
+    @Test
+    public void testGetSymmetry() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+        var symmetry = GameField.Symmetry.Rotational;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(GameField.Symmetry.Rotational, gameField.getSymmetry());
+    }
+
+    @Test
+    public void testGetFieldCenter() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+        var symmetry = GameField.Symmetry.Rotational;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(8.052 / 2, gameField.getFieldCenter().getY(), 0.001);
+        assertEquals(17.548 / 2, gameField.getFieldCenter().getX(), 0.001);
+    }
+
+    @Test
+    public void testGetMirroredTranslation() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+        var symmetry = GameField.Symmetry.Rotational;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        var translation = new Translation2d(1, 2);
+        var mirroredTranslation = gameField.getMirroredTranslation(translation);
+
+        assertEquals(16.548, mirroredTranslation.getX(), 0.001);
+        assertEquals(6.052, mirroredTranslation.getY(), 0.001);
+    }
+
+    @Test
+    public void testGetMirroredRotation() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+        var symmetry = GameField.Symmetry.Rotational;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        var rotation = Rotation2d.fromDegrees(1);
+        var mirroredRotation = gameField.getMirroredRotation(rotation);
+
+        assertEquals(-179, mirroredRotation.getDegrees(), 0.001);
+    }
+
+    @Test
+    public void testGetMirroredPose() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+        var symmetry = GameField.Symmetry.Rotational;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        var translation = new Translation2d(1, 2);
+        var rotation = Rotation2d.fromDegrees(1);
+        var pose = new Pose2d(translation, rotation);
+        var mirroredPose = gameField.getMirroredPose(pose);
+
+        assertEquals(16.548, mirroredPose.getTranslation().getX(), 0.001);
+        assertEquals(6.052, mirroredPose.getTranslation().getY(), 0.001);
+        assertEquals(-179, mirroredPose.getRotation().getDegrees(), 0.001);
+    }
+
+
+    @Test
+    public void testGetFieldWidth_mirroredField() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+        var symmetry = GameField.Symmetry.Mirrored;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(8.211, gameField.getFieldWidth().in(Meters), 0.001);
+    }
+
+    @Test
+    public void testGetFieldLength_mirroredField() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+        var symmetry = GameField.Symmetry.Mirrored;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(16.541, gameField.getFieldLength().in(Meters), 0.001);
+    }
+
+    @Test
+    public void testGetSymmetry_mirroredField() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+        var symmetry = GameField.Symmetry.Mirrored;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(GameField.Symmetry.Mirrored, gameField.getSymmetry());
+    }
+
+    @Test
+    public void testGetFieldCenter_mirroredField() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+        var symmetry = GameField.Symmetry.Mirrored;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        assertEquals(8.211 / 2, gameField.getFieldCenter().getY(), 0.001);
+        assertEquals(16.541 / 2, gameField.getFieldCenter().getX(), 0.001);
+    }
+
+    @Test
+    public void testGetMirroredTranslation_mirroredField() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+        var symmetry = GameField.Symmetry.Mirrored;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        var translation = new Translation2d(1, 2);
+        var mirroredTranslation = gameField.getMirroredTranslation(translation);
+
+        assertEquals(15.541, mirroredTranslation.getX(), 0.001);
+        assertEquals(2, mirroredTranslation.getY(), 0.001);
+    }
+
+    @Test
+    public void testGetMirroredRotation_mirroredField() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+        var symmetry = GameField.Symmetry.Mirrored;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        var rotation = Rotation2d.fromDegrees(1);
+        var mirroredRotation = gameField.getMirroredRotation(rotation);
+
+        assertEquals(-1, mirroredRotation.getDegrees(), 0.001);
+    }
+
+    @Test
+    public void testGetMirroredPose_mirroredField() {
+        var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+        var symmetry = GameField.Symmetry.Mirrored;
+        var gameField = new GameField(fieldLayout, symmetry);
+
+        var translation = new Translation2d(1, 2);
+        var rotation = Rotation2d.fromDegrees(1);
+        var pose = new Pose2d(translation, rotation);
+        var mirroredPose = gameField.getMirroredPose(pose);
+
+        assertEquals(15.541, mirroredPose.getTranslation().getX(), 0.001);
+        assertEquals(2, mirroredPose.getTranslation().getY(), 0.001);
+        assertEquals(-1, mirroredPose.getRotation().getDegrees(), 0.001);
+    }
+}

--- a/src/test/java/xbot/common/subsystems/pose/GameFieldTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/GameFieldTest.java
@@ -67,10 +67,10 @@ public class GameFieldTest {
         var symmetry = GameField.Symmetry.Rotational;
         var gameField = new GameField(fieldLayout, symmetry);
 
-        var rotation = Rotation2d.fromDegrees(1);
-        var mirroredRotation = gameField.getMirroredRotation(rotation);
-
-        assertEquals(-179, mirroredRotation.getDegrees(), 0.001);
+        assertEquals(-179, gameField.getMirroredRotation(Rotation2d.fromDegrees(1)).getDegrees(), 0.001);
+        assertEquals(-90, gameField.getMirroredRotation(Rotation2d.fromDegrees(90)).getDegrees(), 0.001);
+        assertEquals(0, gameField.getMirroredRotation(Rotation2d.fromDegrees(180)).getDegrees(), 0.001);
+        assertEquals(90, gameField.getMirroredRotation(Rotation2d.fromDegrees(-90)).getDegrees(), 0.001);
     }
 
     @Test
@@ -146,10 +146,10 @@ public class GameFieldTest {
         var symmetry = GameField.Symmetry.Mirrored;
         var gameField = new GameField(fieldLayout, symmetry);
 
-        var rotation = Rotation2d.fromDegrees(1);
-        var mirroredRotation = gameField.getMirroredRotation(rotation);
-
-        assertEquals(-1, mirroredRotation.getDegrees(), 0.001);
+        assertEquals(179, gameField.getMirroredRotation(Rotation2d.fromDegrees(1)).getDegrees(), 0.001);
+        assertEquals(90, gameField.getMirroredRotation(Rotation2d.fromDegrees(90)).getDegrees(), 0.001);
+        assertEquals(0, gameField.getMirroredRotation(Rotation2d.fromDegrees(180)).getDegrees(), 0.001);
+        assertEquals(270, gameField.getMirroredRotation(Rotation2d.fromDegrees(-90)).getDegrees(), 0.001);
     }
 
     @Test
@@ -165,6 +165,6 @@ public class GameFieldTest {
 
         assertEquals(15.541, mirroredPose.getTranslation().getX(), 0.001);
         assertEquals(2, mirroredPose.getTranslation().getY(), 0.001);
-        assertEquals(-1, mirroredPose.getRotation().getDegrees(), 0.001);
+        assertEquals(179, mirroredPose.getRotation().getDegrees(), 0.001);
     }
 }

--- a/src/test/java/xbot/common/subsystems/pose/GameFieldTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/GameFieldTest.java
@@ -6,11 +6,13 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import org.junit.Test;
+import xbot.common.injection.BaseCommonLibTest;
 
 import static edu.wpi.first.units.Units.Meters;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class GameFieldTest {
+public class GameFieldTest extends BaseCommonLibTest {
     @Test
     public void testGetFieldWidth() {
         var fieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
@@ -166,5 +168,11 @@ public class GameFieldTest {
         assertEquals(15.541, mirroredPose.getTranslation().getX(), 0.001);
         assertEquals(2, mirroredPose.getTranslation().getY(), 0.001);
         assertEquals(179, mirroredPose.getRotation().getDegrees(), 0.001);
+    }
+
+    @Test
+    public void testInjection() {
+        assertNotNull(getInjectorComponent().getGameField());
+        assertEquals(GameField.Symmetry.Rotational, getInjectorComponent().getGameField().getSymmetry());
     }
 }


### PR DESCRIPTION
…e math

# Why are we doing this?
Having the field rotation math coupled to the PoseSubystem is not ideal, and it couples us to a particular rotation mode based on whatever version of SeriouslyCommonLib is in use.

# Whats changing?
Add an injectable component that will do all of the math for the year's particular game field.

# Questions/notes for reviewers
I'm not convinced by the rotation math, please verify.

# How this was tested
- [x] unit tests added
- [ ] tested on robot
