### PR TITLE
Saqib/mock encoder add distance

### DIFF
--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
@@ -51,7 +51,7 @@ public class MockEncoder extends XEncoder implements ISimulatableSensor {
         this.rate = newRate;
     }
 
-    protected double getDistance() {
+    public double getDistance() {
         return distance;
     }
 

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
@@ -39,6 +39,10 @@ public class MockEncoder extends XEncoder implements ISimulatableSensor {
         this.distance = distance * (isInverted ? -1 : 1);
     }
 
+    public void addDistance(double distance) {
+        this.setDistance(this.getDistance() + distance);
+    }
+
     protected double getRate() {
         return rate;
     }

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
@@ -40,11 +40,7 @@ public class MockEncoder extends XEncoder implements ISimulatableSensor {
     }
 
     public void addDistance(double distance) {
-        System.out.printf("distance: %f");
-        System.out.printf("((isInverted ? -1 : 1) * this.getDistance()): %f", ((isInverted ? -1 : 1) * this.getDistance()));
-        var newDistance = ((isInverted ? -1 : 1) * this.getDistance()) + distance;
-        System.out.printf("newDistance: %f", newDistance);
-        this.setDistance(newDistance);
+        this.setDistance(((isInverted ? -1 : 1) * this.getDistance()) + distance);
     }
 
     protected double getRate() {

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
@@ -51,7 +51,7 @@ public class MockEncoder extends XEncoder implements ISimulatableSensor {
         this.rate = newRate;
     }
 
-    public double getDistance() {
+    protected double getDistance() {
         return distance;
     }
 

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockEncoder.java
@@ -20,17 +20,17 @@ public class MockEncoder extends XEncoder implements ISimulatableSensor {
     @AssistedFactory
     public abstract static class MockEncoderFactory implements XEncoderFactory {
         public abstract MockEncoder create(
-            @Assisted("name") String name,
-            @Assisted("aChannel") int aChannel,
-            @Assisted("bChannel") int bChannel,
-            @Assisted("defaultDistancePerPulse") double defaultDistancePerPulse,
-            @Assisted("owningSystemPrefix") String owningSystemPrefix);
+                @Assisted("name") String name,
+                @Assisted("aChannel") int aChannel,
+                @Assisted("bChannel") int bChannel,
+                @Assisted("defaultDistancePerPulse") double defaultDistancePerPulse,
+                @Assisted("owningSystemPrefix") String owningSystemPrefix);
     }
 
     @AssistedInject
     public MockEncoder(@Assisted("name") String name, @Assisted("aChannel") int aChannel,
             @Assisted("bChannel") int bChannel, @Assisted("defaultDistancePerPulse") double defaultDistancePerPulse,
-                       @Assisted("owningSystemPrefix") String owningSystemPrefix,
+            @Assisted("owningSystemPrefix") String owningSystemPrefix,
             PropertyFactory propMan, DevicePolice police) {
         super(name, aChannel, bChannel, defaultDistancePerPulse, owningSystemPrefix, propMan, police);
     }
@@ -40,7 +40,11 @@ public class MockEncoder extends XEncoder implements ISimulatableSensor {
     }
 
     public void addDistance(double distance) {
-        this.setDistance(this.getDistance() + distance);
+        System.out.printf("distance: %f");
+        System.out.printf("((isInverted ? -1 : 1) * this.getDistance()): %f", ((isInverted ? -1 : 1) * this.getDistance()));
+        var newDistance = ((isInverted ? -1 : 1) * this.getDistance()) + distance;
+        System.out.printf("newDistance: %f", newDistance);
+        this.setDistance(newDistance);
     }
 
     protected double getRate() {
@@ -60,7 +64,7 @@ public class MockEncoder extends XEncoder implements ISimulatableSensor {
 
     @Override
     public void ingestSimulationData(JSONObject payload) {
-        setDistance((double)payload.get("EncoderTicks"));
+        setDistance((double) payload.get("EncoderTicks"));
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?

Needed for: https://github.com/Team488/TeamXbot2025/pull/298

# Whats changing?
Just the ability to add distances to the Encoders without requiring the need to get the distance which is protected.
Editor autoformatted the file.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot

Used in simulation.
