### PR TITLE
Add dynamic factory for XGyro

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/XGyro.java
+++ b/src/main/java/xbot/common/controls/sensors/XGyro.java
@@ -6,7 +6,6 @@ import org.littletonrobotics.junction.Logger;
 import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.io_inputs.XGyroIoInputs;
 import xbot.common.controls.io_inputs.XGyroIoInputsAutoLogged;
-import xbot.common.injection.electrical_contract.CANBusId;
 import xbot.common.injection.electrical_contract.IMUInfo;
 import xbot.common.math.WrappedRotation2d;
 
@@ -25,22 +24,24 @@ public abstract class XGyro implements DataFrameRefreshable, AutoCloseable
         pigeon2
     }
 
-    protected ImuType imuType;
+    protected final ImuType imuType;
+    protected final String deviceName;
 
-    protected XGyroIoInputsAutoLogged io;
+    protected final XGyroIoInputsAutoLogged io;
 
     public abstract static class XGyroFactory {
         public abstract XGyro create(IMUInfo imuInfo);
 
         public XGyro create() {
-            return create(new IMUInfo(InterfaceType.spi, CANBusId.DefaultCanivore, 1));
+            return create(new IMUInfo(InterfaceType.spi));
         }
     }
 
-    protected XGyro(ImuType imuType)
+    protected XGyro(IMUInfo info)
     {
-        this.imuType = imuType;
-        io = new XGyroIoInputsAutoLogged();
+        this.imuType = info.imuType();
+        this.deviceName = info.name();
+        this.io = new XGyroIoInputsAutoLogged();
     }
 
     public abstract boolean isBroken();
@@ -169,7 +170,6 @@ public abstract class XGyro implements DataFrameRefreshable, AutoCloseable
 
     public void refreshDataFrame() {
         updateInputs(io);
-        // TODO: get a name for the gyro so we don't have to use a hardcoded one.
-        Logger.processInputs("IMU", io);
+        Logger.processInputs(this.deviceName, io);
     }
 }

