### PR TITLE
AngleProperty + mutable DistanceProperty

### DIFF
--- a/src/main/java/xbot/common/properties/AngleProperty.java
+++ b/src/main/java/xbot/common/properties/AngleProperty.java
@@ -5,22 +5,22 @@ import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.inputs.LoggableInputs;
 
-import edu.wpi.first.units.DistanceUnit;
-import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.AngleUnit;
+import edu.wpi.first.units.measure.Angle;
 
 
 import xbot.common.logging.Pluralizer;
 
 /**
- * This manages a Distance in the property system.
+ * This manages an Angle in the property system.
  *
  * @author Alex
  */
-public class DistanceProperty extends Property {
-    final Distance defaultValue;
-    final DistanceUnit defaultUnit;
-    Distance lastValue;
-    Distance currentValue;
+public class AngleProperty extends Property {
+    final Angle defaultValue;
+    final AngleUnit defaultUnit;
+    Angle lastValue;
+    Angle currentValue;
 
     private final LoggableInputs inputs = new LoggableInputs() {
         public void toLog(LogTable table) {
@@ -32,18 +32,18 @@ public class DistanceProperty extends Property {
         }
     };
 
-    public DistanceProperty(String prefix, String name, Distance defaultValue, XPropertyManager manager) {
+    public AngleProperty(String prefix, String name, Angle defaultValue, XPropertyManager manager) {
         this(prefix, name, defaultValue, manager, PropertyLevel.Important);
     }
 
-    public DistanceProperty(String prefix, String name, Distance defaultValue, XPropertyManager manager, PropertyLevel level) {
+    public AngleProperty(String prefix, String name, Angle defaultValue, XPropertyManager manager, PropertyLevel level) {
         super(prefix, name  + "-in-" + Pluralizer.pluralize(defaultValue.unit().name()), manager, level);
         this.defaultValue = defaultValue;
         this.defaultUnit = defaultValue.unit();
 
         // Check for non-default on load; also store a "last value" we can use
         // to check if a property has changed recently.
-        Distance firstValue = get_internal();
+        Angle firstValue = get_internal();
         if (get_internal() != defaultValue) {
             log.info("Property " + key + " has the non-default value " + firstValue);
         }
@@ -51,12 +51,12 @@ public class DistanceProperty extends Property {
         currentValue = firstValue;
     }
 
-    public Distance get() {
+    public Angle get() {
         return currentValue;
     }
 
 
-    public Distance get_internal() {
+    public Angle get_internal() {
         Double nullableTableValue = activeStore.getDouble(key);
 
         if(nullableTableValue == null) {
@@ -69,13 +69,13 @@ public class DistanceProperty extends Property {
         return defaultUnit.of(nullableTableValue);
     }
 
-    public void set(Distance value) {
+    public void set(Angle value) {
         activeStore.setDouble(key, value.in(defaultUnit));
         currentValue = value;
     }
 
-    public void hasChangedSinceLastCheck(Consumer<Distance> callback) {
-        Distance currentValue = get();
+    public void hasChangedSinceLastCheck(Consumer<Angle> callback) {
+        Angle currentValue = get();
         if (!currentValue.isEquivalent(lastValue)) {
             callback.accept(currentValue);
         }
@@ -83,7 +83,7 @@ public class DistanceProperty extends Property {
     }
 
     public boolean hasChangedSinceLastCheck() {
-        Distance currentValue = get();
+        Angle currentValue = get();
         boolean changed = !currentValue.isEquivalent(lastValue);
         lastValue = currentValue;
         return changed;

--- a/src/main/java/xbot/common/properties/AngleProperty.java
+++ b/src/main/java/xbot/common/properties/AngleProperty.java
@@ -7,8 +7,7 @@ import org.littletonrobotics.junction.inputs.LoggableInputs;
 
 import edu.wpi.first.units.AngleUnit;
 import edu.wpi.first.units.measure.Angle;
-
-
+import edu.wpi.first.units.measure.MutAngle;
 import xbot.common.logging.Pluralizer;
 
 /**
@@ -19,8 +18,8 @@ import xbot.common.logging.Pluralizer;
 public class AngleProperty extends Property {
     final Angle defaultValue;
     final AngleUnit defaultUnit;
-    Angle lastValue;
-    Angle currentValue;
+    final MutAngle lastValue;
+    final MutAngle currentValue;
 
     private final LoggableInputs inputs = new LoggableInputs() {
         public void toLog(LogTable table) {
@@ -28,7 +27,7 @@ public class AngleProperty extends Property {
         }
 
         public void fromLog(LogTable table) {
-            currentValue = table.get(suffix, defaultValue);
+            currentValue.mut_replace(table.get(suffix, defaultValue));
         }
     };
 
@@ -41,14 +40,18 @@ public class AngleProperty extends Property {
         this.defaultValue = defaultValue;
         this.defaultUnit = defaultValue.unit();
 
+        currentValue = defaultValue.mutableCopy();
+        lastValue = defaultValue.mutableCopy();
+
+
         // Check for non-default on load; also store a "last value" we can use
         // to check if a property has changed recently.
         Angle firstValue = get_internal();
-        if (get_internal() != defaultValue) {
+        if (firstValue != defaultValue) {
             log.info("Property " + key + " has the non-default value " + firstValue);
         }
-        lastValue = firstValue;
-        currentValue = firstValue;
+        lastValue.mut_replace(firstValue);
+        currentValue.mut_replace(firstValue.mutableCopy());
     }
 
     public Angle get() {
@@ -71,7 +74,7 @@ public class AngleProperty extends Property {
 
     public void set(Angle value) {
         activeStore.setDouble(key, value.in(defaultUnit));
-        currentValue = value;
+        currentValue.mut_replace(value);
     }
 
     public void hasChangedSinceLastCheck(Consumer<Angle> callback) {
@@ -79,13 +82,13 @@ public class AngleProperty extends Property {
         if (!currentValue.isEquivalent(lastValue)) {
             callback.accept(currentValue);
         }
-        lastValue = currentValue;
+        lastValue.mut_replace(currentValue);
     }
 
     public boolean hasChangedSinceLastCheck() {
         Angle currentValue = get();
         boolean changed = !currentValue.isEquivalent(lastValue);
-        lastValue = currentValue;
+        lastValue.mut_replace(currentValue);
         return changed;
     }
 
@@ -95,7 +98,7 @@ public class AngleProperty extends Property {
 
     @Override
     public void refreshDataFrame() {
-        currentValue = get_internal();
+        currentValue.mut_replace(get_internal());
         Logger.processInputs(prefix, inputs);
     }
 }

--- a/src/main/java/xbot/common/properties/PropertyFactory.java
+++ b/src/main/java/xbot/common/properties/PropertyFactory.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import xbot.common.logging.RobotAssertionManager;
 import xbot.common.properties.Property.PropertyLevel;
@@ -186,6 +187,28 @@ public class PropertyFactory {
     public DistanceProperty createPersistentProperty(String suffix, Distance defaultValue, PropertyLevel level) {
         checkPrefixSet();
         return new DistanceProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, level);
+    }
+
+    /**
+     * Creates a persistent property for an angle.
+     * @param suffix The suffix for the property.
+     * @param defaultValue The default value for the property.
+     * @return The property.
+     */
+    public AngleProperty createPersistentProperty(String suffix, Angle defaultValue) {
+        return this.createPersistentProperty(suffix, defaultValue, defaultLevel);
+    }
+
+    /**
+     * Creates a persistent property for an angle with a specified property level.
+     * @param suffix The suffix for the property.
+     * @param defaultValue The default value for the property.
+     * @param level The property level.
+     * @return The property.
+     */
+    public AngleProperty createPersistentProperty(String suffix, Angle defaultValue, PropertyLevel level) {
+        checkPrefixSet();
+        return new AngleProperty(getCleanPrefix(), suffix, defaultValue, this.propertyManager, level);
     }
 
 }

--- a/src/test/java/xbot/common/properties/PropertyFactoryTest.java
+++ b/src/test/java/xbot/common/properties/PropertyFactoryTest.java
@@ -2,8 +2,10 @@ package xbot.common.properties;
 
 import xbot.common.injection.BaseCommonLibTest;
 
+import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.Radians;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -31,6 +33,9 @@ public class PropertyFactoryTest extends BaseCommonLibTest {
         assertEquals(1.0, propertyMeters.get().in(Meters), 0.0001);
         // suffix should be modified to state the units
         assertEquals("test-in-Meters", propertyMeters.suffix);
+        
+        propertyMeters.set(Meters.of(2.0));
+        assertEquals(2.0, propertyMeters.get().in(Meters), 0.0001);
 
         // should get back the same value as we put in with the same unit as the defaultValue
         DistanceProperty propertyInches = factory.createPersistentProperty("test", Inches.of(12.0));
@@ -45,14 +50,16 @@ public class PropertyFactoryTest extends BaseCommonLibTest {
         factory.setPrefix("myPrefix");
 
         // should get back the same value as we put in with the same unit as the defaultValue
-        AngleProperty propertyDegrees = factory.createPersistentProperty("test", edu.wpi.first.units.Units.Degrees.of(90.0));
-        assertEquals(90.0, propertyDegrees.get().in(edu.wpi.first.units.Units.Degrees), 0.0001);
+        AngleProperty propertyDegrees = factory.createPersistentProperty("test", Degrees.of(90.0));
+        assertEquals(90.0, propertyDegrees.get().in(Degrees), 0.0001);
         // suffix should be modified to state the units
         assertEquals("test-in-Degrees", propertyDegrees.suffix);
+        propertyDegrees.set(Degrees.of(180.0));
+        assertEquals(180.0, propertyDegrees.get().in(Degrees), 0.0001);
 
         // should get back the same value as we put in with the same unit as the defaultValue
-        AngleProperty propertyRadians = factory.createPersistentProperty("test", edu.wpi.first.units.Units.Radians.of(Math.PI));
-        assertEquals(Math.PI, propertyRadians.get().in(edu.wpi.first.units.Units.Radians), 0.0001);
+        AngleProperty propertyRadians = factory.createPersistentProperty("test", Radians.of(Math.PI));
+        assertEquals(Math.PI, propertyRadians.get().in(Radians), 0.0001);
         // suffix should be modified to state the units
         assertEquals("test-in-Radians", propertyRadians.suffix);
     }

--- a/src/test/java/xbot/common/properties/PropertyFactoryTest.java
+++ b/src/test/java/xbot/common/properties/PropertyFactoryTest.java
@@ -38,4 +38,22 @@ public class PropertyFactoryTest extends BaseCommonLibTest {
         // suffix should be modified to state the units
         assertEquals("test-in-Inches", propertyInches.suffix);
     }
+
+    @Test
+    public void testAngleProperty() {
+        PropertyFactory factory = getInjectorComponent().propertyFactory();
+        factory.setPrefix("myPrefix");
+
+        // should get back the same value as we put in with the same unit as the defaultValue
+        AngleProperty propertyDegrees = factory.createPersistentProperty("test", edu.wpi.first.units.Units.Degrees.of(90.0));
+        assertEquals(90.0, propertyDegrees.get().in(edu.wpi.first.units.Units.Degrees), 0.0001);
+        // suffix should be modified to state the units
+        assertEquals("test-in-Degrees", propertyDegrees.suffix);
+
+        // should get back the same value as we put in with the same unit as the defaultValue
+        AngleProperty propertyRadians = factory.createPersistentProperty("test", edu.wpi.first.units.Units.Radians.of(Math.PI));
+        assertEquals(Math.PI, propertyRadians.get().in(edu.wpi.first.units.Units.Radians), 0.0001);
+        // suffix should be modified to state the units
+        assertEquals("test-in-Radians", propertyRadians.suffix);
+    }
 }


### PR DESCRIPTION
# Why are we doing this?

We have a lot of properties that are Angles, so this will help remove a conversion step. 

Also changing these unit based properties to use mutable units internally so hopefully there's slightly less object churn.

# Questions/notes for reviewers

# How this was tested
- [x] unit tests added
- [ ] tested on robot
