### PR TITLE
Disable network table writing of akit logs when on a real field

### DIFF
--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -98,7 +98,12 @@ public abstract class BaseRobot extends LoggedRobot {
                 if (logDirectory.exists() && logDirectory.isDirectory() && logDirectory.canWrite()) {
                     Logger.addDataReceiver(new WPILOGWriter("/U/logs")); // Log to a USB stick with label LOGSDRIVE plugged into the inner usb port
                 }
-                Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
+
+                if (!DriverStation.isFMSAttached()) {
+                    // Publish data to NetworkTables if we're not on a real field
+                    Logger.addDataReceiver(new NT4Publisher());
+                }
+
                 LoggedPowerDistribution.getInstance(
                         PowerDistribution.kDefaultModule,
                         PowerDistribution.ModuleType.kRev); // Log power distribution data from the configured module

--- a/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
+++ b/src/main/java/xbot/common/subsystems/autonomous/AutonomousCommandSelector.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,8 +52,11 @@ public class AutonomousCommandSelector extends BaseSubsystem {
     public void setCurrentAutonomousCommand(Command currentAutonomousCommand) {
         log.info("Setting CurrentAutonomousCommand to " + currentAutonomousCommand);
         log.info("Setting CurrentStartingPosition to " + currentAutonomousStartingPosition);
-        aKitLog.record("Current autonomous command name",
-                currentAutonomousCommand == null ? "No command set" : currentAutonomousCommand.getName());
+        var nameString = currentAutonomousCommand == null ? "No command set" : currentAutonomousCommand.getName();
+        aKitLog.record("Current autonomous command name", nameString);
+        
+        // to make sure this is always logged to networktables no matter what, also explicitly push it to the SD
+        SmartDashboard.putString("Current autunomous command name", nameString);
 
         this.currentAutonomousCommand = currentAutonomousCommand;
         commandSupplier = null;


### PR DESCRIPTION
# Why are we doing this?

We have a hojillian values being written, which tends to tax the rio and the network.

I saw this line in 254s code which disables writing akit logs when fms is attached. It seems like a good idea in general.

The downside is that during a match we might want to be checking a value and won't be able to. For some crucial things like the current auto command we could be using some explicit overrides here maybe.

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
