### PR TITLE
Combine status frame refreshes into single operation

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -1,5 +1,6 @@
 package xbot.common.controls.actuators.wpi_adapters;
 
+import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
@@ -250,7 +251,6 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     public Angle getRawPosition_internal() {
-        rotorPositionSignal.refresh(false);
         return rotorPositionSignal.getValue();
     }
 
@@ -275,7 +275,6 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     public AngularVelocity getRawVelocity_internal() {
-        rotorVelocitySignal.refresh(false);
         return rotorVelocitySignal.getValue();
     }
 
@@ -303,7 +302,6 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     private Voltage getVoltage_internal() {
-        motorVoltageSignal.refresh(false);
         return motorVoltageSignal.getValue();
     }
 
@@ -320,7 +318,6 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     private Current getCurrent_internal() {
-        statorCurrentSignal.refresh(false);
         return statorCurrentSignal.getValue();
     }
 
@@ -333,7 +330,17 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
         return this.talonConfiguration.MotorOutput.Inverted == InvertedValue.Clockwise_Positive;
     }
 
+    private void refreshAllSignals() {
+        BaseStatusSignal.refreshAll(
+            rotorPositionSignal,
+            rotorVelocitySignal,
+            motorVoltageSignal,
+            statorCurrentSignal
+        );
+    }
+
     protected void updateInputs(XCANMotorControllerInputs inputs) {
+        refreshAllSignals();
         inputs.angle = getRawPosition_internal();
         inputs.angularVelocity = getRawVelocity_internal();
         inputs.voltage = getVoltage_internal();

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/CANCoderAdapter.java
@@ -1,5 +1,6 @@
 package xbot.common.controls.sensors.wpi_adapters;
 
+import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
@@ -85,22 +86,18 @@ public class CANCoderAdapter extends XCANCoder {
     }
 
     public Angle getPosition_internal() {
-        positionSignal.refresh(false);
         return positionSignal.getValue();
     }
 
     public Angle getAbsolutePosition_internal() {
-        absolutePositionSignal.refresh(false);
         return absolutePositionSignal.getValue();
     }
 
     public AngularVelocity getVelocity_internal() {
-        velocitySignal.refresh(false);
         return velocitySignal.getValue();
     }
 
     public DeviceHealth getHealth_internal() {
-        versionSignal.refresh(false);
         if (versionSignal.getStatus().isError()) {
             return DeviceHealth.Unhealthy;
         }
@@ -174,8 +171,18 @@ public class CANCoderAdapter extends XCANCoder {
         return this.cancoder.getConfigurator().apply(toApply);
     }
 
+    private void refreshAllSignals() {
+        BaseStatusSignal.refreshAll(
+            this.versionSignal,
+            this.positionSignal,
+            this.absolutePositionSignal,
+            this.velocitySignal
+        );
+    }
+
     @Override
     public void updateInputs(XAbsoluteEncoderInputs inputs) {
+        refreshAllSignals();
         inputs.deviceHealth = this.getHealth_internal().toString();
         inputs.position = this.getPosition_internal();
         inputs.absolutePosition = this.getAbsolutePosition_internal();


### PR DESCRIPTION
# Why are we doing this?
Refreshing status signals from CTRE devices appears to be one of the most time consuming operations on the robot.

# Whats changing?
Use the BaseStatusSignal.refreshAll() capability to refresh signals, which is documented to be faster than refreshing each signal individually.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot

Blue line is before change, orange line is after change, measured in robot cycle time MS
![image](https://github.com/user-attachments/assets/cd8ad375-9bdf-473e-baf5-068f3a56e0be)
