### PR TITLE
Add ability to get any tag's target observation

### DIFF
--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIO.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionIO.java
@@ -27,13 +27,14 @@ public interface AprilTagVisionIO {
     class VisionIOInputs {
         public boolean connected = false;
         public TargetObservation latestTargetObservation =
-                new TargetObservation(0, new Rotation2d(), new Rotation2d(), new Transform3d());
+                new TargetObservation(0, new Rotation2d(), new Rotation2d(), new Transform3d(), 1);
+        public TargetObservation[] targetObservations = new TargetObservation[0];
         public PoseObservation[] poseObservations = new PoseObservation[0];
         public int[] tagIds = new int[0];
     }
 
     /** Represents the angle to a simple target, not used for pose estimation. */
-    record TargetObservation(int fiducialId, Rotation2d tx, Rotation2d ty, Transform3d cameraToTarget) {}
+    record TargetObservation(int fiducialId, Rotation2d tx, Rotation2d ty, Transform3d cameraToTarget, double ambiguity) {}
 
     /** Represents a robot pose sample used for pose estimation. */
     record PoseObservation(

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionSubsystem.java
@@ -94,6 +94,19 @@ public class AprilTagVisionSubsystem extends SubsystemBase implements DataFrameR
     public Rotation2d getTargetX(int cameraIndex) {
         return cameraHelpers[cameraIndex].inputs.latestTargetObservation.tx();
     }
+    
+    /**
+     * Returns the X angle to the specified target, which can be used for simple servoing
+     * with vision.
+     *
+     * @param cameraIndex The index of the camera to use.
+     * @param tagId The tag to check.
+     * @return The X angle to the specified target.
+     */
+    public Optional<Rotation2d> getTargetX(int cameraIndex, int tagId) {
+        return getTargetObservation(cameraIndex, tagId)
+                .map(AprilTagVisionIO.TargetObservation::tx);
+    }
 
     /**
      * Returns the ID of the best target.
@@ -107,19 +120,6 @@ public class AprilTagVisionSubsystem extends SubsystemBase implements DataFrameR
             return Optional.empty();
         }
         return Optional.of(id);
-    }
-
-    /**
-     * Returns the X angle to the specified target, which can be used for simple servoing
-     * with vision.
-     *
-     * @param cameraIndex The index of the camera to use.
-     * @param tagId The tag to check.
-     * @return The X angle to the specified target.
-     */
-    public Optional<Rotation2d> getTargetX(int cameraIndex, int tagId) {
-        return getTargetObservation(cameraIndex, tagId)
-                .map(AprilTagVisionIO.TargetObservation::tx);
     }
 
     /**

--- a/src/main/java/xbot/common/subsystems/vision/AprilTagVisionSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/vision/AprilTagVisionSubsystem.java
@@ -26,9 +26,11 @@ import xbot.common.properties.PropertyFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -91,6 +93,46 @@ public class AprilTagVisionSubsystem extends SubsystemBase implements DataFrameR
      */
     public Rotation2d getTargetX(int cameraIndex) {
         return cameraHelpers[cameraIndex].inputs.latestTargetObservation.tx();
+    }
+
+    /**
+     * Returns the ID of the best target.
+     *
+     * @param cameraIndex The index of the camera to use.
+     * @return The ID of the best target.
+     */
+    public Optional<Integer> getBestTargetId(int cameraIndex) {
+        var id = cameraHelpers[cameraIndex].inputs.latestTargetObservation.fiducialId();
+        if (id == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(id);
+    }
+
+    /**
+     * Returns the X angle to the specified target, which can be used for simple servoing
+     * with vision.
+     *
+     * @param cameraIndex The index of the camera to use.
+     * @param tagId The tag to check.
+     * @return The X angle to the specified target.
+     */
+    public Optional<Rotation2d> getTargetX(int cameraIndex, int tagId) {
+        return getTargetObservation(cameraIndex, tagId)
+                .map(AprilTagVisionIO.TargetObservation::tx);
+    }
+
+    /**
+     * Returns the raw observation data for the specified target.
+     *
+     * @param cameraIndex The index of the camera to use.
+     * @param tagId The tag to check.
+     * @return The raw observation data for the specified target.
+     */
+    public Optional<AprilTagVisionIO.TargetObservation> getTargetObservation(int cameraIndex, int tagId) {
+        return Arrays.stream(cameraHelpers[cameraIndex].inputs.targetObservations)
+                .filter(t -> t.fiducialId() == tagId)
+                .findFirst();
     }
 
     /**

--- a/src/main/java/xbot/common/subsystems/vision/MockAprilTagVisionIO.java
+++ b/src/main/java/xbot/common/subsystems/vision/MockAprilTagVisionIO.java
@@ -19,7 +19,8 @@ public class MockAprilTagVisionIO implements AprilTagVisionIO {
     public boolean connected = true;
     public int[] tagIds = {};
     public PoseObservation[] poseObservations = {};
-    public TargetObservation latestTargetObservation = new TargetObservation(1, new Rotation2d(), new Rotation2d(), new Transform3d());
+    public TargetObservation latestTargetObservation = new TargetObservation(1, new Rotation2d(), new Rotation2d(), new Transform3d(), 1);
+    public TargetObservation[] targetObservations = { latestTargetObservation };
 
     @AssistedFactory
     public abstract static class FactoryImpl implements AprilTagVisionIOFactory {
@@ -38,5 +39,6 @@ public class MockAprilTagVisionIO implements AprilTagVisionIO {
         inputs.tagIds = this.tagIds;
         inputs.poseObservations = this.poseObservations;
         inputs.latestTargetObservation = this.latestTargetObservation;
+        inputs.targetObservations = this.targetObservations;
     }
 }

--- a/src/test/java/xbot/common/subsystems/vision/AprilTagVisionSubsystemTest.java
+++ b/src/test/java/xbot/common/subsystems/vision/AprilTagVisionSubsystemTest.java
@@ -1,7 +1,9 @@
 package xbot.common.subsystems.vision;
 
 import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import org.junit.Test;
 import xbot.common.injection.BaseCommonLibTest;
@@ -51,5 +53,29 @@ public class AprilTagVisionSubsystemTest extends BaseCommonLibTest {
         subsystem.periodic();
 
         assertEquals(0, subsystem.getAllPoseObservations().size());
+    }
+
+    @Test
+    public void testHandleTargetObservations() {
+        var subsystem = this.getInjectorComponent().getAprilTagVisionSubsystem();
+
+        var io = (MockAprilTagVisionIO)subsystem.io[0];
+        io.latestTargetObservation = new AprilTagVisionIO.TargetObservation(1, new Rotation2d(), new Rotation2d(), new Transform3d(), 0.2);
+        io.targetObservations = new AprilTagVisionIO.TargetObservation[] {
+                new AprilTagVisionIO.TargetObservation(1, new Rotation2d(), new Rotation2d(), new Transform3d(), 0.2),
+                new AprilTagVisionIO.TargetObservation(2, new Rotation2d(), new Rotation2d(), new Transform3d(), 0.2),
+                new AprilTagVisionIO.TargetObservation(3, new Rotation2d(), new Rotation2d(), new Transform3d(), 0.2)
+        };
+        io.tagIds = new int[] {1, 2, 3};
+        subsystem.refreshDataFrame();
+        subsystem.periodic();
+
+        assertEquals(1, subsystem.getBestTargetId(0).get().intValue());
+        assertTrue(subsystem.tagVisibleByAnyCamera(1));
+        assertFalse(subsystem.tagVisibleByAnyCamera(5));
+        assertEquals(Set.of(0), subsystem.camerasWithTagVisible(1));
+        assertEquals(0, subsystem.getTargetX(0, 2).get().getDegrees(), 0.001);
+        assertTrue(subsystem.getTargetObservation(0, 2).isPresent());
+        assertFalse(subsystem.getTargetObservation(0, 5).isPresent());
     }
 }


### PR DESCRIPTION
# Why are we doing this?

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