--- a/src/main/java/xbot/common/controls/sensors/XGyroFactoryImpl.java
+++ b/src/main/java/xbot/common/controls/sensors/XGyroFactoryImpl.java
@@ -1,0 +1,33 @@
+package xbot.common.controls.sensors;
+
+import xbot.common.controls.sensors.wpi_adapters.InertialMeasurementUnitAdapter;
+import xbot.common.controls.sensors.wpi_adapters.Pigeon2Adapter;
+import xbot.common.injection.electrical_contract.IMUInfo;
+
+import javax.inject.Inject;
+
+public class XGyroFactoryImpl extends XGyro.XGyroFactory {
+    private final Pigeon2Adapter.Pigeon2AdapterFactory pigeon2Factory;
+    private final InertialMeasurementUnitAdapter.InertialMeasurementUnitAdapterFactory navXFactory;
+
+    @Inject
+    public XGyroFactoryImpl(
+            Pigeon2Adapter.Pigeon2AdapterFactory pigeon2Factory,
+            InertialMeasurementUnitAdapter.InertialMeasurementUnitAdapterFactory navXFactory
+    ) {
+        this.pigeon2Factory = pigeon2Factory;
+        this.navXFactory = navXFactory;
+    }
+
+    @Override
+    public XGyro create(IMUInfo imuInfo) {
+        switch (imuInfo.imuType()) {
+            case pigeon2 -> {
+                return pigeon2Factory.create(imuInfo);
+            }
+            default -> {
+                return navXFactory.create(imuInfo);
+            }
+        }
+    }
+}

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockGyro.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockGyro.java
@@ -36,8 +36,8 @@ public class MockGyro extends XGyro implements ISimulatableSensor {
 
     @AssistedInject
     public MockGyro(DevicePolice police, @Assisted IMUInfo imuInfo) {
-        super(ImuType.mock);
-        police.registerDevice(DeviceType.IMU, 1, this);
+        super(IMUInfo.createMock(imuInfo));
+        police.registerDevice(DeviceType.IMU, imuInfo.deviceId(), this);
     }
 
     public boolean isConnected() {

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/InertialMeasurementUnitAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/InertialMeasurementUnitAdapter.java
@@ -29,7 +29,7 @@ public class InertialMeasurementUnitAdapter extends XGyro {
 
     @AssistedInject
     public InertialMeasurementUnitAdapter(DevicePolice police, @Assisted IMUInfo imuInfo) {
-        super(ImuType.navX);
+        super(imuInfo);
         /* Options: Port.kMXP, SPI.kMXP, I2C.kMXP or SerialPort.kUSB */
         try {
             switch (imuInfo.interfaceType()) {

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/Pigeon2Adapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/Pigeon2Adapter.java
@@ -27,7 +27,7 @@ public class Pigeon2Adapter extends XGyro {
 
     @AssistedInject
     public Pigeon2Adapter(DevicePolice police, @Assisted IMUInfo imuInfo) {
-        super(ImuType.pigeon2);
+        super(imuInfo);
         this.pigeon = new Pigeon2(imuInfo.deviceId(), imuInfo.canBusId().id());
         police.registerDevice(DevicePolice.DeviceType.CAN, imuInfo.canBusId(), imuInfo.deviceId(), this);
     }

--- a/src/main/java/xbot/common/injection/electrical_contract/IMUInfo.java
+++ b/src/main/java/xbot/common/injection/electrical_contract/IMUInfo.java
@@ -1,14 +1,17 @@
 package xbot.common.injection.electrical_contract;
 
-import com.ctre.phoenix6.CANBus;
 import xbot.common.controls.sensors.XGyro;
 
-public record IMUInfo(XGyro.InterfaceType interfaceType, CANBusId canBusId, int deviceId) {
+public record IMUInfo(String name, XGyro.ImuType imuType, XGyro.InterfaceType interfaceType, CANBusId canBusId, int deviceId) {
     public IMUInfo(XGyro.InterfaceType interfaceType) {
-        this(interfaceType, null, 0);
+        this("IMU", XGyro.ImuType.navX, interfaceType, null, 0);
     }
 
     public IMUInfo(CANBusId canBusId, int deviceId) {
-        this(null, canBusId, deviceId);
+        this("IMU", XGyro.ImuType.pigeon2, null, canBusId, deviceId);
+    }
+
+    public static IMUInfo createMock(IMUInfo realInstance) {
+        return new IMUInfo(realInstance.name(), XGyro.ImuType.mock, realInstance.interfaceType(), realInstance.canBusId(), realInstance.deviceId());
     }
 }

--- a/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
+++ b/src/main/java/xbot/common/injection/modules/RealDevicesModule.java
@@ -27,6 +27,7 @@ import xbot.common.controls.sensors.XDigitalInput.XDigitalInputFactory;
 import xbot.common.controls.sensors.XDutyCycleEncoder;
 import xbot.common.controls.sensors.XEncoder.XEncoderFactory;
 import xbot.common.controls.sensors.XGyro.XGyroFactory;
+import xbot.common.controls.sensors.XGyroFactoryImpl;
 import xbot.common.controls.sensors.XLaserCAN;
 import xbot.common.controls.sensors.XLidarLite.XLidarLiteFactory;
 import xbot.common.controls.sensors.XPowerDistributionPanel.XPowerDistributionPanelFactory;
@@ -75,7 +76,7 @@ public abstract class RealDevicesModule {
 
     @Binds
     @Singleton
-    public abstract XGyroFactory getGyroFactory(InertialMeasurementUnitAdapterFactory impl);
+    public abstract XGyroFactory getGyroFactory(XGyroFactoryImpl impl);
 
     @Binds
     @Singleton

--- a/src/test/java/xbot/common/simulation/SimulatedIMUTest.java
+++ b/src/test/java/xbot/common/simulation/SimulatedIMUTest.java
@@ -21,7 +21,7 @@ public class SimulatedIMUTest extends BaseSimulationTest {
     public void setUp() {
         super.setUp();
 
-        simulatedGyro = (MockGyro)injectorComponent.gyroFactory().create(new IMUInfo(XGyro.InterfaceType.serial, null, 1));
+        simulatedGyro = (MockGyro)injectorComponent.gyroFactory().create(new IMUInfo(XGyro.InterfaceType.serial));
     }
 
     @Test


### PR DESCRIPTION
# Why are we doing this?
Without this, it's impossible to be able to construct more than one kind of Gyro at a time easily.

# Whats changing?
Add a dynamic factory for XGyro, add the ability to change the name of the Gyro properties.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] tested on simulator
