### PR TITLE
Reduce CANCoder and TalonFX log spew, add Alert signals for health

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -26,6 +26,7 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANBusId;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
+import xbot.common.logging.AlertGroups;
 import xbot.common.logic.LogicUtils;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
@@ -130,8 +131,8 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
         police.registerDevice(DevicePolice.DeviceType.CAN, busId, info.deviceId(), info.name());
         this.akitName = info.name()+"/CANMotorController";
 
-        this.unhealthyAlert = new Alert("Motor Controller " + info.deviceId() + " on CAN bus " + busId.toString() +  " (" + owningSystemPrefix + ") is " +
-                "unhealthy",
+        this.unhealthyAlert = new Alert(AlertGroups.DEVICE_HEALTH, "Motor Controller " + info.deviceId() + " on CAN bus " + busId.toString() +  " ("
+                + owningSystemPrefix + ") is unhealthy",
                 Alert.AlertType.kError);
 
         if (defaultPIDProperties == null) {

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -18,6 +18,7 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
 import xbot.common.properties.PropertyFactory;
+import xbot.common.resiliency.DeviceHealth;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RPM;
@@ -98,6 +99,11 @@ public class MockCANMotorController extends XCANMotorController {
         this.d = d;
         this.f = velocityFF;
         this.g = gravityFF;
+    }
+
+    @Override
+    public DeviceHealth getHealth() {
+        return DeviceHealth.Healthy;
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -29,6 +29,7 @@ import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
 import xbot.common.logging.RobotAssertionManager;
 import xbot.common.properties.PropertyFactory;
+import xbot.common.resiliency.DeviceHealth;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RPM;
@@ -146,6 +147,12 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
         this.internalSparkMax.configure(config,
                 SparkBase.ResetMode.kNoResetSafeParameters,
                 SparkBase.PersistMode.kNoPersistParameters);
+    }
+
+    @Override
+    public DeviceHealth getHealth() {
+        var faults = this.internalSparkMax.getFaults();
+        return (faults.can || faults.firmware) ? DeviceHealth.Unhealthy : DeviceHealth.Healthy;
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -1,5 +1,6 @@
 package xbot.common.controls.actuators.wpi_adapters;
 
+import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.ClosedLoopRampsConfigs;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
@@ -56,6 +57,11 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     private final TalonFX internalTalonFx;
     private static final org.apache.logging.log4j.Logger log = LogManager.getLogger(CANTalonFxWpiAdapter.class);
 
+    private final StatusSignal<Angle> rotorPositionSignal;
+    private final StatusSignal<AngularVelocity> rotorVelocitySignal;
+    private final StatusSignal<Voltage> motorVoltageSignal;
+    private final StatusSignal<Current> statorCurrentSignal;
+
     @AssistedInject
     public CANTalonFxWpiAdapter(
             @Assisted("info") CANMotorControllerInfo info,
@@ -67,6 +73,11 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     ) {
         super(info, owningSystemPrefix, propertyFactory, police, pidPropertyPrefix, defaultPIDProperties);
         this.internalTalonFx = new TalonFX(info.deviceId(), info.busId().id());
+
+        this.rotorPositionSignal = this.internalTalonFx.getRotorPosition(false);
+        this.rotorVelocitySignal = this.internalTalonFx.getRotorVelocity(false);
+        this.motorVoltageSignal = this.internalTalonFx.getMotorVoltage(false);
+        this.statorCurrentSignal = this.internalTalonFx.getStatorCurrent(false);
 
         setConfiguration(info.outputConfig());
     }
@@ -161,7 +172,8 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
 
     @Override
     public Angle getRawPosition() {
-        return this.internalTalonFx.getRotorPosition().getValue();
+        rotorPositionSignal.refresh(false);
+        return rotorPositionSignal.getValue();
     }
 
     @Override
@@ -188,7 +200,8 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
 
     @Override
     public AngularVelocity getRawVelocity() {
-        return this.internalTalonFx.getRotorVelocity().getValue();
+        rotorVelocitySignal.refresh(false);
+        return rotorVelocitySignal.getValue();
     }
 
     @Override
@@ -217,7 +230,8 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     public Voltage getVoltage() {
-        return this.internalTalonFx.getMotorVoltage().getValue();
+        motorVoltageSignal.refresh(false);
+        return motorVoltageSignal.getValue();
     }
 
     @Override
@@ -230,7 +244,8 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     public Current getCurrent() {
-        return this.internalTalonFx.getStatorCurrent().getValue();
+        statorCurrentSignal.refresh(false);
+        return statorCurrentSignal.getValue();
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -40,6 +40,7 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
 import xbot.common.properties.PropertyFactory;
+import xbot.common.resiliency.DeviceHealth;
 
 public class CANTalonFxWpiAdapter extends XCANMotorController {
 
@@ -104,6 +105,11 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
                 .withKG(gravityFF);
         slotConfig.SlotNumber = slot;
         this.internalTalonFx.getConfigurator().apply(slotConfig);
+    }
+
+    @Override
+    public DeviceHealth getHealth() {
+        return this.internalTalonFx.isConnected() ? DeviceHealth.Healthy : DeviceHealth.Unhealthy;
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/sensors/XCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XCANCoder.java
@@ -6,6 +6,7 @@ import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.io_inputs.XCANCoderInputs;
 import xbot.common.controls.io_inputs.XCANCoderInputsAutoLogged;
 import xbot.common.injection.electrical_contract.DeviceInfo;
+import xbot.common.logging.AlertGroups;
 import xbot.common.resiliency.DeviceHealth;
 
 public abstract class XCANCoder extends XAbsoluteEncoder {
@@ -21,7 +22,8 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
     public XCANCoder(DeviceInfo info) {
         super(info);
         inputs = new XCANCoderInputsAutoLogged();
-        unhealtyAlert = new Alert("CANCoder " + info.channel + " on CAN bus " + info.canBusId + " is unhealthy", Alert.AlertType.kError);
+        unhealtyAlert = new Alert(AlertGroups.DEVICE_HEALTH, "CANCoder " + info.channel + " on CAN bus " + info.canBusId + " is unhealthy",
+                Alert.AlertType.kError);
     }
 
     /**

--- a/src/main/java/xbot/common/controls/sensors/XCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XCANCoder.java
@@ -1,14 +1,18 @@
 package xbot.common.controls.sensors;
 
 import com.ctre.phoenix6.StatusCode;
+import edu.wpi.first.wpilibj.Alert;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.controls.io_inputs.XCANCoderInputs;
 import xbot.common.controls.io_inputs.XCANCoderInputsAutoLogged;
 import xbot.common.injection.electrical_contract.DeviceInfo;
+import xbot.common.resiliency.DeviceHealth;
 
 public abstract class XCANCoder extends XAbsoluteEncoder {
 
     XCANCoderInputsAutoLogged inputs;
+
+    private final Alert unhealtyAlert;
 
     public interface XCANCoderFactory extends XAbsoluteEncoderFactory {
         XCANCoder create(DeviceInfo deviceInfo, String owningSystemPrefix);
@@ -17,6 +21,7 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
     public XCANCoder(DeviceInfo info) {
         super(info);
         inputs = new XCANCoderInputsAutoLogged();
+        unhealtyAlert = new Alert("CANCoder " + info.channel + " on CAN bus " + info.canBusId + " is unhealthy", Alert.AlertType.kError);
     }
 
     /**
@@ -46,5 +51,7 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
         super.refreshDataFrame();
         updateInputs(inputs);
         Logger.processInputs(info.name+"/CANCoder", inputs);
+
+        unhealtyAlert.set(getHealth() == DeviceHealth.Unhealthy);
     }
 }

--- a/src/main/java/xbot/common/logging/AlertGroups.java
+++ b/src/main/java/xbot/common/logging/AlertGroups.java
@@ -1,0 +1,11 @@
+package xbot.common.logging;
+
+/**
+ * This class contains the names of the alert groups that are used in the logging system.
+ */
+public final class AlertGroups {
+    /**
+     * The name of the alert group that is used for all alerts that are related to the robot's devices.
+     */
+    public static final String DEVICE_HEALTH = "DeviceHealth";
+}

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionCameraHelper.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionCameraHelper.java
@@ -6,6 +6,7 @@ import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.wpilibj.Alert;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.advantage.DataFrameRefreshable;
+import xbot.common.logging.AlertGroups;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 
@@ -51,8 +52,8 @@ class AprilTagVisionCameraHelper implements DataFrameRefreshable {
         this.io = io;
         this.inputs = new VisionIOInputsAutoLogged();
         this.aprilTagFieldLayout = fieldLayout;
-        this.disconnectedAlert = new Alert(
-                "Vision camera " + prefix + " is disconnected.", Alert.AlertType.kWarning);
+        this.disconnectedAlert = new Alert(AlertGroups.DEVICE_HEALTH,
+                "Vision camera " + prefix + " is disconnected.", Alert.AlertType.kError);
 
         pf.setPrefix(this.logPath);
         this.maxAmbiguity = pf.createPersistentProperty("MaxAmbiguity", 0.3);

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,74 +1,71 @@
 {
-    "fileName": "REVLib.json",
-    "name": "REVLib",
-    "version": "2025.0.0",
-    "frcYear": "2025",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "mavenUrls": [
-        "https://maven.revrobotics.com/"
-    ],
-    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2025.json",
-    "javaDependencies": [
-        {
-            "groupId": "com.revrobotics.frc",
-            "artifactId": "REVLib-java",
-            "version": "2025.0.0"
-        }
-    ],
-    "jniDependencies": [
-        {
-            "groupId": "com.revrobotics.frc",
-            "artifactId": "REVLib-driver",
-            "version": "2025.0.0",
-            "skipInvalidPlatforms": true,
-            "isJar": false,
-            "validPlatforms": [
-                "windowsx86-64",
-                "windowsx86",
-                "linuxarm64",
-                "linuxx86-64",
-                "linuxathena",
-                "linuxarm32",
-                "osxuniversal"
-            ]
-        }
-    ],
-    "cppDependencies": [
-        {
-            "groupId": "com.revrobotics.frc",
-            "artifactId": "REVLib-cpp",
-            "version": "2025.0.0",
-            "libName": "REVLib",
-            "headerClassifier": "headers",
-            "sharedLibrary": false,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "windowsx86",
-                "linuxarm64",
-                "linuxx86-64",
-                "linuxathena",
-                "linuxarm32",
-                "osxuniversal"
-            ]
-        },
-        {
-            "groupId": "com.revrobotics.frc",
-            "artifactId": "REVLib-driver",
-            "version": "2025.0.0",
-            "libName": "REVLibDriver",
-            "headerClassifier": "headers",
-            "sharedLibrary": false,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "windowsx86",
-                "linuxarm64",
-                "linuxx86-64",
-                "linuxathena",
-                "linuxarm32",
-                "osxuniversal"
-            ]
-        }
-    ]
+  "fileName": "REVLib.json",
+  "name": "REVLib",
+  "version": "2025.0.2",
+  "frcYear": "2025",
+  "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+  "mavenUrls": [
+    "https://maven.revrobotics.com/"
+  ],
+  "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2025.json",
+  "javaDependencies": [
+    {
+      "groupId": "com.revrobotics.frc",
+      "artifactId": "REVLib-java",
+      "version": "2025.0.2"
+    }
+  ],
+  "jniDependencies": [
+    {
+      "groupId": "com.revrobotics.frc",
+      "artifactId": "REVLib-driver",
+      "version": "2025.0.2",
+      "skipInvalidPlatforms": true,
+      "isJar": false,
+      "validPlatforms": [
+        "windowsx86-64",
+        "linuxarm64",
+        "linuxx86-64",
+        "linuxathena",
+        "linuxarm32",
+        "osxuniversal"
+      ]
+    }
+  ],
+  "cppDependencies": [
+    {
+      "groupId": "com.revrobotics.frc",
+      "artifactId": "REVLib-cpp",
+      "version": "2025.0.2",
+      "libName": "REVLib",
+      "headerClassifier": "headers",
+      "sharedLibrary": false,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "windowsx86-64",
+        "linuxarm64",
+        "linuxx86-64",
+        "linuxathena",
+        "linuxarm32",
+        "osxuniversal"
+      ]
+    },
+    {
+      "groupId": "com.revrobotics.frc",
+      "artifactId": "REVLib-driver",
+      "version": "2025.0.2",
+      "libName": "REVLibDriver",
+      "headerClassifier": "headers",
+      "sharedLibrary": false,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "windowsx86-64",
+        "linuxarm64",
+        "linuxx86-64",
+        "linuxathena",
+        "linuxarm32",
+        "osxuniversal"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
# Why are we doing this?
Logging errors on every sensor update is expensive, and it's difficult to get an overview of faults.

# Whats changing?
Ignore errors when reading status signals on CANCoders and TalonFX, and instead emit an alert when unhealthy.

# Questions/notes for reviewers
This doesn't eliminate all of the log spew, just most of it.

# How this was tested
- [ ] unit tests added
- [x] tested on robot
