### PR TITLE
Exposing maxAccelerationMps2 for calcuting curve.

### DIFF
--- a/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/drive/BaseSwerveDriveSubsystem.java
@@ -176,6 +176,10 @@ public abstract class BaseSwerveDriveSubsystem extends BaseDriveSubsystem implem
         return maxTargetSpeedMps.get();
     }
 
+    public double getMaxAccelerationMetersPerSecondSquared() {
+        return maxAccelerationMps2.get();
+    }
+
     public double getMaxTargetTurnRate() {
         return maxTargetTurnRate.get();
     }


### PR DESCRIPTION
# Why are we doing this?

Using Kobe's Bezier curves wants to expose this for vision to compute with:
```java
        var options = XTableValues.TraversalOptions.newBuilder()
            .setMetersPerSecond(this.drive.getMaxTargetSpeedMetersPerSecond())
            .setAccelerationMetersPerSecond(this.drive.getMaxAccelerationMetersPerSecondSquared())
```

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] Tested in simulator
