### PR TITLE
Unit-ed Property equivalence fix

### DIFF
--- a/src/main/java/xbot/common/properties/AngleProperty.java
+++ b/src/main/java/xbot/common/properties/AngleProperty.java
@@ -1,7 +1,5 @@
 package xbot.common.properties;
 
-import static edu.wpi.first.units.Units.Degrees;
-
 import java.util.function.Consumer;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
@@ -9,7 +7,6 @@ import org.littletonrobotics.junction.inputs.LoggableInputs;
 
 import edu.wpi.first.units.AngleUnit;
 import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.MutAngle;
 import xbot.common.logging.Pluralizer;
 
@@ -23,7 +20,6 @@ public class AngleProperty extends Property {
     final AngleUnit defaultUnit;
     final MutAngle lastValue;
     final MutAngle currentValue;
-    final static Angle equivalenceThreshold = Degrees.of(0.001);
 
     private final LoggableInputs inputs = new LoggableInputs() {
         public void toLog(LogTable table) {
@@ -83,7 +79,7 @@ public class AngleProperty extends Property {
 
     public void hasChangedSinceLastCheck(Consumer<Angle> callback) {
         Angle currentValue = get();
-        if (!currentValue.isNear(lastValue, equivalenceThreshold)) {
+        if (!currentValue.isEquivalent(lastValue)) {
             callback.accept(currentValue);
         }
         lastValue.mut_replace(currentValue);
@@ -91,7 +87,7 @@ public class AngleProperty extends Property {
 
     public boolean hasChangedSinceLastCheck() {
         Angle currentValue = get();
-        boolean changed = !currentValue.isNear(lastValue, equivalenceThreshold);
+        boolean changed = !currentValue.isEquivalent(lastValue);
         lastValue.mut_replace(currentValue);
         return changed;
     }

--- a/src/main/java/xbot/common/properties/AngleProperty.java
+++ b/src/main/java/xbot/common/properties/AngleProperty.java
@@ -1,5 +1,7 @@
 package xbot.common.properties;
 
+import static edu.wpi.first.units.Units.Degrees;
+
 import java.util.function.Consumer;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
@@ -7,6 +9,7 @@ import org.littletonrobotics.junction.inputs.LoggableInputs;
 
 import edu.wpi.first.units.AngleUnit;
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.MutAngle;
 import xbot.common.logging.Pluralizer;
 
@@ -20,6 +23,7 @@ public class AngleProperty extends Property {
     final AngleUnit defaultUnit;
     final MutAngle lastValue;
     final MutAngle currentValue;
+    final static Angle equivalenceThreshold = Degrees.of(0.001);
 
     private final LoggableInputs inputs = new LoggableInputs() {
         public void toLog(LogTable table) {
@@ -79,7 +83,7 @@ public class AngleProperty extends Property {
 
     public void hasChangedSinceLastCheck(Consumer<Angle> callback) {
         Angle currentValue = get();
-        if (!currentValue.isEquivalent(lastValue)) {
+        if (!currentValue.isNear(lastValue, equivalenceThreshold)) {
             callback.accept(currentValue);
         }
         lastValue.mut_replace(currentValue);
@@ -87,7 +91,7 @@ public class AngleProperty extends Property {
 
     public boolean hasChangedSinceLastCheck() {
         Angle currentValue = get();
-        boolean changed = !currentValue.isEquivalent(lastValue);
+        boolean changed = !currentValue.isNear(lastValue, equivalenceThreshold);
         lastValue.mut_replace(currentValue);
         return changed;
     }

--- a/src/main/java/xbot/common/properties/AngleProperty.java
+++ b/src/main/java/xbot/common/properties/AngleProperty.java
@@ -47,7 +47,7 @@ public class AngleProperty extends Property {
         // Check for non-default on load; also store a "last value" we can use
         // to check if a property has changed recently.
         Angle firstValue = get_internal();
-        if (firstValue != defaultValue) {
+        if (!firstValue.isEquivalent(defaultValue)) {
             log.info("Property " + key + " has the non-default value " + firstValue);
         }
         lastValue.mut_replace(firstValue);

--- a/src/main/java/xbot/common/properties/DistanceProperty.java
+++ b/src/main/java/xbot/common/properties/DistanceProperty.java
@@ -46,7 +46,7 @@ public class DistanceProperty extends Property {
         // Check for non-default on load; also store a "last value" we can use
         // to check if a property has changed recently.
         Distance firstValue = get_internal();
-        if (get_internal() != defaultValue) {
+        if (!get_internal().isEquivalent(defaultValue)) {
             log.info("Property " + key + " has the non-default value " + firstValue);
         }
         lastValue.mut_replace(firstValue);

--- a/src/main/java/xbot/common/properties/DistanceProperty.java
+++ b/src/main/java/xbot/common/properties/DistanceProperty.java
@@ -1,5 +1,7 @@
 package xbot.common.properties;
 
+import static edu.wpi.first.units.Units.Meters;
+
 import java.util.function.Consumer;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
@@ -20,6 +22,7 @@ public class DistanceProperty extends Property {
     final DistanceUnit defaultUnit;
     final MutDistance lastValue;
     final MutDistance currentValue;
+    final static Distance equivalenceThreshold = Meters.of(0.0001);
 
     private final LoggableInputs inputs = new LoggableInputs() {
         public void toLog(LogTable table) {
@@ -78,7 +81,7 @@ public class DistanceProperty extends Property {
 
     public void hasChangedSinceLastCheck(Consumer<Distance> callback) {
         Distance currentValue = get();
-        if (!currentValue.isEquivalent(lastValue)) {
+        if (!currentValue.isNear(lastValue, equivalenceThreshold)) {
             callback.accept(currentValue);
         }
         lastValue.mut_replace(currentValue);
@@ -86,7 +89,7 @@ public class DistanceProperty extends Property {
 
     public boolean hasChangedSinceLastCheck() {
         Distance currentValue = get();
-        boolean changed = !currentValue.isEquivalent(lastValue);
+        boolean changed = !currentValue.isNear(lastValue, equivalenceThreshold);
         lastValue.mut_replace(currentValue);
         return changed;
     }

--- a/src/main/java/xbot/common/properties/DistanceProperty.java
+++ b/src/main/java/xbot/common/properties/DistanceProperty.java
@@ -1,7 +1,5 @@
 package xbot.common.properties;
 
-import static edu.wpi.first.units.Units.Meters;
-
 import java.util.function.Consumer;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
@@ -22,7 +20,6 @@ public class DistanceProperty extends Property {
     final DistanceUnit defaultUnit;
     final MutDistance lastValue;
     final MutDistance currentValue;
-    final static Distance equivalenceThreshold = Meters.of(0.0001);
 
     private final LoggableInputs inputs = new LoggableInputs() {
         public void toLog(LogTable table) {
@@ -81,7 +78,7 @@ public class DistanceProperty extends Property {
 
     public void hasChangedSinceLastCheck(Consumer<Distance> callback) {
         Distance currentValue = get();
-        if (!currentValue.isNear(lastValue, equivalenceThreshold)) {
+        if (!currentValue.isEquivalent(lastValue)) {
             callback.accept(currentValue);
         }
         lastValue.mut_replace(currentValue);
@@ -89,7 +86,7 @@ public class DistanceProperty extends Property {
 
     public boolean hasChangedSinceLastCheck() {
         Distance currentValue = get();
-        boolean changed = !currentValue.isNear(lastValue, equivalenceThreshold);
+        boolean changed = !currentValue.isEquivalent(lastValue);
         lastValue.mut_replace(currentValue);
         return changed;
     }


### PR DESCRIPTION
# Why are we doing this?

Noticed on the robot that it kept reporting on boot that many of our Distance/Angle Properties had non-default values, even though they actually were the same. 


# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
