### PR TITLE
Skip AdvantageKit mirror of Property values from NetworkTables (-459 entries for 2026 code in sim)

### DIFF
--- a/src/main/java/xbot/common/advantage/PropertySkippingNT4Publisher.java
+++ b/src/main/java/xbot/common/advantage/PropertySkippingNT4Publisher.java
@@ -1,0 +1,65 @@
+package xbot.common.advantage;
+
+import org.littletonrobotics.junction.LogDataReceiver;
+import org.littletonrobotics.junction.LogTable;
+import org.littletonrobotics.junction.LogTable.LogValue;
+import org.littletonrobotics.junction.networktables.NT4Publisher;
+
+import java.util.Map;
+
+import xbot.common.properties.Property;
+
+/**
+ * A {@link LogDataReceiver} that wraps {@link NT4Publisher} and skips any LogTable entry
+ * under the {@link Property#AKIT_LOG_NAMESPACE} subtable (currently {@code PropertyMirror/}).
+ *
+ * <p>Property values are routed through that subtable so the on-disk WPILOG receiver still
+ * captures them (replay correctness), but the live NetworkTables surface stays clean —
+ * dashboards see the same values via WPILib's {@code /Preferences/...} table (which is
+ * the editable/savable surface and is untouched by this wrapper).
+ *
+ * <p>All other keys (subsystem telemetry, {@code aKitLog.record(...)} outputs, system stats,
+ * driver-station data, etc.) flow through unchanged.
+ */
+public class PropertySkippingNT4Publisher implements LogDataReceiver {
+
+    /** LogTable keys have a leading slash; the namespace constant does not. */
+    static final String DENY_PREFIX = "/" + Property.AKIT_LOG_NAMESPACE;
+
+    private final LogDataReceiver wrapped;
+
+    public PropertySkippingNT4Publisher() {
+        this(new NT4Publisher());
+    }
+
+    /** Visible for testing. */
+    PropertySkippingNT4Publisher(LogDataReceiver wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void start() {
+        wrapped.start();
+    }
+
+    @Override
+    public void end() {
+        wrapped.end();
+    }
+
+    @Override
+    public void putTable(LogTable table) throws InterruptedException {
+        LogTable filtered = new LogTable(table.getTimestamp());
+        for (Map.Entry<String, LogValue> entry : table.getAll(false).entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith(DENY_PREFIX)) {
+                continue;
+            }
+            // LogTable.put prepends the root prefix "/" automatically, so strip the
+            // leading slash we got from getAll() to avoid producing "//Foo".
+            String relativeKey = key.startsWith("/") ? key.substring(1) : key;
+            filtered.put(relativeKey, entry.getValue());
+        }
+        wrapped.putTable(filtered);
+    }
+}

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -98,14 +98,15 @@ public abstract class BaseRobot extends LoggedRobot {
                 if (logDirectory.exists() && logDirectory.isDirectory() && logDirectory.canWrite()) {
                     Logger.addDataReceiver(new WPILOGWriter("/U/logs")); // Log to a USB stick with label LOGSDRIVE plugged into the inner usb port
                 }
-                // Publish data to NetworkTables, but skip the AKit-side mirror of Property
-                // values (they're in the on-disk WPILOG for replay, and the editable surface
-                // for dashboards lives at /Preferences/... via WPILib Preferences, untouched).
-                Logger.addDataReceiver(new PropertySkippingNT4Publisher());
+                
 
                 if (!DriverStation.isFMSAttached()) {
                     // Publish data to NetworkTables if we're not on a real field
-                    Logger.addDataReceiver(new NT4Publisher());
+
+                    // Publish data to NetworkTables, but skip the AKit-side mirror of Property
+                    // values (they're in the on-disk WPILOG for replay, and the editable surface
+                    // for dashboards lives at /Preferences/... via WPILib Preferences, untouched).
+                    Logger.addDataReceiver(new PropertySkippingNT4Publisher());
                 }
 
                 LoggedPowerDistribution.getInstance(

--- a/src/main/java/xbot/common/command/BaseRobot.java
+++ b/src/main/java/xbot/common/command/BaseRobot.java
@@ -9,7 +9,6 @@ import org.littletonrobotics.junction.LogFileUtil;
 import org.littletonrobotics.junction.LoggedPowerDistribution;
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
-import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
 
@@ -21,6 +20,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import xbot.common.advantage.DataFrameRefreshable;
+import xbot.common.advantage.PropertySkippingNT4Publisher;
 import xbot.common.controls.sensors.XTimer;
 import xbot.common.controls.sensors.XTimerImpl;
 import xbot.common.injection.DevicePolice;
@@ -98,7 +98,10 @@ public abstract class BaseRobot extends LoggedRobot {
                 if (logDirectory.exists() && logDirectory.isDirectory() && logDirectory.canWrite()) {
                     Logger.addDataReceiver(new WPILOGWriter("/U/logs")); // Log to a USB stick with label LOGSDRIVE plugged into the inner usb port
                 }
-                Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
+                // Publish data to NetworkTables, but skip the AKit-side mirror of Property
+                // values (they're in the on-disk WPILOG for replay, and the editable surface
+                // for dashboards lives at /Preferences/... via WPILib Preferences, untouched).
+                Logger.addDataReceiver(new PropertySkippingNT4Publisher());
                 LoggedPowerDistribution.getInstance(
                         PowerDistribution.kDefaultModule,
                         PowerDistribution.ModuleType.kRev); // Log power distribution data from the configured module

--- a/src/main/java/xbot/common/properties/BooleanProperty.java
+++ b/src/main/java/xbot/common/properties/BooleanProperty.java
@@ -79,6 +79,6 @@ public class BooleanProperty extends Property {
     @Override
     public void refreshDataFrame() {
         currentValue = get_internal();
-        Logger.processInputs(prefix, inputs);
+        Logger.processInputs(akitLogPrefix(), inputs);
     }
 }

--- a/src/main/java/xbot/common/properties/DoubleProperty.java
+++ b/src/main/java/xbot/common/properties/DoubleProperty.java
@@ -92,6 +92,6 @@ public class DoubleProperty extends Property {
     @Override
     public void refreshDataFrame() {
         currentValue = get_internal();
-        Logger.processInputs(prefix, inputs);
+        Logger.processInputs(akitLogPrefix(), inputs);
     }
 }

--- a/src/main/java/xbot/common/properties/MeasureProperty.java
+++ b/src/main/java/xbot/common/properties/MeasureProperty.java
@@ -98,6 +98,6 @@ public class MeasureProperty<
     @Override
     public void refreshDataFrame() {
         currentValue.mut_replace(get_internal());
-        Logger.processInputs(prefix, inputs);
+        Logger.processInputs(akitLogPrefix(), inputs);
     }
 }

--- a/src/main/java/xbot/common/properties/Property.java
+++ b/src/main/java/xbot/common/properties/Property.java
@@ -18,6 +18,22 @@ import xbot.common.advantage.DataFrameRefreshable;
  */
 public abstract class Property implements DataFrameRefreshable {
     /**
+     * Namespace used for the AdvantageKit log subtable that Property values flow through.
+     * <p>
+     * Every Property records its current value as a {@code LoggableInputs} via
+     * {@code Logger.processInputs(akitLogPrefix(), inputs)} so replay sees the value the robot
+     * actually used. The AKit-side mirror is then forwarded to NetworkTables by default — which
+     * is redundant, because dashboards already see the value via WPILib's {@code /Preferences/...}
+     * surface. Routing the Property log entries through this dedicated subtable lets the NT
+     * publisher drop them by prefix without touching the on-disk log receiver (which still gets
+     * everything, keeping replay correct).
+     * <p>
+     * The name {@code PropertyMirror} (rather than just {@code Properties}) avoids confusion with
+     * the WPILib {@code Preferences} table that lives at {@code /Preferences/...} in NetworkTables.
+     */
+    public static final String AKIT_LOG_NAMESPACE = "PropertyMirror/";
+
+    /**
      * The key for the property.
      */
     public final String key;
@@ -74,6 +90,17 @@ public abstract class Property implements DataFrameRefreshable {
 
     public PropertyLevel getLevel() {
         return level;
+    }
+
+    /**
+     * @return The full prefix this Property uses when calling
+     *     {@code Logger.processInputs(...)}. Subclasses should pass this to
+     *     {@code Logger.processInputs} so their LogTable entries land under the
+     *     {@link #AKIT_LOG_NAMESPACE Properties/} subtable rather than mixing in with
+     *     subsystem telemetry.
+     */
+    protected String akitLogPrefix() {
+        return AKIT_LOG_NAMESPACE + prefix;
     }
 
     /**

--- a/src/main/java/xbot/common/properties/StringProperty.java
+++ b/src/main/java/xbot/common/properties/StringProperty.java
@@ -74,6 +74,6 @@ public class StringProperty extends Property {
     @Override
     public void refreshDataFrame() {
         currentValue = get_internal();
-        Logger.processInputs(prefix, inputs);
+        Logger.processInputs(akitLogPrefix(), inputs);
     }
 }

--- a/src/test/java/xbot/common/advantage/PropertySkippingNT4PublisherTest.java
+++ b/src/test/java/xbot/common/advantage/PropertySkippingNT4PublisherTest.java
@@ -1,0 +1,147 @@
+package xbot.common.advantage;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.littletonrobotics.junction.LogDataReceiver;
+import org.littletonrobotics.junction.LogTable;
+import org.littletonrobotics.junction.LogTable.LogValue;
+
+import java.util.Map;
+
+import xbot.common.properties.Property;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class PropertySkippingNT4PublisherTest {
+
+    private CapturingReceiver wrapped;
+    private PropertySkippingNT4Publisher publisher;
+
+    @Before
+    public void setUp() {
+        wrapped = new CapturingReceiver();
+        publisher = new PropertySkippingNT4Publisher(wrapped);
+    }
+
+    @Test
+    public void nonPropertyKeysAreForwarded() throws InterruptedException {
+        LogTable input = new LogTable(123L);
+        input.put("RealOutputs/Drive/Pose", 3.14);
+        input.put("SystemStats/BatteryVoltage", 12.4);
+        input.put("Timestamp", 123L);
+
+        publisher.putTable(input);
+
+        Map<String, LogValue> forwarded = wrapped.lastTable.getAll(false);
+        assertNotNull(forwarded.get("/RealOutputs/Drive/Pose"));
+        assertNotNull(forwarded.get("/SystemStats/BatteryVoltage"));
+        assertNotNull(forwarded.get("/Timestamp"));
+    }
+
+    @Test
+    public void propertyNamespacedKeysAreDropped() throws InterruptedException {
+        LogTable input = new LogTable(1L);
+        input.put(Property.AKIT_LOG_NAMESPACE + "ShooterSubsystem/VoltageRampTime", 0.2);
+        input.put(Property.AKIT_LOG_NAMESPACE + "DriveSubsystem/MaxSpeed", 4.0);
+
+        publisher.putTable(input);
+
+        Map<String, LogValue> forwarded = wrapped.lastTable.getAll(false);
+        assertNull(forwarded.get("/" + Property.AKIT_LOG_NAMESPACE + "ShooterSubsystem/VoltageRampTime"));
+        assertNull(forwarded.get("/" + Property.AKIT_LOG_NAMESPACE + "DriveSubsystem/MaxSpeed"));
+        assertTrue(forwarded.isEmpty());
+    }
+
+    @Test
+    public void mixOfPropertyAndNonPropertyKeysIsHandled() throws InterruptedException {
+        LogTable input = new LogTable(7L);
+        input.put("RealOutputs/Shooter/RPM", 6000.0);
+        input.put(Property.AKIT_LOG_NAMESPACE + "Shooter/VoltageRampTime", 0.2);
+        input.put("DriverStation/Alliance", "Red");
+        input.put(Property.AKIT_LOG_NAMESPACE + "Drive/MaxSpeed", 4.0);
+
+        publisher.putTable(input);
+
+        Map<String, LogValue> forwarded = wrapped.lastTable.getAll(false);
+        assertNotNull(forwarded.get("/RealOutputs/Shooter/RPM"));
+        assertNotNull(forwarded.get("/DriverStation/Alliance"));
+        assertNull(forwarded.get("/" + Property.AKIT_LOG_NAMESPACE + "Shooter/VoltageRampTime"));
+        assertNull(forwarded.get("/" + Property.AKIT_LOG_NAMESPACE + "Drive/MaxSpeed"));
+        assertEquals(2, forwarded.size());
+    }
+
+    @Test
+    public void timestampIsPreserved() throws InterruptedException {
+        LogTable input = new LogTable(424242L);
+        input.put("Timestamp", 424242L);
+
+        publisher.putTable(input);
+
+        assertEquals(424242L, wrapped.lastTable.getTimestamp());
+    }
+
+    @Test
+    public void emptyInputDoesNotCrash() throws InterruptedException {
+        LogTable input = new LogTable(0L);
+
+        publisher.putTable(input);
+
+        assertNotNull(wrapped.lastTable);
+        assertTrue(wrapped.lastTable.getAll(false).isEmpty());
+    }
+
+    @Test
+    public void startAndEndAreForwarded() {
+        publisher.start();
+        publisher.end();
+        assertTrue(wrapped.started);
+        assertTrue(wrapped.ended);
+    }
+
+    @Test
+    public void denyPrefixIncludesLeadingSlash() {
+        // Sanity check on the relationship between the namespace constant and the deny prefix.
+        // LogTable.getAll() returns keys with a leading slash; the namespace doesn't have one.
+        assertTrue(PropertySkippingNT4Publisher.DENY_PREFIX.startsWith("/"));
+        assertEquals("/" + Property.AKIT_LOG_NAMESPACE, PropertySkippingNT4Publisher.DENY_PREFIX);
+    }
+
+    @Test
+    public void keyThatMerelyContainsTheNamespaceIsNotDropped() throws InterruptedException {
+        // A key like /RealOutputs/PropertyMirror/Foo happens to contain "PropertyMirror/" but
+        // isn't under the namespace — it must still be forwarded.
+        LogTable input = new LogTable(1L);
+        input.put("RealOutputs/" + Property.AKIT_LOG_NAMESPACE + "Foo", 1.0);
+
+        publisher.putTable(input);
+
+        Map<String, LogValue> forwarded = wrapped.lastTable.getAll(false);
+        assertNotNull(forwarded.get("/RealOutputs/" + Property.AKIT_LOG_NAMESPACE + "Foo"));
+        assertFalse(forwarded.isEmpty());
+    }
+
+    private static final class CapturingReceiver implements LogDataReceiver {
+        LogTable lastTable;
+        boolean started;
+        boolean ended;
+
+        @Override
+        public void start() {
+            started = true;
+        }
+
+        @Override
+        public void end() {
+            ended = true;
+        }
+
+        @Override
+        public void putTable(LogTable table) {
+            lastTable = table;
+        }
+    }
+}


### PR DESCRIPTION
This PR was written by Claude Opus 4.8 with my direction and manual verification of changes.

# Why are we doing this?

Each Property currently costs **two** NetworkTables entries:

1. `/Preferences/<prefix>/<suffix>` — the WPILib `Preferences`-backed editable/savable dashboard surface.
2. `/AdvantageKit/<prefix>/<suffix>` — a mirror created by `Logger.processInputs(...)` in `Property.refreshDataFrame()`, which records the value as a `LoggableInputs` so replay sees what the robot used.

The AKit mirror has to exist for replay correctness, but it doesn't need to be published over NetworkTables — dashboards already see the value via `/Preferences/...`. With well over a thousand Properties on the bot, the redundant mirrors are a meaningful chunk of the NT load that's been stressing the rio.

This PR drops the AKit mirror's path to NT, keeps it on disk for replay, and leaves `/Preferences/...` untouched.

# Whats changing?

**New: `xbot.common.advantage.PropertySkippingNT4Publisher`** — a `LogDataReceiver` that wraps `NT4Publisher`. On each `putTable`, it builds a filtered copy of the incoming `LogTable` that omits any entry under the `PropertyMirror/` namespace, then forwards to the real `NT4Publisher`. The `WPILOGWriter` data receiver is untouched — disk capture (and therefore replay) is unaffected.

**Property base class** — added `public static final String AKIT_LOG_NAMESPACE = "PropertyMirror/"` and a `protected akitLogPrefix()` helper that returns `PropertyMirror/<prefix>`. Subclasses use it when calling `Logger.processInputs(...)`.

**Property subclasses** — `DoubleProperty`, `BooleanProperty`, `StringProperty`, `MeasureProperty` all change `Logger.processInputs(prefix, inputs)` → `Logger.processInputs(akitLogPrefix(), inputs)`. One-line each.

**`BaseRobot.robotInit()`** — `new NT4Publisher()` → `new PropertySkippingNT4Publisher()`.

# Measured impact

Counted live against the TeamXbot2026 sim using a small `ntcore`-based Python script (connect as an NT4 client, subscribe `""` with the topics-only flag, wait for announcements, group by path).

### Top-level NT tables

| Top-level table | Before | After | Δ |
|---|---:|---:|---:|
| `/AdvantageKit` | 937 | 478 | **−459** |
| `/Preferences` | 459 | 459 | 0 |
| `/SmartDashboard` | 184 | 184 | 0 |
| `/photonvision` | 85 | 85 | 0 |
| `/CameraPublisher` | 48 | 48 | 0 |
| `/.schema` | 16 | 16 | 0 |
| `/FMSInfo` | 9 | 9 | 0 |
| `/PathPlanner` | 4 | 4 | 0 |
| `/Shuffleboard` | 3 | 3 | 0 |
| `/LiveWindow` | 1 | 1 | 0 |
| **Total** | **1746** | **1287** | **−459 (−26%)** |

Drop is exactly the number of `/Preferences/...` entries — every WPILib Preference that had an AKit mirror has lost the mirror. Nothing else moved.

### Per-subsystem matching: AKit mirror is decoupled, Preferences is intact

| Subsystem | `/Preferences/<X>` before → after | `/AdvantageKit/<X>` before → after |
|---|---:|---:|
| ShooterSubsystem | 82 → 82 | 82 → 0 |
| AprilTagVisionSubsystemExtended | 40 → 40 | 60 → 20 |
| ClimberSubsystem | 36 → 36 | 37 → 1 |
| IntakeDeploySubsystem | 36 → 36 | 36 → 0 |
| HopperRollerSubsystem | 34 → 34 | 34 → 0 |
| CollectorSubsystem | 30 → 30 | 30 → 0 |
| ShooterFeederSubsystem | 30 → 30 | 30 → 0 |
| SwerveDriveSubsystem | 28 → 28 | 28 → 0 |
| SwerveSteeringSubsystem | 27 → 27 | 27 → 0 |
| DriveSubsystem | 22 → 22 | 74 → 52 |
| Simulator | 16 → 16 | 16 → 0 |
| TrajectoriesCalculation | 14 → 14 | 14 → 0 |
| HoodSubsystem | 7 → 7 | (not in top-40) |
| IntakeDeployAdaptiveCloseWhileFiringCommand | 7 → 7 | (not in top-40) |

The `/Preferences/<X>` column is unchanged everywhere (dashboards still see and edit the values). The `/AdvantageKit/<X>` column drops to 0 wherever everything under that subtable was a property mirror, and drops by exactly the Preferences count where the subsystem also has real telemetry going through `aKitLog.record(...)` (e.g. `DriveSubsystem` keeps 52 telemetry keys, `AprilTagVisionSubsystemExtended` keeps 20).

# Questions/notes for reviewers

- **Naming.** I picked `PropertyMirror/` (rather than `Properties/`) deliberately so the deny prefix in the wrapper reads less ambiguously next to WPILib's `Preferences` table. They sit close together conceptually and the original name kept tripping me up when re-reading the code.

# How this was tested

- [x] unit tests added (8 new tests in `PropertySkippingNT4PublisherTest`; full suite: 294 tests, 0 failures, 10 skipped)
- [x] tested on robot (sim) — TeamXbot2026 sim, NT topic count and per-subsystem breakdown captured above

🤖 Generated with [Claude Code](https://claude.com/claude-code)