### PR TITLE
Adding finish modes for SwerveSimpleTrajectoryLogic

### DIFF
--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -15,7 +15,6 @@ import xbot.common.subsystems.drive.SwerveKinematicsCalculator;
 import xbot.common.subsystems.drive.SwervePointKinematics;
 import xbot.common.subsystems.drive.SwerveSimpleTrajectoryMode;
 import xbot.common.subsystems.drive.control_logic.HeadingModule;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +27,6 @@ import static edu.wpi.first.units.Units.Seconds;
 public class SwerveSimpleTrajectoryLogic {
 
     public enum FinishMode {
-        LooseVelocity,
         LoosePositionAndRotation,
         BeAtPidTarget
     }
@@ -60,7 +58,6 @@ public class SwerveSimpleTrajectoryLogic {
     // You can't use the threshold without ever setting them but as for now they are just
     // arbitrary value that I think makes sense and that we can reference off of
     private FinishMode finishMode = FinishMode.BeAtPidTarget;
-    private double looseVelocityThreshold = 0.4;
     private double loosePositionThreshold = 0.5;
     private double looseRotationThreshold = 30;
 
@@ -128,11 +125,6 @@ public class SwerveSimpleTrajectoryLogic {
 
     public List<XbotSwervePoint> getResolvedKeyPoints() {
         return keyPoints;
-    }
-
-    public void setFinishModeLooseVelocity(double velocity) {
-        this.finishMode = FinishMode.LooseVelocity;
-        this.looseVelocityThreshold = velocity;
     }
 
     public void setFinishModeLoosePositionAndRotation(double position, double rotation) {
@@ -442,11 +434,9 @@ public class SwerveSimpleTrajectoryLogic {
         XYPair currentPosition = new XYPair(currentPose.getX(), currentPose.getY());
 
         // Get the difference between where we are, and where we want to be.
-        XYPair goalVector = targetPosition.clone().add(
+        return targetPosition.clone().add(
                 currentPosition.scale(-1)
         );
-
-        return goalVector;
     }
 
     public Twist2d calculatePowers(Pose2d currentPose, PIDManager positionalPid, HeadingModule headingModule) {
@@ -552,15 +542,11 @@ public class SwerveSimpleTrajectoryLogic {
 
         boolean finished = false;
         switch (finishMode) {
-            case LooseVelocity:
-                boolean meetVelocityThreshold = goalVector.getMagnitude() < looseVelocityThreshold;
-                finished = lastResult.isOnFinalPoint && meetVelocityThreshold;
-                break;
             case LoosePositionAndRotation:
                 double rotationDifference = lastResult.chaseHeading.getDegrees() - currentPose.getRotation().getDegrees();
                 boolean isNearPositionTarget = lastResult.distanceToTargetPoint < loosePositionThreshold;
                 boolean isNearRotationTarget = rotationDifference < looseRotationThreshold;
-                finished = lastResult.isOnFinalPoint && isNearPositionTarget && isNearRotationTarget;
+                finished = lastResult.isOnFinalLeg && isNearPositionTarget && isNearRotationTarget;
                 break;
             case BeAtPidTarget: // Fall into default
             default:

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -145,6 +145,7 @@ public class SwerveSimpleTrajectoryLogic {
         this.distanceThresholdToPrioritizeRotation = distanceThresholdToPrioritizeRotation;
     }
 
+    // TODO: refactor to that setting velocity mode also requires corresponding double/kinematics as a 2nd parameter
     public void setVelocityMode(SwerveSimpleTrajectoryMode mode) {
         this.mode = mode;
     }

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -546,6 +546,8 @@ public class SwerveSimpleTrajectoryLogic {
                 double rotationDifference = lastResult.chaseHeading.getDegrees() - currentPose.getRotation().getDegrees();
                 boolean isNearPositionTarget = lastResult.distanceToTargetPoint < loosePositionThreshold;
                 boolean isNearRotationTarget = rotationDifference < looseRotationThreshold;
+
+                // Using isOnFinalLeg here instead of isOnFinalPoint as it's more loose
                 finished = lastResult.isOnFinalLeg && isNearPositionTarget && isNearRotationTarget;
                 break;
             case BeAtPidTarget: // Fall into default

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -15,24 +15,29 @@ import xbot.common.subsystems.drive.SwerveKinematicsCalculator;
 import xbot.common.subsystems.drive.SwervePointKinematics;
 import xbot.common.subsystems.drive.SwerveSimpleTrajectoryMode;
 import xbot.common.subsystems.drive.control_logic.HeadingModule;
+import xbot.common.subsystems.pose.BasePoseSubsystem;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
 import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 
+
 public class SwerveSimpleTrajectoryLogic {
+
+    public enum FinishMode {
+        LooseVelocity,
+        LoosePositionAndRotation,
+        BeAtPidTarget
+    }
 
     Logger log = LogManager.getLogger(this.getClass());
     final AKitLogger aKitLog = new AKitLogger("SimpleTimeInterpolator/");
 
     private Supplier<List<XbotSwervePoint>> keyPointsProvider;
     private List<XbotSwervePoint> keyPoints;
-    private boolean stopWhenFinished = true;
     private final SimpleTimeInterpolator interpolator;
     SimpleTimeInterpolator.InterpolationResult lastResult;
     double maxPower = 1.0;
@@ -51,6 +56,13 @@ public class SwerveSimpleTrajectoryLogic {
     private SwervePointKinematics globalKinematics = null;
     private SwerveSimpleTrajectoryMode mode = SwerveSimpleTrajectoryMode.DurationInSeconds;
     RobotAssertionManager assertionManager;
+
+    // You can't use the threshold without ever setting them but as for now they are just
+    // arbitrary value that I think makes sense and that we can reference off of
+    private FinishMode finishMode = FinishMode.BeAtPidTarget;
+    private double looseVelocityThreshold = 0.4;
+    private double loosePositionThreshold = 0.5;
+    private double looseRotationThreshold = 30;
 
     public SwerveSimpleTrajectoryLogic(RobotAssertionManager assertionManager) {
         this.assertionManager = assertionManager;
@@ -118,8 +130,19 @@ public class SwerveSimpleTrajectoryLogic {
         return keyPoints;
     }
 
-    public void setStopWhenFinished(boolean newValue) {
-        this.stopWhenFinished = newValue;
+    public void setFinishModeLooseVelocity(double velocity) {
+        this.finishMode = FinishMode.LooseVelocity;
+        this.looseVelocityThreshold = velocity;
+    }
+
+    public void setFinishModeLoosePositionAndRotation(double position, double rotation) {
+        this.finishMode = FinishMode.LoosePositionAndRotation;
+        this.loosePositionThreshold = position;
+        this.looseRotationThreshold = rotation;
+    }
+
+    public void setFinishModeBeAtPidTarget() {
+        this.finishMode = FinishMode.BeAtPidTarget;
     }
 
     public void setPrioritizeRotationIfCloseToGoal(boolean prioritizeRotationIfCloseToGoal) {
@@ -524,15 +547,25 @@ public class SwerveSimpleTrajectoryLogic {
     }
 
     public boolean recommendIsFinished(Pose2d currentPose, PIDManager positionalPid, HeadingModule headingModule) {
+        // TODO: Figure out what world goalVector is in (Power? Something else?)
         var goalVector = getGoalVector(currentPose);
-        // TODO: Move this threshold into a variable
-        boolean isAtNoStoppingGoal = goalVector.getMagnitude() < 0.40;
 
         boolean finished = false;
-        if (!stopWhenFinished) {
-            finished = lastResult.isOnFinalPoint && isAtNoStoppingGoal;
-        } else {
-            finished =  lastResult.isOnFinalPoint && positionalPid.isOnTarget() && headingModule.isOnTarget();
+        switch (finishMode) {
+            case LooseVelocity:
+                boolean meetVelocityThreshold = goalVector.getMagnitude() < looseVelocityThreshold;
+                finished = lastResult.isOnFinalPoint && meetVelocityThreshold;
+                break;
+            case LoosePositionAndRotation:
+                double rotationDifference = lastResult.chaseHeading.getDegrees() - currentPose.getRotation().getDegrees();
+                boolean isNearPositionTarget = lastResult.distanceToTargetPoint < loosePositionThreshold;
+                boolean isNearRotationTarget = rotationDifference < looseRotationThreshold;
+                finished = lastResult.isOnFinalPoint && isNearPositionTarget && isNearRotationTarget;
+                break;
+            case BeAtPidTarget: // Fall into default
+            default:
+                finished =  lastResult.isOnFinalPoint && positionalPid.isOnTarget() && headingModule.isOnTarget();
+                break;
         }
 
         if (finished) {

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -538,7 +538,7 @@ public class SwerveSimpleTrajectoryLogic {
     }
 
     public boolean recommendIsFinished(Pose2d currentPose, PIDManager positionalPid, HeadingModule headingModule) {
-        double translationDifference = getGoalVector(currentPose).getMagnitude();
+        double translationDifference = lastResult.distanceToTargetPoint;
         double rotationDifference = lastResult.chaseHeading.getDegrees() - currentPose.getRotation().getDegrees();
 
         boolean finished = false;

--- a/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
+++ b/src/main/java/xbot/common/trajectory/SwerveSimpleTrajectoryLogic.java
@@ -538,14 +538,13 @@ public class SwerveSimpleTrajectoryLogic {
     }
 
     public boolean recommendIsFinished(Pose2d currentPose, PIDManager positionalPid, HeadingModule headingModule) {
-        // TODO: Figure out what world goalVector is in (Power? Something else?)
-        var goalVector = getGoalVector(currentPose);
+        double translationDifference = getGoalVector(currentPose).getMagnitude();
+        double rotationDifference = lastResult.chaseHeading.getDegrees() - currentPose.getRotation().getDegrees();
 
         boolean finished = false;
         switch (finishMode) {
             case LoosePositionAndRotation:
-                double rotationDifference = lastResult.chaseHeading.getDegrees() - currentPose.getRotation().getDegrees();
-                boolean isNearPositionTarget = lastResult.distanceToTargetPoint < loosePositionThreshold;
+                boolean isNearPositionTarget = translationDifference < loosePositionThreshold;
                 boolean isNearRotationTarget = rotationDifference < looseRotationThreshold;
 
                 // Using isOnFinalLeg here instead of isOnFinalPoint as it's more loose
@@ -558,7 +557,8 @@ public class SwerveSimpleTrajectoryLogic {
         }
 
         if (finished) {
-            log.info(String.format("SwerveLogic recommends Finished, goal is %f away.", goalVector.getMagnitude()));
+            String template = "SwerveLogic recommends Finished, position is %.2f away, rotation is %.1f away.";
+            log.info(String.format(template, translationDifference, rotationDifference));
         }
         return finished;
     }


### PR DESCRIPTION
# Why are we doing this?
Added a way for users to customize position and rotation thresholds before finishing such that they don't have to rely on pid. Also allow for setting a custom loose velocity.

# Whats changing?
Additionally just refactored older logic so it looks better and is more maintainable.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
