### PR TITLE
Set swerve calibrations for X2i, make configurable via contract

### DIFF
--- a/src/main/java/xbot/common/injection/electrical_contract/XSwerveDriveElectricalContract.java
+++ b/src/main/java/xbot/common/injection/electrical_contract/XSwerveDriveElectricalContract.java
@@ -56,7 +56,7 @@ public interface XSwerveDriveElectricalContract {
      * @return The diameter of the drive wheels.
      */
     default Distance getDriveWheelDiameter() {
-        return Inches.of(2);
+        return Inches.of(4);
     }
 
     /**

--- a/src/main/java/xbot/common/injection/electrical_contract/XSwerveDriveElectricalContract.java
+++ b/src/main/java/xbot/common/injection/electrical_contract/XSwerveDriveElectricalContract.java
@@ -1,7 +1,10 @@
 package xbot.common.injection.electrical_contract;
 
+import edu.wpi.first.units.measure.Distance;
 import xbot.common.injection.swerve.SwerveInstance;
 import xbot.common.math.XYPair;
+
+import static edu.wpi.first.units.Units.Inches;
 
 /**
  * This interface defines the base electrical contract
@@ -47,4 +50,28 @@ public interface XSwerveDriveElectricalContract {
      * @return The offset from the center of the robot as an {@link XYPair} for the given {@link SwerveInstance}, in inches.
      */
     XYPair getSwerveModuleOffsetsInInches(SwerveInstance swerveInstance);
+
+    /**
+     * Returns the diameter of the drive wheels.
+     * @return The diameter of the drive wheels.
+     */
+    default Distance getDriveWheelDiameter() {
+        return Inches.of(2);
+    }
+
+    /**
+     * Returns the gear ratio for the drive motors.
+     * @return The gear ratio for the drive motors.
+     */
+    default double getDriveGearRatio() {
+        return 6.48; // Documented value for WCP x2i with X3 10t gears.
+    }
+
+    /**
+     * Returns the gear ratio for the steering motors.
+     * @return The gear ratio for the steering motors.
+     */
+    default double getSteeringGearRatio() {
+        return 12.1; // Documented value for WCP x2i.
+    }
 }


### PR DESCRIPTION
# Why are we doing this?
Calibration for our serve modules is wrong, but each robot will need different calibrations.

# Whats changing?
Expose gear ratios for swerve drive in the contract. Offload the math to the ratio converters in the motor controller classes.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on simulator
