### PR TITLE
Feature/lasercan filter invalid v2

### DIFF
--- a/src/main/java/xbot/common/controls/io_inputs/LaserCANInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/LaserCANInputs.java
@@ -1,9 +1,14 @@
 package xbot.common.controls.io_inputs;
 
 import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.Time;
 import org.littletonrobotics.junction.AutoLog;
+
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.Seconds;
 
 @AutoLog
 public class LaserCANInputs {
-    public Distance distance;
+    public Distance distance = Meters.zero();
+    public Time measurementLatency = Seconds.zero();
 }

--- a/src/main/java/xbot/common/controls/io_inputs/LaserCANInputs.java
+++ b/src/main/java/xbot/common/controls/io_inputs/LaserCANInputs.java
@@ -9,6 +9,7 @@ import static edu.wpi.first.units.Units.Seconds;
 
 @AutoLog
 public class LaserCANInputs {
+    public boolean isMeasurementValid = false;
     public Distance distance = Meters.zero();
     public Time measurementLatency = Seconds.zero();
 }

--- a/src/main/java/xbot/common/controls/sensors/XLaserCAN.java
+++ b/src/main/java/xbot/common/controls/sensors/XLaserCAN.java
@@ -1,6 +1,7 @@
 package xbot.common.controls.sensors;
 
 import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.Time;
 import org.littletonrobotics.junction.Logger;
 import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.controls.io_inputs.LaserCANInputs;
