### PR TITLE
Revert "Revert "Add is running Alerts to BaseCommand and CommandGroups""

### DIFF
--- a/src/main/java/xbot/common/command/BaseCommand.java
+++ b/src/main/java/xbot/common/command/BaseCommand.java
@@ -2,6 +2,7 @@ package xbot.common.command;
 
 import javax.inject.Inject;
 
+import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj2.command.Command;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -16,6 +17,7 @@ import xbot.common.properties.IPropertySupport;
  */
 public abstract class BaseCommand extends Command implements IPropertySupport {
 
+    protected final Alert runningAlert;
     protected final Logger log;
     protected final AKitLogger aKitLog;
     protected final TimeLogger monitor;
@@ -28,6 +30,7 @@ public abstract class BaseCommand extends Command implements IPropertySupport {
         log = LogManager.getLogger(this.getName());
         aKitLog = new AKitLogger(this);
         monitor = new TimeLogger(this.getName(), 20);
+        runningAlert = new Alert("Commands", this.getName(), Alert.AlertType.kInfo);
     }
 
     @Override
@@ -44,7 +47,16 @@ public abstract class BaseCommand extends Command implements IPropertySupport {
     }
 
     @Override
-    public abstract void initialize();
+    public void initialize() {
+        // the name might not be set at construction, so let's update it here
+        this.runningAlert.setText(this.getName());
+        this.runningAlert.set(true);
+    }
+
+    @Override
+    public void end(boolean isInterrupted) {
+        this.runningAlert.set(false);
+    }
 
     public void includeOnSmartDashboard() {
         if (commandPutter != null) {

--- a/src/main/java/xbot/common/command/BaseParallelCommandGroup.java
+++ b/src/main/java/xbot/common/command/BaseParallelCommandGroup.java
@@ -1,0 +1,120 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+
+package xbot.common.command;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+
+/**
+ * A command composition that runs a set of commands in parallel, ending when the last command ends.
+ *
+ * <p>The rules for command compositions apply: command instances that are passed to it cannot be
+ * added to any other composition or scheduled individually, and the composition requires all
+ * subsystems its components require.
+ *
+ * <p>This class is provided by the NewCommands VendorDep
+ */
+public class BaseParallelCommandGroup extends Command {
+  // maps commands in this composition to whether they are still running
+  // LinkedHashMap guarantees we iterate over commands in the order they were added (Note that
+  // changing the value associated with a command does NOT change the order)
+  private final Map<Command, Boolean> m_commands = new LinkedHashMap<>();
+  private boolean m_runWhenDisabled = true;
+  private InterruptionBehavior m_interruptBehavior = InterruptionBehavior.kCancelIncoming;
+
+  /**
+   * Creates a new ParallelCommandGroup. The given commands will be executed simultaneously. The
+   * command composition will finish when the last command finishes. If the composition is
+   * interrupted, only the commands that are still running will be interrupted.
+   *
+   * @param commands the commands to include in this composition.
+   */
+  @SuppressWarnings("this-escape")
+  public BaseParallelCommandGroup(Command... commands) {
+    addCommands(commands);
+  }
+
+  /**
+   * Adds the given commands to the group.
+   *
+   * @param commands Commands to add to the group.
+   */
+  public final void addCommands(Command... commands) {
+    if (m_commands.containsValue(true)) {
+      throw new IllegalStateException(
+          "Commands cannot be added to a composition while it's running");
+    }
+
+    CommandScheduler.getInstance().registerComposedCommands(commands);
+
+    for (Command command : commands) {
+      if (!Collections.disjoint(command.getRequirements(), getRequirements())) {
+        throw new IllegalArgumentException(
+            "Multiple commands in a parallel composition cannot require the same subsystems");
+      }
+      m_commands.put(command, false);
+      addRequirements(command.getRequirements());
+      m_runWhenDisabled &= command.runsWhenDisabled();
+      if (command.getInterruptionBehavior() == InterruptionBehavior.kCancelSelf) {
+        m_interruptBehavior = InterruptionBehavior.kCancelSelf;
+      }
+    }
+  }
+
+  @Override
+  public final void initialize() {
+    super.initialize();
+    for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
+      commandRunning.getKey().initialize();
+      commandRunning.setValue(true);
+    }
+  }
+
+  @Override
+  public final void execute() {
+    for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
+      if (!commandRunning.getValue()) {
+        continue;
+      }
+      commandRunning.getKey().execute();
+      if (commandRunning.getKey().isFinished()) {
+        commandRunning.getKey().end(false);
+        commandRunning.setValue(false);
+      }
+    }
+  }
+
+  @Override
+  public final void end(boolean interrupted) {
+    super.end(interrupted);
+    if (interrupted) {
+      for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
+        if (commandRunning.getValue()) {
+          commandRunning.getKey().end(true);
+        }
+      }
+    }
+  }
+
+  @Override
+  public final boolean isFinished() {
+    return !m_commands.containsValue(true);
+  }
+
+  @Override
+  public boolean runsWhenDisabled() {
+    return m_runWhenDisabled;
+  }
+
+  @Override
+  public InterruptionBehavior getInterruptionBehavior() {
+    return m_interruptBehavior;
+  }
+}

