### PR TITLE
if pid props aren't provided, use null not an empty set 

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -77,7 +77,7 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
                 String owningSystemPrefix,
                 String pidPropertyPrefix
         ) {
-            return create(info, owningSystemPrefix, pidPropertyPrefix, new XCANMotorControllerPIDProperties());
+            return create(info, owningSystemPrefix, pidPropertyPrefix, null);
         }
     }
 


### PR DESCRIPTION

# Why are we doing this?

We had existing logic that looked for null properties to decide if it should create all the PID properties in NetworkTables. With the current setup we always made them even for motors that didn't care about PID.

Tested in sim


# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