@@ -28,6 +29,10 @@ public abstract class XLaserCAN implements DataFrameRefreshable {
 
     public Distance getDistance() {
         return inputs.distance;
+    }
+
+    public Time getMeasurementLatency() {
+        return inputs.measurementLatency;
     }
 
     public abstract void updateInputs(LaserCANInputs inputs);

--- a/src/main/java/xbot/common/controls/sensors/XLaserCAN.java
+++ b/src/main/java/xbot/common/controls/sensors/XLaserCAN.java
@@ -10,6 +10,8 @@ import xbot.common.injection.DevicePolice;
 import xbot.common.injection.DevicePolice.DeviceType;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 
+import java.util.Optional;
+
 public abstract class XLaserCAN implements DataFrameRefreshable {
 
     final LaserCANInputsAutoLogged inputs;
@@ -27,8 +29,11 @@ public abstract class XLaserCAN implements DataFrameRefreshable {
         inputs = new LaserCANInputsAutoLogged();
     }
 
-    public Distance getDistance() {
-        return inputs.distance;
+    public Optional<Distance> getDistance() {
+        if (inputs.isMeasurementValid) {
+            return Optional.of(inputs.distance);
+        }
+        return Optional.empty();
     }
 
     public Time getMeasurementLatency() {

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockLaserCAN.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockLaserCAN.java
@@ -5,12 +5,16 @@ import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import xbot.common.controls.io_inputs.LaserCANInputs;
 import xbot.common.controls.sensors.XLaserCAN;
+import xbot.common.controls.sensors.XTimer;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.DeviceInfo;
+
+import static edu.wpi.first.units.Units.Seconds;
 
 public class MockLaserCAN extends XLaserCAN {
 
     private double distanceMeters = Double.MAX_VALUE;
+    private double measurementTime = Double.MIN_VALUE;
 
     @AssistedFactory
     public abstract static class MockLaserCANFactory implements XLaserCANFactory {
@@ -29,10 +33,12 @@ public class MockLaserCAN extends XLaserCAN {
 
     public void setDistance(double distanceMeters) {
         this.distanceMeters = distanceMeters;
+        this.measurementTime = XTimer.getFPGATimestamp();
     }
 
     @Override
     public void updateInputs(LaserCANInputs inputs) {
         inputs.distance = edu.wpi.first.units.Units.Meters.of(distanceMeters);
+        inputs.measurementLatency = Seconds.of(XTimer.getFPGATimestamp() - measurementTime);
     }
 }

--- a/src/main/java/xbot/common/controls/sensors/mock_adapters/MockLaserCAN.java
+++ b/src/main/java/xbot/common/controls/sensors/mock_adapters/MockLaserCAN.java
@@ -38,6 +38,7 @@ public class MockLaserCAN extends XLaserCAN {
 
     @Override
     public void updateInputs(LaserCANInputs inputs) {
+        inputs.isMeasurementValid = true;
         inputs.distance = edu.wpi.first.units.Units.Meters.of(distanceMeters);
         inputs.measurementLatency = Seconds.of(XTimer.getFPGATimestamp() - measurementTime);
     }

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/LaserCANWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/LaserCANWpiAdapter.java
@@ -22,7 +22,7 @@ public class LaserCANWpiAdapter extends XLaserCAN {
 
     protected LaserCan laserCan;
     private Distance previousMeasurement = Meters.zero();
-    private Time previousMeasurementTime = Seconds.of(Double.MAX_VALUE);
+    private Time previousMeasurementTime = Seconds.of(Double.MIN_VALUE);
     final Alert healthAlert;
 
     @AssistedFactory

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/LaserCANWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/LaserCANWpiAdapter.java
@@ -5,18 +5,24 @@ import au.grapplerobotics.interfaces.LaserCanInterface;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.wpilibj.Alert;
 import xbot.common.controls.io_inputs.LaserCANInputs;
 import xbot.common.controls.sensors.XLaserCAN;
+import xbot.common.controls.sensors.XTimer;
 import xbot.common.injection.DevicePolice;
 import xbot.common.injection.electrical_contract.DeviceInfo;
 import xbot.common.logging.AlertGroups;
 
 import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.Seconds;
 
 public class LaserCANWpiAdapter extends XLaserCAN {
 
     protected LaserCan laserCan;
+    private Distance previousMeasurement = Meters.zero();
+    private Time previousMeasurementTime = Seconds.of(Double.MAX_VALUE);
     final Alert healthAlert;
 
     @AssistedFactory
@@ -46,10 +52,16 @@ public class LaserCANWpiAdapter extends XLaserCAN {
     @Override
     public void updateInputs(LaserCANInputs inputs) {
         LaserCanInterface.Measurement measurement = laserCan.getMeasurement();
-        if (measurement != null) {
+        if (measurement != null && measurement.status == LaserCan.LASERCAN_STATUS_VALID_MEASUREMENT) {
             inputs.distance = Meters.of(measurement.distance_mm / 1000.0);
+            if (!inputs.distance.isEquivalent(previousMeasurement)) {
+                previousMeasurementTime = XTimer.getFPGATimestampTime();
+                previousMeasurement = inputs.distance;
+            }
+            inputs.measurementLatency = XTimer.getFPGATimestampTime().minus(previousMeasurementTime);
         } else {
             inputs.distance = Meters.of(0);
+            inputs.measurementLatency = Seconds.zero();
         }
     }
 }

--- a/src/main/java/xbot/common/controls/sensors/wpi_adapters/LaserCANWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/sensors/wpi_adapters/LaserCANWpiAdapter.java
@@ -59,9 +59,11 @@ public class LaserCANWpiAdapter extends XLaserCAN {
                 previousMeasurement = inputs.distance;
             }
             inputs.measurementLatency = XTimer.getFPGATimestampTime().minus(previousMeasurementTime);
+            inputs.isMeasurementValid = true;
         } else {
             inputs.distance = Meters.of(0);
             inputs.measurementLatency = Seconds.zero();
+            inputs.isMeasurementValid = false;
         }
     }
 }


### PR DESCRIPTION
# Why are we doing this?
LaserCAN sensor can report unreliable values, and it can report stale values due to its slow update frequency.

# Whats changing?
Report the time of the latest measurement, and return an Optional.empty() measurement when the sensor data is unreliable.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