--- a/src/main/java/xbot/common/command/BaseParallelDeadlineGroup.java
+++ b/src/main/java/xbot/common/command/BaseParallelDeadlineGroup.java
@@ -1,0 +1,158 @@
+package xbot.common.command;
+
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A command composition that runs a set of commands in parallel, ending only when a specific
+ * command (the "deadline") ends, interrupting all other commands that are still running at that
+ * point.
+ *
+ * <p>The rules for command compositions apply: command instances that are passed to it cannot be
+ * added to any other composition or scheduled individually, and the composition requires all
+ * subsystems its components require.
+ *
+ * <p>This class is provided by the NewCommands VendorDep
+ */
+public class BaseParallelDeadlineGroup extends Command {
+  // maps commands in this composition to whether they are still running
+  // LinkedHashMap guarantees we iterate over commands in the order they were added (Note that
+  // changing the value associated with a command does NOT change the order)
+  private final Map<Command, Boolean> m_commands = new LinkedHashMap<>();
+  private boolean m_runWhenDisabled = true;
+  private boolean m_finished = true;
+  private Command m_deadline;
+  private InterruptionBehavior m_interruptBehavior = InterruptionBehavior.kCancelIncoming;
+
+  /**
+   * Creates a new ParallelDeadlineGroup. The given commands, including the deadline, will be
+   * executed simultaneously. The composition will finish when the deadline finishes, interrupting
+   * all other still-running commands. If the composition is interrupted, only the commands still
+   * running will be interrupted.
+   *
+   * @param deadline the command that determines when the composition ends
+   * @param otherCommands the other commands to be executed
+   * @throws IllegalArgumentException if the deadline command is also in the otherCommands argument
+   */
+  @SuppressWarnings("this-escape")
+  public BaseParallelDeadlineGroup(Command deadline, Command... otherCommands) {
+    setDeadline(deadline);
+    addCommands(otherCommands);
+  }
+
+  /**
+   * Sets the deadline to the given command. The deadline is added to the group if it is not already
+   * contained.
+   *
+   * @param deadline the command that determines when the group ends
+   * @throws IllegalArgumentException if the deadline command is already in the composition
+   */
+  public final void setDeadline(Command deadline) {
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    boolean isAlreadyDeadline = deadline == m_deadline;
+    if (isAlreadyDeadline) {
+      return;
+    }
+    if (m_commands.containsKey(deadline)) {
+      throw new IllegalArgumentException(
+          "The deadline command cannot also be in the other commands!");
+    }
+    addCommands(deadline);
+    m_deadline = deadline;
+  }
+
+  /**
+   * Adds the given commands to the group.
+   *
+   * @param commands Commands to add to the group.
+   */
+  public final void addCommands(Command... commands) {
+    if (!m_finished) {
+      throw new IllegalStateException(
+          "Commands cannot be added to a composition while it's running");
+    }
+
+    CommandScheduler.getInstance().registerComposedCommands(commands);
+
+    for (Command command : commands) {
+      if (!Collections.disjoint(command.getRequirements(), getRequirements())) {
+        throw new IllegalArgumentException(
+            "Multiple commands in a parallel group cannot require the same subsystems");
+      }
+      m_commands.put(command, false);
+      addRequirements(command.getRequirements());
+      m_runWhenDisabled &= command.runsWhenDisabled();
+      if (command.getInterruptionBehavior() == InterruptionBehavior.kCancelSelf) {
+        m_interruptBehavior = InterruptionBehavior.kCancelSelf;
+      }
+    }
+  }
+
+  @Override
+  public final void initialize() {
+    super.initialize();
+    for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
+      commandRunning.getKey().initialize();
+      commandRunning.setValue(true);
+    }
+    m_finished = false;
+  }
+
+  @Override
+  public final void execute() {
+    for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
+      if (!commandRunning.getValue()) {
+        continue;
+      }
+      commandRunning.getKey().execute();
+      if (commandRunning.getKey().isFinished()) {
+        commandRunning.getKey().end(false);
+        commandRunning.setValue(false);
+        if (commandRunning.getKey().equals(m_deadline)) {
+          m_finished = true;
+        }
+      }
+    }
+  }
+
+  @Override
+  public final void end(boolean interrupted) {
+    super.end(interrupted);
+    for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
+      if (commandRunning.getValue()) {
+        commandRunning.getKey().end(true);
+      }
+    }
+  }
+
+  @Override
+  public final boolean isFinished() {
+    return m_finished;
+  }
+
+  @Override
+  public boolean runsWhenDisabled() {
+    return m_runWhenDisabled;
+  }
+
+  @Override
+  public InterruptionBehavior getInterruptionBehavior() {
+    return m_interruptBehavior;
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    super.initSendable(builder);
+
+    builder.addStringProperty("deadline", m_deadline::getName, null);
+  }
+}

