### PR TITLE
Allow new constructor in SwerveDriveRotationAdvisor that takes in a deadband

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveRotationAdvisor.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveDriveRotationAdvisor.java
@@ -23,7 +23,7 @@ public class SwerveDriveRotationAdvisor {
     AKitLogger aKitLogger;
 
     public SwerveDriveRotationAdvisor(ISwerveAdvisorPoseSupport pose, ISwerveAdvisorDriveSupport drive, PropertyFactory pf,
-                                      HumanVsMachineDecider hvmDecider) {
+                                      HumanVsMachineDecider hvmDecider, double defaultDeadband) {
         pf.setPrefix("SwerveDriveRotationAdvisor/");
         this.hvmDecider = hvmDecider;
         this.drive = drive;
@@ -32,6 +32,13 @@ public class SwerveDriveRotationAdvisor {
         aKitLogger = new AKitLogger(pf.getPrefix());
 
         this.minimumMagnitudeToSnap = pf.createPersistentProperty("MinimumMagnitudeToSnap", 0.75);
+
+        hvmDecider.setDeadband(defaultDeadband);
+    }
+
+    public SwerveDriveRotationAdvisor(ISwerveAdvisorPoseSupport pose, ISwerveAdvisorDriveSupport drive, PropertyFactory pf,
+                                      HumanVsMachineDecider hvmDecider) {
+        this(pose, drive, pf, hvmDecider, 0.05);
     }
 
     public SwerveSuggestedRotation getSuggestedRotationValue(XYPair snappingInput, double triggerRotateIntent) {


### PR DESCRIPTION
# Why are we doing this?
Too many layered deadbands - this allows us to effectively remove one if needed.
# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
