### PR TITLE
Corresponding SCL changes for reducing autonomous init time

### DIFF
--- a/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
+++ b/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,6 +23,7 @@ public class AutonomousCommandSelector extends BaseSubsystem {
     Supplier<Command> commandSupplier;
 
     Command currentAutonomousCommand;
+    Pose2d currentAutonomousStartingPosition;
     boolean isDefault;
 
     @Inject
@@ -38,8 +40,17 @@ public class AutonomousCommandSelector extends BaseSubsystem {
         return currentAutonomousCommand;
     }
 
+    public Pose2d getCurrentAutonomousStartingPosition(){
+        return currentAutonomousStartingPosition;
+    }
+
+    public void setCurrentAutonomousStartingPosition(Pose2d position){
+        this.currentAutonomousStartingPosition = position;
+    }
+
     public void setCurrentAutonomousCommand(Command currentAutonomousCommand) {
         log.info("Setting CurrentAutonomousCommand to " + currentAutonomousCommand);
+        log.info("Setting CurrentStartingPosition to " + currentAutonomousStartingPosition);
         aKitLog.record("Current autonomous command name",
                 currentAutonomousCommand == null ? "No command set" : currentAutonomousCommand.getName());
 
@@ -47,7 +58,7 @@ public class AutonomousCommandSelector extends BaseSubsystem {
         commandSupplier = null;
         isDefault = false;
     }
-    
+
     public void setCurrentAutonomousCommandSupplier(Supplier<Command> supplier) {
         commandSupplier = supplier;
         this.currentAutonomousCommand = null;

--- a/src/main/java/xbot/common/subsystems/autonomous/SetAutonomousCommand.java
+++ b/src/main/java/xbot/common/subsystems/autonomous/SetAutonomousCommand.java
@@ -21,6 +21,10 @@ public class SetAutonomousCommand extends BaseCommand {
         return true;
     }
 
+    public void setAutoCommand(Command autonomousCommand) {
+        setAutoCommand(autonomousCommand, new Pose2d());
+    }
+
     public void setAutoCommand(Command autonomousCommand, Pose2d startingPosition) {
         this.autonomousCommand = autonomousCommand;
         selector.setCurrentAutonomousStartingPosition(startingPosition);

--- a/src/main/java/xbot/common/subsystems/autonomous/SetAutonomousCommand.java
+++ b/src/main/java/xbot/common/subsystems/autonomous/SetAutonomousCommand.java
@@ -11,6 +11,8 @@ public class SetAutonomousCommand extends BaseCommand {
     private final AutonomousCommandSelector selector;
     private Command autonomousCommand;
 
+    private Pose2d autonomousStartingPosition;
+
     @Inject
     public SetAutonomousCommand(AutonomousCommandSelector selector) {
         this.selector = selector;
@@ -27,7 +29,7 @@ public class SetAutonomousCommand extends BaseCommand {
 
     public void setAutoCommand(Command autonomousCommand, Pose2d startingPosition) {
         this.autonomousCommand = autonomousCommand;
-        selector.setCurrentAutonomousStartingPosition(startingPosition);
+        this.autonomousStartingPosition = startingPosition;
     }
 
     @Override
@@ -35,6 +37,7 @@ public class SetAutonomousCommand extends BaseCommand {
         if (autonomousCommand != null) {
             log.info("Setting Auto to: " + autonomousCommand.getName());
             selector.setCurrentAutonomousCommand(autonomousCommand);
+            selector.setCurrentAutonomousStartingPosition(autonomousStartingPosition);
         } else {
             log.warn("No autonomous command configured. Not changing the current autonomous command.");
         }

--- a/src/main/java/xbot/common/subsystems/autonomous/SetAutonomousCommand.java
+++ b/src/main/java/xbot/common/subsystems/autonomous/SetAutonomousCommand.java
@@ -2,6 +2,7 @@ package xbot.common.subsystems.autonomous;
 
 import javax.inject.Inject;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import xbot.common.command.BaseCommand;
 
@@ -20,8 +21,9 @@ public class SetAutonomousCommand extends BaseCommand {
         return true;
     }
 
-    public void setAutoCommand(Command autonomousCommand) {
+    public void setAutoCommand(Command autonomousCommand, Pose2d startingPosition) {
         this.autonomousCommand = autonomousCommand;
+        selector.setCurrentAutonomousStartingPosition(startingPosition);
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?
Hopefully reducing auto init time by 40 ms by doing position initializing during auto init, these are just the SCL changes I need for my PR on Xbot2025
# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
