### PR TITLE
Add method to set the max velocity for a trapezoidal profile

### DIFF
--- a/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/XCANMotorController.java
@@ -263,6 +263,8 @@ public abstract class XCANMotorController implements DataFrameRefreshable {
 
     public abstract void setTrapezoidalProfileJerk(Velocity<AngularAccelerationUnit> jerk);
 
+    public abstract void setTrapezoidalProfileMaxVelocity(AngularVelocity velocity);
+
     public abstract void setPower(double power);
 
     public abstract double getPower();

--- a/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
+++ b/src/main/java/xbot/common/controls/actuators/mock_adapters/MockCANMotorController.java
@@ -100,6 +100,11 @@ public class MockCANMotorController extends XCANMotorController {
     }
 
     @Override
+    public void setTrapezoidalProfileMaxVelocity(AngularVelocity velocity) {
+
+    }
+
+    @Override
     public void setPidDirectly(double p, double i, double d, double velocityFF, double gravityFF, int slot) {
         this.p = p;
         this.i = i;

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANSparkMaxWpiAdapter.java
@@ -134,6 +134,15 @@ public class CANSparkMaxWpiAdapter extends XCANMotorController {
     }
 
     @Override
+    public void setTrapezoidalProfileMaxVelocity(AngularVelocity velocity) {
+        var config = new SparkMaxConfig();
+        config.closedLoop.maxMotion.maxVelocity(velocity.in(RPM));
+        this.internalSparkMax.configure(config,
+                SparkBase.ResetMode.kNoResetSafeParameters,
+                SparkBase.PersistMode.kNoPersistParameters);
+    }
+
+    @Override
     public void setPidDirectly(double p, double i, double d, double velocityFF, double gravityFF, int slot) {
         if (gravityFF != 0) {
             log.warn("setPidDirectly: Gravity feedforward is not supported by SparkMax");

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANTalonFxWpiAdapter.java
@@ -226,6 +226,16 @@ public class CANTalonFxWpiAdapter extends XCANMotorController {
     }
 
     @Override
+    public void setTrapezoidalProfileMaxVelocity(AngularVelocity velocity) {
+        if (configCacheFailedAlert.get()) {
+            cacheConfiguration();
+        }
+
+        this.talonConfiguration.MotionMagic.withMotionMagicCruiseVelocity(velocity);
+        invokeWithRetry(() -> this.internalTalonFx.getConfigurator().apply(this.talonConfiguration.MotionMagic), 3);
+    }
+
+    @Override
     public void setPower(double power) {
         if (!isValidPowerRequest(power)) {
             return;

--- a/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANVictorSPXWpiAdapter.java
+++ b/src/main/java/xbot/common/controls/actuators/wpi_adapters/CANVictorSPXWpiAdapter.java
@@ -107,6 +107,11 @@ public class CANVictorSPXWpiAdapter extends XCANMotorController {
     }
 
     @Override
+    public void setTrapezoidalProfileMaxVelocity(AngularVelocity velocity) {
+
+    }
+
+    @Override
     public void setPower(double power) {
         internalVictor.set(VictorSPXControlMode.PercentOutput, power);
     }


### PR DESCRIPTION
# Why are we doing this?
Both the TalonFX and SparkMAX provide a way to limit the max velocity of a trapezoidal profile. This might be useful.

# Whats changing?
Expose additional method to set trapezoidal profile max velocity.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
