### PR TITLE
Feature/swerve commits to encoders

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/XCANCoder.java
+++ b/src/main/java/xbot/common/controls/sensors/XCANCoder.java
@@ -13,7 +13,7 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
 
     XCANCoderInputsAutoLogged inputs;
 
-    private final Alert unhealtyAlert;
+    private final Alert unhealthyAlert;
 
     public interface XCANCoderFactory extends XAbsoluteEncoderFactory {
         XCANCoder create(DeviceInfo deviceInfo, String owningSystemPrefix);
@@ -22,7 +22,7 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
     public XCANCoder(DeviceInfo info) {
         super(info);
         inputs = new XCANCoderInputsAutoLogged();
-        unhealtyAlert = new Alert(AlertGroups.DEVICE_HEALTH, "CANCoder " + info.channel + " on CAN bus " + info.canBusId + " is unhealthy",
+        unhealthyAlert = new Alert(AlertGroups.DEVICE_HEALTH, "CANCoder " + info.channel + " on CAN bus " + info.canBusId + " is unhealthy",
                 Alert.AlertType.kError);
     }
 
@@ -54,6 +54,6 @@ public abstract class XCANCoder extends XAbsoluteEncoder {
         updateInputs(inputs);
         Logger.processInputs(info.name+"/CANCoder", inputs);
 
-        unhealtyAlert.set(getHealth() == DeviceHealth.Unhealthy);
+        unhealthyAlert.set(getHealth() == DeviceHealth.Unhealthy);
     }
 }

--- a/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -80,10 +80,6 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
         }
         if (electricalContract.areCanCodersReady()) {
             this.encoder = canCoderFactory.create(electricalContract.getSteeringEncoder(swerveInstance), this.getPrefix());
-            // Since the CANCoders start with absolute knowledge from the start, that means this system
-            // is always calibrated.
-            // As a special case, we have to perform the first refresh in order to have any useful data.
-            encoder.refreshDataFrame();
         }
         setupStatusFramesAsNeeded();
     }

--- a/src/main/java/xbot/common/subsystems/drive/swerve/commands/SwerveSteeringMaintainerCommand.java
+++ b/src/main/java/xbot/common/subsystems/drive/swerve/commands/SwerveSteeringMaintainerCommand.java
@@ -11,16 +11,12 @@ public class SwerveSteeringMaintainerCommand extends BaseMaintainerCommand<Doubl
 
     private final SwerveSteeringSubsystem subsystem;
 
-    private boolean enableAutoCalibrate;
-
     @Inject
     public SwerveSteeringMaintainerCommand(SwerveSteeringSubsystem subsystemToMaintain, PropertyFactory pf, HumanVsMachineDeciderFactory hvmFactory) {
         super(subsystemToMaintain, pf, hvmFactory, 0.001, 0.001);
         pf.setPrefix(this);
 
         this.subsystem = subsystemToMaintain;
-
-        this.enableAutoCalibrate = true;
     }
 
     @Override
@@ -30,15 +26,7 @@ public class SwerveSteeringMaintainerCommand extends BaseMaintainerCommand<Doubl
 
     @Override
     protected void calibratedMachineControlAction() {
-        if (this.subsystem.isUsingMotorControllerPid()) {
-            this.subsystem.setMotorControllerPidTarget();
-        } else {
-            this.subsystem.setPower(this.subsystem.calculatePower());
-        }
-
-        if (enableAutoCalibrate && isMaintainerAtGoal() && subsystem.getVelocity().magnitude() < 0.001) {
-            this.subsystem.calibrateMotorControllerPositionFromCanCoder();
-        }
+        this.subsystem.setMotorControllerPidTarget();
     }
 
     @Override
@@ -62,17 +50,11 @@ public class SwerveSteeringMaintainerCommand extends BaseMaintainerCommand<Doubl
     public void initialize() {
         this.subsystem.setTargetValue(this.subsystem.getCurrentValue());
         this.subsystem.setPower(0.0);
-        this.subsystem.resetPid();
-
-        if (enableAutoCalibrate) {
-            this.subsystem.calibrateMotorControllerPositionFromCanCoder();
-        }
     }
 
     @Override
     public void end(boolean interrupted) {
         super.end(interrupted);
-
         this.initialize();
     }
 }


### PR DESCRIPTION
# Why are we doing this?
Every once in a while, when the robot boots, it gets into a state where one or more swerve modules starts rotating rapidly. A code reboot has fixed this each time. I don't have definitive evidence, but from reading through the code, it looks like we check the CANCoder health on boot, and if it's not healthy, we "lock in" to using the onboard motor controller as as PID. 

In practice, since we haven't tuned that PID, we get crazy rotation. Based on our experiences with motor drift, I'm not convinced this is even a practical fallback; I think at this point we have to commit to effectively all or nothing. If we can't connect to the encoder, then we mark the module degraded and always set 0 power to steering and drive, hoping the other 3 modules can take up the slack.

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
