### PR TITLE
Allow for slewing the main drive

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -499,11 +499,12 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
 
     protected boolean isValidVoltageRequest(Voltage voltage) {
         if (voltage.gt(Volts.of(0)) && softwareForwardLimit.get()) {
-            log.warn("Attempted to set positive voltage on motor controller with forward software limit enabled");
+            // TODO: Change these various warnings to only trigger once on the rising edge of the issue.
+            //log.warn("Attempted to set positive voltage on motor controller with forward software limit enabled");
             return false;
         }
         if (voltage.lt(Volts.of(0)) && softwareReverseLimit.get()) {
-            log.warn("Attempted to set negative voltage on motor controller with reverse software limit enabled");
+            //log.warn("Attempted to set negative voltage on motor controller with reverse software limit enabled");
             return false;
         }
         return true;
@@ -511,11 +512,11 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
 
     protected boolean isValidPowerRequest(double power) {
         if (power > 0 && softwareForwardLimit.get()) {
-            log.warn("Attempted to set positive power on motor controller with forward software limit enabled");
+            //log.warn("Attempted to set positive power on motor controller with forward software limit enabled");
             return false;
         }
         if (power < 0 && softwareReverseLimit.get()) {
-            log.warn("Attempted to set negative power on motor controller with reverse software limit enabled");
+            //log.warn("Attempted to set negative power on motor controller with reverse software limit enabled");
             return false;
         }
         return true;
@@ -530,7 +531,7 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
 
     protected Distance convertRawAngleToDistance(Angle rawAngle) {
         if (distancePerMotorRotationsScaleFactor == null) {
-            log.warn("Distance per angle not set for motor controller {}", akitName);
+            //log.warn("Distance per angle not set for motor controller {}", akitName);
             return Meters.zero();
         }
         return rawAngle.timesConversionFactor(distancePerMotorRotationsScaleFactor);
@@ -538,7 +539,7 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
 
     protected Angle convertDistanceToRawAngle(Distance distance) {
         if (distancePerMotorRotationsInverseScaleFactor == null) {
-            log.warn("Distance per angle not set for motor controller {}", akitName);
+            //log.warn("Distance per angle not set for motor controller {}", akitName);
             return Rotations.zero();
         }
         return distance.timesConversionFactor(distancePerMotorRotationsInverseScaleFactor);

--- a/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
@@ -1,5 +1,6 @@
 package xbot.common.subsystems.drive;
 
+import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -12,8 +13,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import xbot.common.advantage.AKitLogger;
 import xbot.common.advantage.DataFrameRefreshable;
+import xbot.common.controls.sensors.XTimer;
 import xbot.common.injection.swerve.SwerveComponent;
-import xbot.common.math.MathUtils;
 import xbot.common.math.PIDDefaults;
 import xbot.common.math.PIDManager;
 import xbot.common.math.XYPair;
@@ -35,6 +36,7 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
 
     private final DoubleProperty maxTargetSpeedMps;
     private final DoubleProperty maxTargetTurnRate;
+    private final DoubleProperty maxAccelerationMps2;
 
     private final SwerveDriveKinematics swerveDriveKinematics;
     private String activeModuleLabel;
@@ -77,6 +79,9 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
 
     private boolean noviceMode = false;
 
+    private SlewRateLimiter slewRateLimiter;
+    private double lastMoveCallTime;
+
     public BaseSwerveDriveSubsystem(PIDManager.PIDManagerFactory pidFactory, PropertyFactory pf,
                                     SwerveComponent frontLeftSwerve, SwerveComponent frontRightSwerve,
                                     SwerveComponent rearLeftSwerve, SwerveComponent rearRightSwerve) {
@@ -97,6 +102,8 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
 
         this.maxTargetSpeedMps = pf.createPersistentProperty("MaxTargetSpeedMetersPerSecond", 4.5);
         this.maxTargetTurnRate = pf.createPersistentProperty("MaxTargetTurnRate", 8.0);
+        this.maxAccelerationMps2 = pf.createPersistentProperty("MaxAccelerationMps2", 9.0); //TODO: tune.
+
         this.activeModuleLabel = activeModule.toString();
         this.desiredHeading = 0;
 
@@ -108,7 +115,7 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
         // TODO: eventually, this should retrieved from auto or the pose subsystem as a field like
         // "Desired initial wheel direction" so there's no thrash right at the start of a match.
         // Probably not a huge priority, Since as soon as we move once the robot remembers the last commanded direction.
-        lastCommandedDirection = new XYPair(0, 90);
+        lastCommandedDirection = new XYPair(0.1, 0);
 
         positionalPidManager = pidFactory.create(
                 this.getPrefix() + "PositionPID",
@@ -122,6 +129,7 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
         headingPidManager.setEnableErrorThreshold(true);
         headingPidManager.setEnableTimeThreshold(true);
 
+        slewRateLimiter = new SlewRateLimiter(maxAccelerationMps2.get());
     }
 
     /**
@@ -329,6 +337,31 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
      * @param centerOfRotationInches The center of rotation.
      */
     public void move(XYPair translate, double rotate, XYPair centerOfRotationInches) {
+        // We want to smooth out any sudden changes in velocity. Given that we need to compare two vectors, really what we're saying is that
+        // the magnitude of the distance between the last commanded vector and the newly commanded vector should be constrained.
+
+        if (XTimer.getFPGATimestamp() - lastMoveCallTime > 1) {
+            // It's been over 1 second since somebody last called the drive. This means any ephemeral state is very stale.
+            // Setting the last commanded direction to the current direction will prevent surprising behavior. This will allow for
+            // powerful motions if the joystick is being held in a direction as the robot enables. Ideally this would use the robot's
+            // current velocity, but the drive subsystem doesn't have access to that information.
+            lastCommandedDirection = translate;
+        }
+
+        // First, discover this vector.
+        XYPair deltaVector = translate.clone().add(lastCommandedDirection.clone().scale(-1));
+
+        // Limit its magnitude based on the slew rate limiter.
+        double deltaMagnitude = deltaVector.getMagnitude();
+        double maxDeltaMagnitude = slewRateLimiter.calculate(deltaMagnitude);
+
+        if (Math.abs(deltaMagnitude - maxDeltaMagnitude) > 0.001 && !unlockFullDrivePower) {
+            // Only scale the vector if we have to, and if we're not in "full power" mode.
+            deltaVector = XYPair.fromPolar(deltaVector.getAngle(), maxDeltaMagnitude);
+
+            // Override the "Translate" vector with this result
+            translate = lastCommandedDirection.clone().add(deltaVector);
+        }
 
         if (activateBrakeOverride) {
             this.setWheelsToXMode();
@@ -401,6 +434,8 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
             lastCommandedDirection = translate;
             lastCommandedRotation = rotate;
         }
+
+        lastMoveCallTime = XTimer.getFPGATimestamp();
     }
 
     public void setActivateBrakeOverride(boolean activateBrakeOverride) {
@@ -601,6 +636,10 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
         aKitLog.setLogLevel(AKitLogger.LogLevel.DEBUG);
         aKitLog.record("VelocityMaintainerTargets",
             new Translation2d(velocityMaintainerXTarget, velocityMaintainerXTarget));
+
+        if (maxAccelerationMps2.hasChangedSinceLastCheck()) {
+            slewRateLimiter = new SlewRateLimiter(maxAccelerationMps2.get());
+        }
     }
 
     public void refreshDataFrame() {


### PR DESCRIPTION
# Why are we doing this?
Lets us set an acceleration limiter on the core drive. Useful for preventing things like a PositionalPID from "leaping off the start".
# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested in sim
