### PR TITLE
Fix XCANMotorController implementations not properly following AKit c…

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -8,7 +8,6 @@ import edu.wpi.first.units.AngularAccelerationUnit;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Frequency;
 import edu.wpi.first.units.measure.MutAngle;
 import edu.wpi.first.units.measure.MutAngularVelocity;
@@ -28,7 +27,6 @@ import xbot.common.resiliency.DeviceHealth;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RPM;
-import static edu.wpi.first.units.Units.Volt;
 import static edu.wpi.first.units.Units.Volts;
 import static edu.wpi.first.units.Units.Rotations;
 
@@ -145,8 +143,7 @@ public class MockCANMotorController extends XCANMotorController {
         this.maxPower = maxPower;
     }
 
-    @Override
-    public Angle getRawPosition() {
+    public Angle getRawPosition_internal() {
         return this.position.copy();
     }
 
@@ -169,8 +166,7 @@ public class MockCANMotorController extends XCANMotorController {
         return targetPosition.copy();
     }
 
-    @Override
-    public AngularVelocity getRawVelocity() {
+    public AngularVelocity getRawVelocity_internal() {
         return velocity.copy();
     }
 
@@ -222,8 +218,8 @@ public class MockCANMotorController extends XCANMotorController {
 
     @Override
     protected void updateInputs(XCANMotorControllerInputs inputs) {
-        inputs.angle = getPosition();
-        inputs.angularVelocity = getVelocity();
+        inputs.angle = getRawPosition_internal();
+        inputs.angularVelocity = getRawVelocity_internal();
         inputs.voltage = voltage;
         inputs.current = current;
     }

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -182,8 +182,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
                 SparkBase.PersistMode.kNoPersistParameters);
     }
 
-    @Override
-    public Angle getRawPosition() {
+    public Angle getRawPosition_internal() {
         return Rotations.of(this.internalSparkMax.getEncoder().getPosition());
     }
 
@@ -208,8 +207,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
                 .setReference(rawPosition.in(Rotations), controlType, getClosedLoopSlot(slot));
     }
 
-    @Override
-    public AngularVelocity getRawVelocity() {
+    public AngularVelocity getRawVelocity_internal() {
         return RPM.of(this.internalSparkMax.getEncoder().getVelocity());
     }
 
@@ -250,7 +248,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
         };
     }
 
-    public Voltage getVoltage() {
+    public Voltage getVoltage_internal() {
         return Volts.of(
                 this.internalSparkMax.getAppliedOutput() * internalSparkMax.getBusVoltage());
     }
@@ -260,7 +258,7 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
         log.warn("setVoltageRange: Voltage range is not supported by SparkMax");
     }
 
-    public Current getCurrent() {
+    private Current getCurrent_internal() {
         return Amps.of(this.internalSparkMax.getOutputCurrent());
     }
 
@@ -270,10 +268,10 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     protected void updateInputs(XCANMotorControllerInputs inputs) {
-        inputs.angle = getPosition();
-        inputs.angularVelocity = getVelocity();
-        inputs.voltage = getVoltage();
-        inputs.current = getCurrent();
+        inputs.angle = getRawPosition_internal();
+        inputs.angularVelocity = getRawVelocity_internal();
+        inputs.voltage = getVoltage_internal();
+        inputs.current = getCurrent_internal();
     }
 
     @Override

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -249,8 +249,7 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         invokeWithRetry(() -> this.internalTalonFx.getConfigurator().apply(talonConfiguration.MotorOutput), 3);
     }
 
-    @Override
-    public Angle getRawPosition() {
+    public Angle getRawPosition_internal() {
         rotorPositionSignal.refresh(false);
         return rotorPositionSignal.getValue();
     }
@@ -275,8 +274,7 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         invokeWithRetry(() -> this.internalTalonFx.setControl(controlRequest), 1);
     }
 
-    @Override
-    public AngularVelocity getRawVelocity() {
+    public AngularVelocity getRawVelocity_internal() {
         rotorVelocitySignal.refresh(false);
         return rotorVelocitySignal.getValue();
     }
@@ -304,7 +302,7 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         invokeWithRetry(() -> this.internalTalonFx.setControl(new VoltageOut(voltage)), 1);
     }
 
-    public Voltage getVoltage() {
+    private Voltage getVoltage_internal() {
         motorVoltageSignal.refresh(false);
         return motorVoltageSignal.getValue();
     }
@@ -321,7 +319,7 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         invokeWithRetry(() -> this.internalTalonFx.getConfigurator().apply(this.talonConfiguration.Voltage), 3);
     }
 