--- a/src/main/java/xbot/common/command/BaseSequentialCommandGroup.java
+++ b/src/main/java/xbot/common/command/BaseSequentialCommandGroup.java
@@ -1,0 +1,130 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package xbot.common.command;
+
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A command composition that runs a list of commands in sequence.
+ *
+ * <p>The rules for command compositions apply: command instances that are passed to it cannot be
+ * added to any other composition or scheduled individually, and the composition requires all
+ * subsystems its components require.
+ *
+ * <p>This class is provided by the NewCommands VendorDep
+ */
+public class BaseSequentialCommandGroup extends BaseCommand {
+  private final List<Command> m_commands = new ArrayList<>();
+  private int m_currentCommandIndex = -1;
+  private boolean m_runWhenDisabled = true;
+  private InterruptionBehavior m_interruptBehavior = InterruptionBehavior.kCancelIncoming;
+
+  /**
+   * Creates a new SequentialCommandGroup. The given commands will be run sequentially, with the
+   * composition finishing when the last command finishes.
+   *
+   * @param commands the commands to include in this composition.
+   */
+  @SuppressWarnings("this-escape")
+  public BaseSequentialCommandGroup(Command... commands) {
+    addCommands(commands);
+  }
+
+  public BaseSequentialCommandGroup(String name, Command... commands) {
+    this.setName(name);
+    addCommands(commands);
+  }
+
+  /**
+   * Adds the given commands to the group.
+   *
+   * @param commands Commands to add, in order of execution.
+   */
+  @SuppressWarnings("PMD.UseArraysAsList")
+  public final void addCommands(Command... commands) {
+    if (m_currentCommandIndex != -1) {
+      throw new IllegalStateException(
+          "Commands cannot be added to a composition while it's running");
+    }
+
+    CommandScheduler.getInstance().registerComposedCommands(commands);
+
+    for (Command command : commands) {
+      m_commands.add(command);
+      addRequirements(command.getRequirements());
+      m_runWhenDisabled &= command.runsWhenDisabled();
+      if (command.getInterruptionBehavior() == InterruptionBehavior.kCancelSelf) {
+        m_interruptBehavior = InterruptionBehavior.kCancelSelf;
+      }
+    }
+  }
+
+  @Override
+  public final void initialize() {
+    super.initialize();
+    m_currentCommandIndex = 0;
+
+    if (!m_commands.isEmpty()) {
+      m_commands.get(0).initialize();
+    }
+  }
+
+  @Override
+  public final void execute() {
+    if (m_commands.isEmpty()) {
+      return;
+    }
+
+    Command currentCommand = m_commands.get(m_currentCommandIndex);
+
+    currentCommand.execute();
+    if (currentCommand.isFinished()) {
+      currentCommand.end(false);
+      m_currentCommandIndex++;
+      if (m_currentCommandIndex < m_commands.size()) {
+        m_commands.get(m_currentCommandIndex).initialize();
+      }
+    }
+  }
+
+  @Override
+  public final void end(boolean interrupted) {
+    super.end(interrupted);
+    if (interrupted
+        && !m_commands.isEmpty()
+        && m_currentCommandIndex > -1
+        && m_currentCommandIndex < m_commands.size()) {
+      m_commands.get(m_currentCommandIndex).end(true);
+    }
+    m_currentCommandIndex = -1;
+  }
+
+  @Override
+  public final boolean isFinished() {
+    return m_currentCommandIndex == m_commands.size();
+  }
+
+  @Override
+  public boolean runsWhenDisabled() {
+    return m_runWhenDisabled;
+  }
+
+  @Override
+  public InterruptionBehavior getInterruptionBehavior() {
+    return m_interruptBehavior;
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    super.initSendable(builder);
+
+    builder.addIntegerProperty("index", () -> m_currentCommandIndex, null);
+  }
+}


### PR DESCRIPTION
Reverts Team488/SeriouslyCommonLib#581

Turns out the Scheduler approach we were hoping could replace this doesn't work for stuff inside command groups (one of the main things we care about), so we still might want this way