### PR TITLE
Run maintainers in disabled, with Coast action

### DIFF
--- a/src/main/java/xbot/common/command/BaseMaintainerCommand.java
+++ b/src/main/java/xbot/common/command/BaseMaintainerCommand.java
@@ -63,6 +63,11 @@ public abstract class BaseMaintainerCommand<T> extends BaseCommand {
         decider = humanVsMachineDeciderFactory.create(this.getPrefix());
     }
 
+    @Override
+    public boolean runsWhenDisabled() {
+        return true;
+    }
+
     /**
      * Resets the decider to the given mode.
      * @param startInAutomaticMode True to start in automatic mode, false to start in human control mode.

--- a/src/main/java/xbot/common/logic/HumanVsMachineDecider.java
+++ b/src/main/java/xbot/common/logic/HumanVsMachineDecider.java
@@ -3,6 +3,7 @@ package xbot.common.logic;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
+import edu.wpi.first.wpilibj.DriverStation;
 import xbot.common.controls.sensors.XTimer;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.Property;
@@ -22,7 +23,7 @@ public class HumanVsMachineDecider {
         InitializeMachineControl,
         MachineControl
     }
-    
+
     private double lastHumanTime;
     private final DoubleProperty deadbandProp;
     private final DoubleProperty coastTimeProp;
@@ -78,22 +79,26 @@ public class HumanVsMachineDecider {
      * @return The recommended mode.
      */
     public HumanVsMachineMode getRecommendedMode(double humanInput) {
-                
+
+        if (DriverStation.isDisabled()) {
+            return HumanVsMachineMode.Coast;
+        }
+
         if (Math.abs(humanInput) > deadbandProp.get()) {
             lastHumanTime = XTimer.getFPGATimestamp();
             inAutomaticMode = false;
             return HumanVsMachineMode.HumanControl;
         }
-        
+
         if (XTimer.getFPGATimestamp() - lastHumanTime < coastTimeProp.get()) {
             return HumanVsMachineMode.Coast;
         }
-        
+
         if (!inAutomaticMode) {
             inAutomaticMode = true;
             return HumanVsMachineMode.InitializeMachineControl;
         }
-        
+
         return HumanVsMachineMode.MachineControl;
     }
 

--- a/src/test/java/xbot/common/logic/HumanVsMachineDeciderTest.java
+++ b/src/test/java/xbot/common/logic/HumanVsMachineDeciderTest.java
@@ -2,6 +2,8 @@ package xbot.common.logic;
 
 import static org.junit.Assert.assertTrue;
 
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
 import org.junit.Test;
 
 import xbot.common.injection.BaseCommonLibTest;
@@ -10,17 +12,22 @@ import xbot.common.logic.HumanVsMachineDecider.HumanVsMachineMode;
 public class HumanVsMachineDeciderTest extends BaseCommonLibTest {
 
     HumanVsMachineDecider decider;
-    
+
     @Override
     public void setUp() {
         super.setUp();
         decider = getInjectorComponent().humanVsMachineDeciderFactory().create("Test");
     }
-    
+
     @Test
     public void testStandardPath() {
+        assertTrue("Start in coast while disabled", decider.getRecommendedMode(0) == HumanVsMachineMode.Coast);
+
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.notifyNewData();
+
         assertTrue("Start in machine control", decider.getRecommendedMode(0) == HumanVsMachineMode.MachineControl);
-        
+
         assertTrue("Human input brings us back out", decider.getRecommendedMode(1) == HumanVsMachineMode.HumanControl);
         timer.advanceTimeInSecondsBy(0.01);
         assertTrue("Then we coast", decider.getRecommendedMode(0.01) == HumanVsMachineMode.Coast);


### PR DESCRIPTION
# Why are we doing this?
On TeleopInit/AutonomousInit, we initialize a whole bunch of commands all at once, possibly leading to high robot cycle times.

# Whats changing?
Startup the maintainers in Coast when disabled, to make sure at least those don't need to be constructed.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x]  tested on simulator