-    public Current getCurrent() {
+    private Current getCurrent_internal() {
         statorCurrentSignal.refresh(false);
         return statorCurrentSignal.getValue();
     }
@@ -336,10 +334,10 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     protected void updateInputs(XCANMotorControllerInputs inputs) {
-        inputs.angle = getPosition();
-        inputs.angularVelocity = getVelocity();
-        inputs.voltage = getVoltage();
-        inputs.current = getCurrent();
+        inputs.angle = getRawPosition_internal();
+        inputs.angularVelocity = getRawVelocity_internal();
+        inputs.voltage = getVoltage_internal();
+        inputs.current = getCurrent_internal();
     }
 
     private boolean invokeWithRetry(Supplier<StatusCode> applyFunction, int retryCount) {

--- a/src/main/java/xbot/common/controls/io_inputs/XCANMotorControllerInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/XCANMotorControllerInputs.java
@@ -6,10 +6,15 @@ import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.Volts;
+
 @AutoLog
 public class XCANMotorControllerInputs {
-    public Angle angle;
-    public AngularVelocity angularVelocity;
-    public Voltage voltage;
-    public Current current;
+    public Angle angle = Rotations.zero();
+    public AngularVelocity angularVelocity = RPM.zero();
+    public Voltage voltage = Volts.zero();
+    public Current current = Amps.zero();
 }

--- a/src/main/java/xbot/common/subsystems/pose/MockBasePoseSubsystem.java
+++ b/src/main/java/xbot/common/subsystems/pose/MockBasePoseSubsystem.java
@@ -39,11 +39,19 @@ public class MockBasePoseSubsystem extends BasePoseSubsystem {
     public void setDriveEncoderDistances(int left, int right) {
         ((MockCANMotorController)this.left).setPosition(Rotations.of(left));
         ((MockCANMotorController)this.right).setPosition(Rotations.of(right));
+        refreshDataFrame();
         periodic();
     }
 
     public void forceTotalXandY(double x, double y) {
         totalDistanceX = x;
         totalDistanceY = y;
+    }
+
+    @Override
+    public void refreshDataFrame() {
+        super.refreshDataFrame();
+        left.refreshDataFrame();
+        right.refreshDataFrame();
     }
 }

--- a/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
+++ b/src/test/java/xbot/common/controls/actuators/CANMotorControllerTest.java
@@ -96,15 +96,20 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
         motor.setDistancePerMotorRotationsScaleFactor(Meters.per(Rotations).of(4));
 
         motor.setRawPosition(Rotations.of(1));
+        motor.refreshDataFrame();
 
         assertTrue(Meters.of(4).isNear(motor.getPositionAsDistance(), 0.001));
         assertTrue(Rotations.of(2).isNear(motor.getPosition(), 0.001));
 
         motor.setPosition(Rotations.of(1));
+        motor.refreshDataFrame();
+
         assertTrue(Meters.of(2).isNear(motor.getPositionAsDistance(), 0.001));
         assertTrue(Rotations.of(0.5).isNear(motor.getRawPosition(), 0.001));
 
         motor.setRawVelocity(RotationsPerSecond.of(1));
+        motor.refreshDataFrame();
+
         assertTrue(RotationsPerSecond.of(2).isNear(motor.getVelocity(), 0.001));
 
         motor.setVelocityTarget(RotationsPerSecond.of(1));
@@ -112,7 +117,10 @@ public class CANMotorControllerTest extends BaseCommonLibTest {
 
         motor.setAngleScaleFactor(null);
         assertTrue(motor.getPosition().isEquivalent(motor.getRawPosition()));
+
         motor.setPosition(Rotations.of(10));
+        motor.refreshDataFrame();
+
         assertTrue(motor.getPosition().isEquivalent(motor.getRawPosition()));
         assertTrue(Rotations.of(10).isNear(motor.getRawPosition(), 0.001));
         motor.setVelocityTarget(RotationsPerSecond.of(1));

--- a/src/test/java/xbot/common/subsystems/pose/commands/ResetDistanceCommandTest.java
+++ b/src/test/java/xbot/common/subsystems/pose/commands/ResetDistanceCommandTest.java
@@ -8,73 +8,73 @@ import xbot.common.subsystems.pose.BasePoseTest;
 public class ResetDistanceCommandTest extends BasePoseTest {
 
     ResetDistanceCommand reset;
-    
+
     @Before
     public void setup() {
         super.setup();
         reset = getInjectorComponent().resetDistanceCommand();
     }
-    
+
     @Test
     public void testPositionReset() {
         verifyRobotOrientedDistance(0);
         verifyAbsoluteDistance(0, 0);
-        
+
         pose.setDriveEncoderDistances(100, 100);
         verifyRobotOrientedDistance(100);
         verifyAbsoluteDistance(100, 0);
-        
+
         reset.isFinished();
         reset.initialize();
         reset.execute();
-        
+
         verifyRobotOrientedDistance(0);
         verifyAbsoluteDistance(0, 0);
     }
-    
+
     @Test
     public void testResetTwiceInSuccession() {
         verifyRobotOrientedDistance(0);
         verifyAbsoluteDistance(0, 0);
-        
+
         pose.setDriveEncoderDistances(100, 100);
         verifyRobotOrientedDistance(100);
         verifyAbsoluteDistance(100, 0);
-        
+
         reset.isFinished();
         reset.initialize();
         reset.execute();
         reset.isFinished();
         reset.initialize();
         reset.execute();
-        
+
         verifyRobotOrientedDistance(0);
         verifyAbsoluteDistance(0, 0);
     }
-    
+
     @Test
     public void testResetTwice() {
         verifyRobotOrientedDistance(0);
         verifyAbsoluteDistance(0, 0);
-        
+
         pose.setDriveEncoderDistances(100, 100);
         verifyRobotOrientedDistance(100);
         verifyAbsoluteDistance(100, 0);
-        
+
         reset.isFinished();
         reset.initialize();
         reset.execute();
-        
+
         pose.setDriveEncoderDistances(200, 200);
         verifyRobotOrientedDistance(100);
         verifyAbsoluteDistance(100, 0);
-        
+
         reset.isFinished();
         reset.initialize();
         reset.execute();
-        
+
         verifyRobotOrientedDistance(0);
         verifyAbsoluteDistance(0, 0);
     }
-    
+
 }


### PR DESCRIPTION
…onventions

# Why are we doing this?
Performance tracing indicated that we were spending a lot of time in SwerveModuleSubsystem.refreshDataFrome, but not in one of the child refreshDataFrame methods. This indicated that the calls to getPosition / getVelocity weren't using cached values!

# Whats changing?
Rewrite the motor controllers to always use the AKit cached inputs when reading state.
Note that as a result, when using mocks, this behaves more like a real robot where you need to refresh data frame before getting the new value back!

# Questions/notes for reviewers

# How this was tested
- [x] unit tests added
- [ ] tested on robot
